### PR TITLE
Allow generating test coverage reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ artifacts/
 cache/
 dist/
 ipfs.cmd
+.coverage_*/
+
+/apps/*/coverage.json
+/apps/*/coverage/

--- a/.solcover.js
+++ b/.solcover.js
@@ -1,0 +1,7 @@
+module.exports = {
+  skipFiles: ['test_helpers'],
+  providerOptions: {
+    default_balance_ether: 10000,
+    gasPrice: '0x1',
+  },
+}

--- a/README.md
+++ b/README.md
@@ -37,6 +37,30 @@ In an app folder:
 npm run test:gas
 ```
 
+#### Generate test coverage report
+
+For all apps, in the repo root:
+
+```bash
+npm run test:all:coverage
+```
+
+In an app folder:
+
+```bash
+npm run test:coverage
+```
+
+Test coverage is reported to `coverage.json` and `coverage/index.html` files located
+inside each app's folder.
+
+Keep in mind that the code uses `assert`s to check invariants that should always be kept
+unless the code is buggy (in contrast to `require` statements which check pre-coditions),
+so full branch coverage will never be reported until
+[solidity-coverage#219] is implemented.
+
+[solidity-coverage#219]: https://github.com/sc-forks/solidity-coverage/issues/269
+
 ### Configuration
 
 Can be specified in a local file `.dev.env`.

--- a/apps/depool/buidler.config.js
+++ b/apps/depool/buidler.config.js
@@ -4,6 +4,7 @@ const hooks = require('./scripts/buidler-hooks')
 usePlugin('@aragon/buidler-aragon')
 usePlugin("@nomiclabs/buidler-ganache")
 usePlugin('buidler-gas-reporter')
+usePlugin('solidity-coverage')
 
 module.exports = {
   // Default Buidler configurations. Read more about it at https://buidler.dev/config/
@@ -11,6 +12,9 @@ module.exports = {
   networks: {
     development: {
       url: 'http://localhost:8545',
+    },
+    coverage: {
+      url: 'http://localhost:8555',
     },
   },
   solc: {

--- a/apps/depool/package.json
+++ b/apps/depool/package.json
@@ -7,6 +7,7 @@
     "lint": "solium --dir ./contracts",
     "test": "buidler test --network buidlerevm",
     "test:gas": "REPORT_GAS=true buidler test --network development",
+    "test:coverage": "buidler coverage --network coverage --solcoverjs ../../.solcover.js",
     "start": "buidler start",
     "publish:major": "buidler publish major",
     "publish:minor": "buidler publish minor",

--- a/apps/depooloracle/buidler.config.js
+++ b/apps/depooloracle/buidler.config.js
@@ -4,6 +4,7 @@ const hooks = require('./scripts/buidler-hooks')
 usePlugin('@aragon/buidler-aragon')
 usePlugin("@nomiclabs/buidler-ganache")
 usePlugin('buidler-gas-reporter')
+usePlugin('solidity-coverage')
 
 module.exports = {
   // Default Buidler configurations. Read more about it at https://buidler.dev/config/
@@ -11,6 +12,9 @@ module.exports = {
   networks: {
     development: {
       url: 'http://localhost:8545',
+    },
+    coverage: {
+      url: 'http://localhost:8555',
     },
   },
   solc: {

--- a/apps/depooloracle/package.json
+++ b/apps/depooloracle/package.json
@@ -7,6 +7,7 @@
     "lint": "solium --dir ./contracts",
     "test": "buidler test --network buidlerevm",
     "test:gas": "REPORT_GAS=true buidler test --network development",
+    "test:coverage": "buidler coverage --network coverage --solcoverjs ../../.solcover.js",
     "start": "buidler start",
     "publish:major": "buidler publish major",
     "publish:minor": "buidler publish minor",

--- a/apps/steth/buidler.config.js
+++ b/apps/steth/buidler.config.js
@@ -4,6 +4,7 @@ const hooks = require('./scripts/buidler-hooks')
 usePlugin('@aragon/buidler-aragon')
 usePlugin("@nomiclabs/buidler-ganache")
 usePlugin('buidler-gas-reporter')
+usePlugin('solidity-coverage')
 
 module.exports = {
   // Default Buidler configurations. Read more about it at https://buidler.dev/config/
@@ -11,6 +12,9 @@ module.exports = {
   networks: {
     development: {
       url: 'http://localhost:8545',
+    },
+    coverage: {
+      url: 'http://localhost:8555',
     },
   },
   solc: {

--- a/apps/steth/package.json
+++ b/apps/steth/package.json
@@ -7,6 +7,7 @@
     "lint": "solium --dir ./contracts",
     "test": "buidler test --network buidlerevm",
     "test:gas": "REPORT_GAS=true buidler test --network development",
+    "test:coverage": "buidler coverage --network coverage --solcoverjs ../../.solcover.js",
     "start": "buidler start",
     "publish:major": "buidler publish major",
     "publish:minor": "buidler publish minor",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "npm run test:all",
     "test:all": "lerna run --scope=@depools/apps-* --concurrency=1 --stream test",
     "test:all:gas": "lerna run --scope=@depools/apps-* --concurrency=1 --stream test:gas",
-    "coverage": "SOLIDITY_COVERAGE=true npm run ganache-cli:test",
+    "test:all:coverage": "lerna run --scope=@depools/apps-* --concurrency=1 --stream test:coverage",
     "truffle:dev": "truffle dev",
     "ganache-cli:test": "./node_modules/@aragon/test-helpers/ganache-cli.sh",
     "install:frontend": "cd app && npm install",


### PR DESCRIPTION
Adds the following NPM scripts:

* `test:coverage` (in an app folder);
* `test:all:coverage` (in the repo root) to generate reports for all apps.