### PR TITLE
Improve E2E startup script

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -190,9 +190,9 @@ if [ $ETH2_RESET ]; then
 
   if [ $SPEC = "minimal" ]; then
     # reduce slot time generation
-    sed -i 's/SECONDS_PER_SLOT: 6/SECONDS_PER_SLOT: 1/' $LOCAL_TESTNET_DIR/config.yaml
+    sed -i '' 's/SECONDS_PER_SLOT: 6/SECONDS_PER_SLOT: 1/' $LOCAL_TESTNET_DIR/config.yaml
     # set according eth1 block time generation, see docker-compose.yml
-    sed -i 's/SECONDS_PER_ETH1_BLOCK: 14/SECONDS_PER_ETH1_BLOCK: 2/' $LOCAL_TESTNET_DIR/config.yaml
+    sed -i '' 's/SECONDS_PER_ETH1_BLOCK: 14/SECONDS_PER_ETH1_BLOCK: 2/' $LOCAL_TESTNET_DIR/config.yaml
   fi
 
   echo "Specification generated at $LOCAL_TESTNET_DIR."


### PR DESCRIPTION
* Fix running under OSX
* Fail friendly and early unless `jq` is installed

Regarding the `sed` fix, see https://stackoverflow.com/a/17535174/804678. It works on Linux since GNU `sed` allows to skip backup file extension after the `-i` flag, but the one on OSX doesn't.