### PR TITLE
Revert "Improve E2E startup script"

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -59,11 +59,6 @@ while test $# -gt 0; do
   esac
 done
 
-if ! command -v jq >/dev/null; then
-  echo 'Please install jq executable: https://stedolan.github.io/jq'
-  exit 1
-fi
-
 if [[ $RESET ]]; then
   echo "Cleanup"
   docker-compose down -v --remove-orphans
@@ -190,9 +185,9 @@ if [ $ETH2_RESET ]; then
 
   if [ $SPEC = "minimal" ]; then
     # reduce slot time generation
-    sed -i '' 's/SECONDS_PER_SLOT: 6/SECONDS_PER_SLOT: 1/' $LOCAL_TESTNET_DIR/config.yaml
+    sed -i 's/SECONDS_PER_SLOT: 6/SECONDS_PER_SLOT: 1/' $LOCAL_TESTNET_DIR/config.yaml
     # set according eth1 block time generation, see docker-compose.yml
-    sed -i '' 's/SECONDS_PER_ETH1_BLOCK: 14/SECONDS_PER_ETH1_BLOCK: 2/' $LOCAL_TESTNET_DIR/config.yaml
+    sed -i 's/SECONDS_PER_ETH1_BLOCK: 14/SECONDS_PER_ETH1_BLOCK: 2/' $LOCAL_TESTNET_DIR/config.yaml
   fi
 
   echo "Specification generated at $LOCAL_TESTNET_DIR."


### PR DESCRIPTION
The fix is incompatible with most other Linux systems. For Mac OS the problem can be solved by installing the GNU version of `sed` tool (e.g. `brew install gnu-sed`).