### PR TITLE
script for generate validator keys

### DIFF
--- a/deposit.sh
+++ b/deposit.sh
@@ -17,4 +17,4 @@ if [[ "$(docker images -q $IMG 2> /dev/null)" == "" ]] || [[ $REBUILD ]]; then
   rm -rf $TMP_DIR
 fi
 
-docker run -it -v $PWD/data:/data $IMG --folder /data "$@"
+docker run -it --rm -v $PWD/data:/data $IMG --folder /data "$@"


### PR DESCRIPTION
The E2E-tests require a tool to generate validator keys with predefined validation withdrawalCredentials.

For this purpose, the fork of the [eth2.0-deposit-cli tool](https://github.com/depools/eth2.0-deposit-cli/tree/custom-data) was made.

The following parameters have been added:
```bash
--mnemonic="abra cada bra ..."   # predefined user mnemonic
--withdrawal_pk=1a2b3c...       # predefined withdrawal public key
```

For better usability, without installing all the dependencies, the tool runs in a Docker container which one will build on the first run.

The keystore(s) and deposit(s) will be placed at `./data/validator_keys` folder.

A complete run example, will generate 10 keys:
```bash
./deposit.sh --num_validators=10 --chain=medalla --password=123 --mnemonic="explain tackle mirror kit van hammer degree position ginger unfair soup bonus" --withdrawal_pk=836d2906a6983ea4ea39dbda674c5d55062904d82c8dddf70607f383c8d665fab6a6c0026bf57e85a03f099d5cfc1511
```

