### PR TITLE
Optimise deposit gas

### DIFF
--- a/contracts/0.4.24/interfaces/INodeOperatorsRegistry.sol
+++ b/contracts/0.4.24/interfaces/INodeOperatorsRegistry.sol
@@ -142,6 +142,17 @@ interface INodeOperatorsRegistry {
     function getSigningKey(uint256 _operator_id, uint256 _index) external view returns
             (bytes key, bytes depositSignature, bool used);
 
+    /**
+      * @notice Returns a tuple: the first element is the number of active node operators;
+      * the second element contains packed metrics of all node operators, including inactive.
+      * The second element is a tightly-packed byte array consisting of 33-byte chunks, with
+      * i-th chunk corresponding to the i-th node operator and having the following layout:
+      * UK|TK|SV|SL|A, where UK is the number of used signing keys, TK is the total number of
+      * signing keys, SV is the number of stopped validators, and SL is staking limit, all
+      * 8-byte unsigned integers, and A is the active flag, a 1-byte unsigned integer (0 or 1).
+      */
+    function getNodeOperatorsMetrics() external view returns (uint256 activeCount, bytes memory data);
+
     event SigningKeyAdded(uint256 indexed operatorId, bytes pubkey);
     event SigningKeyRemoved(uint256 indexed operatorId, bytes pubkey);
 }

--- a/contracts/0.4.24/interfaces/INodeOperatorsRegistry.sol
+++ b/contracts/0.4.24/interfaces/INodeOperatorsRegistry.sol
@@ -143,15 +143,13 @@ interface INodeOperatorsRegistry {
             (bytes key, bytes depositSignature, bool used);
 
     /**
-      * @notice Returns a tuple: the first element is the number of active node operators;
-      * the second element contains packed metrics of all node operators, including inactive.
-      * The second element is a tightly-packed byte array consisting of 33-byte chunks, with
-      * i-th chunk corresponding to the i-th node operator and having the following layout:
-      * UK|TK|SV|SL|A, where UK is the number of used signing keys, TK is the total number of
-      * signing keys, SV is the number of stopped validators, and SL is staking limit, all
-      * 8-byte unsigned integers, and A is the active flag, a 1-byte unsigned integer (0 or 1).
+      * @notice Returns metrics of active node operators: a tightly-packed byte array consisting
+      * of 40-byte chunks, with each chunk corresponding to an active node operator and having the
+      * following layout: UK|TK|SV|SL|ID, where UK is the number of used signing keys, TK is the
+      * total number of signing keys, SV is the number of stopped validators, SL is staking limit,
+      * and ID is the id of the node operator, all 8-byte unsigned integers.
       */
-    function getNodeOperatorsMetrics() external view returns (uint256 activeCount, bytes memory data);
+    function getActiveNodeOperatorsMetrics() external view returns (bytes memory data);
 
     event SigningKeyAdded(uint256 indexed operatorId, bytes pubkey);
     event SigningKeyRemoved(uint256 indexed operatorId, bytes pubkey);

--- a/gasprofile/tx-deposit.js
+++ b/gasprofile/tx-deposit.js
@@ -6,8 +6,6 @@ const { deployDaoAndPool } = require('../test/scenario/helpers/deploy')
 
 const NodeOperatorsRegistry = artifacts.require('NodeOperatorsRegistry')
 
-console.log('toBN', toBN)
-
 const arbitraryN = toBN('0x0159e2036050fb43f6ecaca13a7b53b23ea54a623e47fb2bd89a5b4a18da3295')
 const withdrawalCredentials = pad('0x0202', 32)
 const validatorData = []
@@ -62,11 +60,10 @@ async function main() {
     validatorData.push.apply(validatorData, data)
   }
 
-  for (let iProvider = 0; iProvider < numProviders; ++iProvider) {
-    await pool.submit(ZERO_ADDRESS, { from: user1, value: ETH(33) })
-  }
+  // preheating: use one signing key from each provider
+  await pool.submit(ZERO_ADDRESS, { from: user1, value: ETH(32 * numProviders + 1) })
 
-  await printTx(`pool.submit`, pool.submit(ZERO_ADDRESS, { from: user1, value: ETH(33) }))
+  await printTx(`pool.submit(32 ETH)`, pool.submit(ZERO_ADDRESS, { from: user2, value: ETH(32) }))
 }
 
 async function printTx(name, promise) {


### PR DESCRIPTION
This PR attempts to optimize gas consumption of the deposit process by making one call to a proxied
`StakingProvidersRegistry` contract instead of one call per provider.

This might be used in addition to #107 to temporarily solve the problem with gas consumption
during submitting Ether (#105).

#### Gas profiling scenario

1. 10 staking providers having 3 validator keys each are added;
2. a user submits 321 Ether, using 1 key from each validator and leaving 1 Ether buffered;
3. another user submits 32 Ether. `<— this TX is profiled`

The mock deposit contract was used, so I've added a separate column with the corrected gas number,
assuming that the real `DepositContract` uses `70000 - 21000` gas per deposit.

#### Total gas

|     | Total gas w/ mock | Total w/ real Deposit contract |
| --- | --: | --: |
| Before opt. | 709,590 | 517,399 |
| After opt. | 548,184 | 355,993 |
| Reduction | 22% | 31% |

#### Gas arranged by activity

| Activity | Gas before opt. | Gas after opt. | Delta |
| --- | --: | --: | --: |
| minting token | 123,725 | same | 0 |
| **loading SP cache** | **196,340** | **39,620** | **-156,720** |
| finding the best SP | 3,999 | same | 0 |
| obtaining signing keys | 22,834 | same | 0 |
| deposit (Lido code) | 13,986 | same | 0 |
| deposit (mock call) | 241,191 | same | 0 |
| updating used keys (preparation) | 5,057 | same | 0 |
| updating used keys (call) | 21,857 | same | 0 |
| unaccounted (mostly unstructured storage ops) | 59,409 | 54,723 |  |

#### Detailed profiling reports

Including line-by-line gas spent by all contracts:

* [After optmimization](https://github.com/lidofinance/lido-dao/files/5498463/report-after-opt-all-contracts.txt)
* [Before optmimization](https://github.com/lidofinance/lido-dao/files/5498465/report-before-opt-all-contracts.txt)

Including only line-by-line gas spent inside the `DePool` contract:

* [After optmimization](https://github.com/lidofinance/lido-dao/files/5498464/report-after-opt-only-depool.txt)
* [Before optmimization](https://github.com/lidofinance/lido-dao/files/5498466/report-before-opt-only-depool.txt)