### PR TITLE
Make deposit iteration limit an argument of the deposit function

### DIFF
--- a/apps/lido/arapp.json
+++ b/apps/lido/arapp.json
@@ -19,11 +19,6 @@
       "name": "Set oracle contract address",
       "id": "SET_ORACLE",
       "params": []
-    },
-    {
-      "name": "Set maximum number of Ethereum 2.0 validators registered in a single transaction",
-      "id": "SET_DEPOSIT_ITERATION_LIMIT",
-      "params": []
     }
   ],
   "environments": {

--- a/contracts/0.4.24/Lido.sol
+++ b/contracts/0.4.24/Lido.sol
@@ -34,7 +34,6 @@ contract Lido is ILido, IsContract, Pausable, AragonApp {
     bytes32 constant public MANAGE_FEE = keccak256("MANAGE_FEE");
     bytes32 constant public MANAGE_WITHDRAWAL_KEY = keccak256("MANAGE_WITHDRAWAL_KEY");
     bytes32 constant public SET_ORACLE = keccak256("SET_ORACLE");
-    bytes32 constant public SET_DEPOSIT_ITERATION_LIMIT = keccak256("SET_DEPOSIT_ITERATION_LIMIT");
 
     uint256 constant public PUBKEY_LENGTH = 48;
     uint256 constant public WITHDRAWAL_CREDENTIALS_LENGTH = 32;
@@ -44,6 +43,9 @@ contract Lido is ILido, IsContract, Pausable, AragonApp {
 
     uint256 internal constant MIN_DEPOSIT_AMOUNT = 1 ether;     // validator_registration.vy
     uint256 internal constant DEPOSIT_AMOUNT_UNIT = 1000000000 wei;     // validator_registration.vy
+
+    /// @dev default value for maximum number of Ethereum 2.0 validators registered in a single depositBufferedEther call
+    uint256 internal constant DEFAULT_MAX_DEPOSITS_PER_CALL = 16;
 
     bytes32 internal constant FEE_VALUE_POSITION = keccak256("lido.Lido.fee");
     bytes32 internal constant TREASURY_FEE_VALUE_POSITION = keccak256("lido.Lido.treasuryFee");
@@ -63,8 +65,6 @@ contract Lido is ILido, IsContract, Pausable, AragonApp {
     bytes32 internal constant BEACON_BALANCE_VALUE_POSITION = keccak256("lido.Lido.beaconBalance");
     /// @dev number of Lido's validators available in the Beacon state
     bytes32 internal constant BEACON_VALIDATORS_VALUE_POSITION = keccak256("lido.Lido.beaconValidators");
-    /// @dev maximum number of Ethereum 2.0 validators registered in a single transaction
-    bytes32 internal constant DEPOSIT_ITERATION_LIMIT_VALUE_POSITION = keccak256("lido.Lido.depositIterationLimit");
 
 
     /// @dev Credentials which allows the DAO to withdraw Ether on the 2.0 side
@@ -88,14 +88,12 @@ contract Lido is ILido, IsContract, Pausable, AragonApp {
     * @param validatorRegistration official ETH2 Deposit contract
     * @param _oracle oracle contract
     * @param _operators instance of Node Operators Registry
-    * @param _depositIterationLimit the number of deposit calls per transaction
     */
     function initialize(
         ISTETH _token,
         IValidatorRegistration validatorRegistration,
         address _oracle,
-        INodeOperatorsRegistry _operators,
-        uint256 _depositIterationLimit
+        INodeOperatorsRegistry _operators
     )
         public onlyInit
     {
@@ -103,7 +101,6 @@ contract Lido is ILido, IsContract, Pausable, AragonApp {
         _setValidatorRegistrationContract(validatorRegistration);
         _setOracle(_oracle);
         _setOperators(_operators);
-        _setDepositIterationLimit(_depositIterationLimit);
 
         initialized();
     }
@@ -133,7 +130,15 @@ contract Lido is ILido, IsContract, Pausable, AragonApp {
     * @dev This function is separated from submit() to reduce the cost of sending funds.
     */
     function depositBufferedEther() external {
-        return _depositBufferedEther();
+        return _depositBufferedEther(DEFAULT_MAX_DEPOSITS_PER_CALL);
+    }
+
+    /**
+      * @notice Deposits buffered ethers to the official DepositContract, making no more than `_maxDeposits` deposit calls.
+      * @dev This function is separated from submit() to reduce the cost of sending funds.
+      */
+    function depositBufferedEther(uint256 _maxDeposits) external {
+        return _depositBufferedEther(_maxDeposits);
     }
 
     /**
@@ -190,15 +195,6 @@ contract Lido is ILido, IsContract, Pausable, AragonApp {
     */
     function setOracle(address _oracle) external auth(SET_ORACLE) {
         _setOracle(_oracle);
-    }
-
-    /**
-    * @notice Set maximum number of Ethereum 2.0 validators registered in a single transaction.
-    * @dev This parameter used to change the amount of consumed gas per TX to the adequate levels
-    * @param _limit max number of Deposit iterations per single transaction
-    */
-    function setDepositIterationLimit(uint256 _limit) external auth(SET_DEPOSIT_ITERATION_LIMIT) {
-        _setDepositIterationLimit(_limit);
     }
 
     /**
@@ -348,14 +344,6 @@ contract Lido is ILido, IsContract, Pausable, AragonApp {
     }
 
     /**
-    * @notice Gets maximum number of Ethereum 2.0 validators registered in a single transaction
-    * @return uint256 max number of Deposit iterations per single transaction
-    */
-    function getDepositIterationLimit() public view returns (uint256) {
-        return DEPOSIT_ITERATION_LIMIT_VALUE_POSITION.getStorageUint256();
-    }
-
-    /**
       * @notice Gets node operators registry interface handle
       */
     function getOperators() public view returns (INodeOperatorsRegistry) {
@@ -428,15 +416,6 @@ contract Lido is ILido, IsContract, Pausable, AragonApp {
     }
 
     /**
-    * @notice Internal function to set deposit loop iteration limit
-    * @param _limit max number of deposits per transaction
-    */
-    function _setDepositIterationLimit(uint256 _limit) internal {
-        require(0 != _limit, "ZERO_LIMIT");
-        DEPOSIT_ITERATION_LIMIT_VALUE_POSITION.setStorageUint256(_limit);
-    }
-
-    /**
     * @dev Process user deposit, mints liquid tokens and increase the pool buffer
     * @param _referral address of referral.
     * @return StETH amount of tokens generated
@@ -463,7 +442,7 @@ contract Lido is ILido, IsContract, Pausable, AragonApp {
     /**
     * @dev Deposits buffered eth to the DepositContract and assigns chunked deposits to node operators
     */
-    function _depositBufferedEther() internal whenNotStopped {
+    function _depositBufferedEther(uint256 _maxDeposits) internal whenNotStopped {
         uint256 buffered = _getBufferedEther();
         if (buffered >= DEPOSIT_SIZE) {
             uint256 unaccounted = _getUnaccountedEther();
@@ -471,7 +450,7 @@ contract Lido is ILido, IsContract, Pausable, AragonApp {
             uint256 toUnbuffer = buffered.div(DEPOSIT_SIZE).mul(DEPOSIT_SIZE);
             assert(toUnbuffer <= buffered && toUnbuffer != 0);
 
-            _markAsUnbuffered(_ETH2Deposit(toUnbuffer));
+            _markAsUnbuffered(_ETH2Deposit(toUnbuffer, _maxDeposits));
 
             assert(_getUnaccountedEther() == unaccounted);
         }
@@ -482,7 +461,7 @@ contract Lido is ILido, IsContract, Pausable, AragonApp {
     * @param _amount Total amount of Ethers to deposit to the ETH 2.0 side
     * @return actually deposited amount
     */
-    function _ETH2Deposit(uint256 _amount) internal returns (uint256) {
+    function _ETH2Deposit(uint256 _amount, uint256 _maxDeposits) internal returns (uint256) {
         assert(_amount >= MIN_DEPOSIT_AMOUNT);
 
         // Memory is very cheap, although you don't want to grow it too much.
@@ -490,10 +469,9 @@ contract Lido is ILido, IsContract, Pausable, AragonApp {
         if (0 == cache.length)
             return 0;
 
-        uint256 totalDepositCalls = 0;
-        uint256 maxDepositCalls = getDepositIterationLimit();
+        uint256 totalDeposits = 0;
         uint256 depositAmount = _amount;
-        while (depositAmount != 0 && totalDepositCalls < maxDepositCalls) {
+        while (depositAmount != 0 && totalDeposits < _maxDeposits) {
             // Finding the best suitable operator
             uint256 bestOperatorIdx = cache.length;   // 'not found' flag
             uint256 smallestStake;
@@ -520,7 +498,7 @@ contract Lido is ILido, IsContract, Pausable, AragonApp {
 
             // Invoking deposit for the best operator
             depositAmount = depositAmount.sub(DEPOSIT_SIZE);
-            ++totalDepositCalls;
+            ++totalDeposits;
 
             (bytes memory key, bytes memory signature, bool used) =  /* solium-disable-line */
                 getOperators().getSigningKey(cache[bestOperatorIdx].id, cache[bestOperatorIdx].usedSigningKeys++);
@@ -530,12 +508,12 @@ contract Lido is ILido, IsContract, Pausable, AragonApp {
             _stake(key, signature);
         }
 
-        if (0 != totalDepositCalls) {
-            DEPOSITED_VALIDATORS_VALUE_POSITION.setStorageUint256(DEPOSITED_VALIDATORS_VALUE_POSITION.getStorageUint256().add(totalDepositCalls));
+        if (0 != totalDeposits) {
+            DEPOSITED_VALIDATORS_VALUE_POSITION.setStorageUint256(DEPOSITED_VALIDATORS_VALUE_POSITION.getStorageUint256().add(totalDeposits));
             _write_back_operator_cache(cache);
         }
 
-        return totalDepositCalls.mul(DEPOSIT_SIZE);
+        return totalDeposits.mul(DEPOSIT_SIZE);
     }
 
     /**

--- a/contracts/0.4.24/template/LidoTemplate.sol
+++ b/contracts/0.4.24/template/LidoTemplate.sol
@@ -58,13 +58,6 @@ contract LidoTemplate is BaseTemplate {
 
     }
 
-    struct BeaconSpec {
-        uint64 epochsPerFrame;
-        uint64 slotsPerEpoch;
-        uint64 secondsPerSlot;
-        uint64 genesisTime;
-    }
-
     DeployState private deployState;
 
     constructor(
@@ -88,7 +81,6 @@ contract LidoTemplate is BaseTemplate {
         uint256[] _stakes,
         uint64[3] _votingSettings,
         address _BeaconDepositContract,
-        uint256 _depositIterationLimit,
         uint32[4] _beaconSpec
     )
         external
@@ -111,7 +103,6 @@ contract LidoTemplate is BaseTemplate {
             state,
             _votingSettings,
             _BeaconDepositContract,
-            _depositIterationLimit,
             _beaconSpec[0], // epochsPerFrame
             _beaconSpec[1], // slotsPerEpoch
             _beaconSpec[2], // secondsPerSlot
@@ -140,7 +131,6 @@ contract LidoTemplate is BaseTemplate {
         DeployState memory state,
         uint64[3] memory _votingSettings,
         address _BeaconDepositContract,
-        uint256 _depositIterationLimit,
         uint64 _epochsPerFrame,
         uint64 _slotsPerEpoch,
         uint64 _secondsPerSlot,
@@ -164,8 +154,7 @@ contract LidoTemplate is BaseTemplate {
             state.steth,
             _BeaconDepositContract,
             state.oracle,
-            state.operators,
-            _depositIterationLimit
+            state.operators
         );
         state.lido = Lido(_installNonDefaultApp(state.dao, LIDO_APP_ID, initializeData));
 
@@ -213,7 +202,6 @@ contract LidoTemplate is BaseTemplate {
         state.acl.createPermission(state.voting, state.lido, state.lido.MANAGE_FEE(), state.voting);
         state.acl.createPermission(state.voting, state.lido, state.lido.MANAGE_WITHDRAWAL_KEY(), state.voting);
         state.acl.createPermission(state.voting, state.lido, state.lido.SET_ORACLE(), state.voting);
-        state.acl.createPermission(state.voting, state.lido, state.lido.SET_DEPOSIT_ITERATION_LIMIT(), state.voting);
     }
 
     function _resetStorage() internal {

--- a/contracts/0.4.24/test_helpers/TestLido.sol
+++ b/contracts/0.4.24/test_helpers/TestLido.sol
@@ -15,12 +15,11 @@ contract TestLido is Lido {
         ISTETH _token,
         IValidatorRegistration validatorRegistration,
         address _oracle,
-        INodeOperatorsRegistry _operators,
-        uint256 _depositIterationLimit
+        INodeOperatorsRegistry _operators
     )
     public
     {
-        super.initialize(_token, validatorRegistration, _oracle, _operators, _depositIterationLimit);
+        super.initialize(_token, validatorRegistration, _oracle, _operators);
         treasury = address(new VaultMock());
         insurance = address(new VaultMock());
     }

--- a/docs/protocol-levers.md
+++ b/docs/protocol-levers.md
@@ -108,34 +108,18 @@ The pool uses these credentials to register new ETH 2.0 validators.
 
 ### Deposit loop iteration limit
 
-Controls how many ETH 2.0 validators can be registered in a single transaction.
+Controls how many ETH 2.0 deposits can be made in a single transaction.
 
-* Mutator: `setDepositIterationLimit(uint256)`
-  * Permission required: `SET_DEPOSIT_ITERATION_LIMIT`
-* Accessor: `getDepositIterationLimit() returns (uint256)`
+* A parameter of the `depositBufferedEther(uint256)` funciton
+* Default value: `16`
 * [Scenario test](/test/scenario/lido_deposit_iteration_limit.js)
 
-When someone submits Ether to the pool, the received Ether gets buffered in the pool contract. If the amount
-of the buffered Ether becomes larger than the ETH 2.0 deposit size (32 ETH), then the pool tries to register
-as many ETH 2.0 validators as it can. The limiting factors here are the amount of the buffered Ether (obviously),
-the number of spare validator keys (provided by node operators), and the deposit loop iteration limit,
-controlled by this lever.
+When someone calls `depositBufferedEther`, the pool tries to register as many ETH 2.0 validators
+as it can given the buffered Ether amount. The limit is passed as an argument to this function and
+is needed to prevent the transaction from [failing due to the block gas limit], which is possible
+if the amount of the buffered Ether becomes sufficiently large.
 
-The limit is needed to prevent the submit transaction from [failing due to the block gas limit](https://github.com/ConsenSys/smart-contract-best-practices/blob/8f99aef/docs/known_attacks.md#gas-limit-dos-on-a-contract-via-unbounded-operations).
-This is possible if the amount of the buffered Ether becomes sufficiently large, which, in turn, can occur due to:
-
-* a user sending a large amount of Ether in a single transaction;
-* temporary lack of new validator keys.
-
-In a situation when some Ether that could otherwise be used to register validators gets left buffered in
-the pool due to this limit, one can resume registering new validators by submitting zero Ether, which is
-allowed exactly for this purpose.
-
-Currently, the submit function, compiled with `200` optimizer iterations, consumes around `577000 gas` plus
-`107000 gas` for each registered validator, so the default limit is set by deploy scripts to `16` validators
-to make the submit transaction occupy no more than `20%` of a block. See [this file](/estimate_deposit_loop_gas.js)
-for the related calculations; you can run them with `yarn estimate-deposit-loop-gas`.
-
+[failing due to the block gas limit]: https://github.com/ConsenSys/smart-contract-best-practices/blob/8f99aef/docs/known_attacks.md#gas-limit-dos-on-a-contract-via-unbounded-operations
 
 ### Pausing
 

--- a/e2e/scripts/deployed-reset.js
+++ b/e2e/scripts/deployed-reset.js
@@ -16,8 +16,7 @@ const DEFAULT_DAO_SETTINGS = {
   tokenSymbol: 'LDO',
   voteDuration: 60 * 3, // 3 minutes
   votingSupportRequired: '500000000000000000', // 50e16 basis points === 50%
-  votingMinAcceptanceQuorum: '50000000000000000', // 5e16 basis points === 5%
-  depositIterationLimit: 16
+  votingMinAcceptanceQuorum: '50000000000000000' // 5e16 basis points === 5%
 }
 
 const main = async ({

--- a/e2e/scripts/helpers/apps/lidoHelper.js
+++ b/e2e/scripts/helpers/apps/lidoHelper.js
@@ -58,10 +58,6 @@ export async function setFeeDistribution(treasuryFee, insuranceFee, NOSFee, hold
   await voteForAction(voteId, holders, 'setFeeDistribution')
 }
 
-export function getDepositIterationLimit() {
-  return lidoContract.methods.getDepositIterationLimit().call()
-}
-
 export async function addSigningKeys(validatorsTestData, holder, count, holders) {
   const validatorsPubKeys = validatorsTestData.pubKey
   const validatorsSignatures = validatorsTestData.signature
@@ -95,9 +91,9 @@ export async function getInsuranceFundAddress() {
   return await lidoContract.methods.getInsuranceFund().call()
 }
 
-export async function submit(sender, value, referral) {
+export async function submit(sender, value, referral, maxDepositCalls = 16) {
   await lidoContract.methods.submit(referral).send({ from: sender, value: value, gas: '8000000' })
-  await depositBufferedEther(sender)
+  await depositBufferedEther(sender, maxDepositCalls)
 }
 
 export async function getEther2Stat() {
@@ -114,14 +110,14 @@ export async function getTreasury() {
   return await lidoContract.methods.getTreasury().call()
 }
 
-export async function depositToLidoContract(from, value, referral = '0x0000000000000000000000000000000000000000') {
+export async function depositToLidoContract(from, value, referral = '0x0000000000000000000000000000000000000000', maxDepositCalls = 16) {
   await submit(from, value, referral)
-  await depositBufferedEther(from)
+  await depositBufferedEther(from, maxDepositCalls)
   // return await eth1Helper.sendTransaction(web3, getProxyAddress(), from, value)
 }
 
-export async function depositBufferedEther(from) {
-  await lidoContract.methods.depositBufferedEther().send({ from, gas: '8000000' })
+export async function depositBufferedEther(from, maxDepositCalls = 16) {
+  await lidoContract.methods.depositBufferedEther(maxDepositCalls).send({ from, gas: '8000000' })
 }
 
 export function getTotalControlledEther() {

--- a/e2e/test/fullFlow.test.js
+++ b/e2e/test/fullFlow.test.js
@@ -36,7 +36,8 @@ import {
   SET_NODE_OPERATOR_ADDRESS_ROLE,
   SET_NODE_OPERATOR_ACTIVE_ROLE,
   SET_NODE_OPERATOR_LIMIT_ROLE,
-  REPORT_STOPPED_VALIDATORS_ROLE
+  REPORT_STOPPED_VALIDATORS_ROLE,
+  ZERO_ADDRESS
 } from '../scripts/helpers/constants'
 
 test.before('Connecting Web3', async (t) => {
@@ -101,9 +102,6 @@ test('Full flow test ', async (t) => {
   t.is(result[0], TREASURY_FEE.toString(), 'Check that treasury fee was set correctly')
   t.is(result[1], INSURANCE_FEE.toString(), 'Check that insurance fee was set correctly')
   t.is(result[2], NODE_OPERATOR_BASIC_FEE.toString(), 'Check that nodeOperator basic fee was set correctly')
-
-  logger.info('Check the correctness of deposit iteration limit')
-  t.is(await lidoHelper.getDepositIterationLimit(), '16', 'Check that deposit iteration limit was set correctly')
 
   logger.info('Add nodeOperator1 and add signing keys')
   await nodeOperatorsHelper.addNodeOperator('test provider1', nosMember1, 2, holder1, quorumHolders)
@@ -368,7 +366,8 @@ test('Full flow test ', async (t) => {
 
   logger.info('Check deposit iteration limit')
   const user5Deposit = ETH(20 * 32)
-  await lidoHelper.depositToLidoContract(user5, user5Deposit)
+  const maxDepositCalls = 16
+  await lidoHelper.depositToLidoContract(user5, user5Deposit, ZERO_ADDRESS, maxDepositCalls)
   ether2Stat = await lidoHelper.getBeaconStat()
   t.is(await stEthHelper.getBalance(user5), user5Deposit, 'Check that user receive an appropriate amount of stEth tokens')
   t.is(

--- a/scripts/deploy-lido-dao.js
+++ b/scripts/deploy-lido-dao.js
@@ -23,7 +23,6 @@ const DEFAULT_DAO_SETTINGS = {
   voteDuration: 60 * 3, // 3 minutes
   votingSupportRequired: '500000000000000000', // 50e16 basis points === 50%
   votingMinAcceptanceQuorum: '50000000000000000', // 5e16 basis points === 5%
-  depositIterationLimit: 16,
   beaconSpec: {
     epochsPerFrame: 225,
     slotsPerEpoch: 32,
@@ -244,7 +243,6 @@ async function deployDAO({
       daoInitialSettings.stakes,
       votingSettings,
       depositContractAddress,
-      daoInitialSettings.depositIterationLimit,
       beaconSpec,
       { from: owner }
     )

--- a/test/0.4.24/lido.test.js
+++ b/test/0.4.24/lido.test.js
@@ -72,7 +72,6 @@ contract('Lido', ([appManager, voting, user1, user2, user3, nobody]) => {
     await acl.createPermission(voting, app.address, await app.PAUSE_ROLE(), appManager, { from: appManager })
     await acl.createPermission(voting, app.address, await app.MANAGE_FEE(), appManager, { from: appManager })
     await acl.createPermission(voting, app.address, await app.MANAGE_WITHDRAWAL_KEY(), appManager, { from: appManager })
-    await acl.createPermission(voting, app.address, await app.SET_DEPOSIT_ITERATION_LIMIT(), appManager, { from: appManager })
 
     await acl.createPermission(app.address, token.address, await token.MINT_ROLE(), appManager, { from: appManager })
     await acl.createPermission(app.address, token.address, await token.BURN_ROLE(), appManager, { from: appManager })
@@ -90,7 +89,7 @@ contract('Lido', ([appManager, voting, user1, user2, user3, nobody]) => {
     })
 
     // Initialize the app's proxy.
-    await app.initialize(token.address, validatorRegistration.address, oracle.address, operators.address, 10)
+    await app.initialize(token.address, validatorRegistration.address, oracle.address, operators.address)
     treasuryAddr = await app.getTreasury()
     insuranceAddr = await app.getInsuranceFund()
 
@@ -176,14 +175,6 @@ contract('Lido', ([appManager, voting, user1, user2, user3, nobody]) => {
     assertBn(await operators.getTotalSigningKeyCount(1, { from: nobody }), 0)
     assertBn(await operators.getUnusedSigningKeyCount(1, { from: nobody }), 0)
     assert.equal(await app.getWithdrawalCredentials({ from: nobody }), pad('0x0203', 32))
-  })
-
-  it('setDepositIterationLimit works', async () => {
-    await app.setDepositIterationLimit(22, { from: voting })
-    assertBn(await app.getDepositIterationLimit(), 22)
-
-    await assertRevert(app.setDepositIterationLimit(0, { from: voting }), 'ZERO_LIMIT')
-    await assertRevert(app.setDepositIterationLimit(33, { from: user1 }), 'APP_AUTH_FAILED')
   })
 
   it('pad64 works', async () => {

--- a/test/deposit.test.js
+++ b/test/deposit.test.js
@@ -82,7 +82,6 @@ contract('Lido with official deposit contract', ([appManager, voting, user1, use
     await acl.createPermission(voting, app.address, await app.PAUSE_ROLE(), appManager, { from: appManager })
     await acl.createPermission(voting, app.address, await app.MANAGE_FEE(), appManager, { from: appManager })
     await acl.createPermission(voting, app.address, await app.MANAGE_WITHDRAWAL_KEY(), appManager, { from: appManager })
-    await acl.createPermission(voting, app.address, await app.SET_DEPOSIT_ITERATION_LIMIT(), appManager, { from: appManager })
 
     await acl.createPermission(app.address, token.address, await token.MINT_ROLE(), appManager, { from: appManager })
     await acl.createPermission(app.address, token.address, await token.BURN_ROLE(), appManager, { from: appManager })
@@ -100,7 +99,7 @@ contract('Lido with official deposit contract', ([appManager, voting, user1, use
     })
 
     // Initialize the app's proxy.
-    await app.initialize(token.address, depositContract.address, oracle.address, operators.address, 10)
+    await app.initialize(token.address, depositContract.address, oracle.address, operators.address)
     treasuryAddr = await app.getTreasury()
     insuranceAddr = await app.getInsuranceFund()
 

--- a/test/scenario/helpers/deploy.js
+++ b/test/scenario/helpers/deploy.js
@@ -11,7 +11,7 @@ module.exports = {
   deployDaoAndPool
 }
 
-async function deployDaoAndPool(appManager, voting, depositIterationLimit = 10) {
+async function deployDaoAndPool(appManager, voting) {
   // Deploy the DAO, oracle and validator registration mocks, and base contracts for
   // StETH (the token), Lido (the pool) and NodeOperatorsRegistry (the Node Operators registry)
 
@@ -48,7 +48,6 @@ async function deployDaoAndPool(appManager, voting, depositIterationLimit = 10) 
     POOL_PAUSE_ROLE,
     POOL_MANAGE_FEE,
     POOL_MANAGE_WITHDRAWAL_KEY,
-    POOL_SET_DEPOSIT_ITERATION_LIMIT,
     NODE_OPERATOR_REGISTRY_MANAGE_SIGNING_KEYS,
     NODE_OPERATOR_REGISTRY_ADD_NODE_OPERATOR_ROLE,
     NODE_OPERATOR_REGISTRY_SET_NODE_OPERATOR_ACTIVE_ROLE,
@@ -62,7 +61,6 @@ async function deployDaoAndPool(appManager, voting, depositIterationLimit = 10) 
     pool.PAUSE_ROLE(),
     pool.MANAGE_FEE(),
     pool.MANAGE_WITHDRAWAL_KEY(),
-    pool.SET_DEPOSIT_ITERATION_LIMIT(),
     nodeOperatorRegistry.MANAGE_SIGNING_KEYS(),
     nodeOperatorRegistry.ADD_NODE_OPERATOR_ROLE(),
     nodeOperatorRegistry.SET_NODE_OPERATOR_ACTIVE_ROLE(),
@@ -79,7 +77,6 @@ async function deployDaoAndPool(appManager, voting, depositIterationLimit = 10) 
     acl.createPermission(voting, pool.address, POOL_PAUSE_ROLE, appManager, { from: appManager }),
     acl.createPermission(voting, pool.address, POOL_MANAGE_FEE, appManager, { from: appManager }),
     acl.createPermission(voting, pool.address, POOL_MANAGE_WITHDRAWAL_KEY, appManager, { from: appManager }),
-    acl.createPermission(voting, pool.address, POOL_SET_DEPOSIT_ITERATION_LIMIT, appManager, { from: appManager }),
     // Allow voting to manage node operators registry
     acl.createPermission(voting, nodeOperatorRegistry.address, NODE_OPERATOR_REGISTRY_MANAGE_SIGNING_KEYS, appManager, {
       from: appManager
@@ -111,8 +108,7 @@ async function deployDaoAndPool(appManager, voting, depositIterationLimit = 10) 
     token.address,
     validatorRegistrationMock.address,
     oracleMock.address,
-    nodeOperatorRegistry.address,
-    depositIterationLimit
+    nodeOperatorRegistry.address
   )
 
   await oracleMock.setPool(pool.address)


### PR DESCRIPTION
Fixes: #151.

The default limit, enforced if the caller skips passing a custom one, is `16`.