### PR TITLE
UI: round Eth/StEth values down to three decimal places

### DIFF
--- a/apps/lido/app/package.json
+++ b/apps/lido/app/package.json
@@ -7,6 +7,7 @@
     "@aragon/api-react": "^2.0.0",
     "@aragon/ui": "^1.7.0",
     "@openzeppelin/contracts": "3.1.0",
+    "bn.js": "^5.1.3",
     "core-js": "^3.6.5",
     "formik": "^2.2.0",
     "react": "^16.13.1",

--- a/apps/lido/app/src/App.js
+++ b/apps/lido/app/src/App.js
@@ -19,6 +19,7 @@ import ChangeWCSidePanel from './components/ChangeWCSidePanel'
 import DbeSidePanel from './components/DbeSidePanel'
 import ChangeFeeDistrSidePanel from './components/ChangeFeeDistrSidePanel'
 import WcBadge from './components/WcBadge'
+import { formatEth } from './utils'
 
 export default function App() {
   const { api, appState, currentApp, guiStyle } = useAragonApi()
@@ -230,11 +231,11 @@ export default function App() {
       },
       {
         label: 'Buffered Ether',
-        content: <strong>{bufferedEther || 'No data'}</strong>,
+        content: <strong>{formatEth(bufferedEther) || 'No data'}</strong>,
       },
       {
         label: 'Total Pooled Ether',
-        content: <strong>{totalPooledEther || 'No data'}</strong>,
+        content: <strong>{formatEth(totalPooledEther) || 'No data'}</strong>,
       },
       {
         label: 'Validator Registration Contract',
@@ -265,7 +266,7 @@ export default function App() {
         label: 'Deposits',
         content: <strong>{stat.depositedValidators}</strong>,
       },
-      { label: 'Balance', content: <strong>{stat.beaconBalance}</strong> },
+      { label: 'Balance', content: <strong>{formatEth(stat.beaconBalance)}</strong> },
     ]
   }, [appState])
 

--- a/apps/lido/app/src/script.js
+++ b/apps/lido/app/src/script.js
@@ -1,7 +1,6 @@
 import 'core-js/stable'
 import 'regenerator-runtime/runtime'
 import Aragon, { events } from '@aragon/api'
-import { fromWei } from 'web3-utils'
 
 const app = new Aragon()
 
@@ -88,12 +87,12 @@ function getWithdrawalCredentials() {
   return app.call('getWithdrawalCredentials').toPromise()
 }
 
-async function getBufferedEther() {
-  return fromWei(await app.call('getBufferedEther').toPromise())
+function getBufferedEther() {
+  return app.call('getBufferedEther').toPromise()
 }
 
-async function getTotalPooledEther() {
-  return fromWei(await app.call('getTotalPooledEther').toPromise())
+function getTotalPooledEther() {
+  return app.call('getTotalPooledEther').toPromise()
 }
 
 function getToken() {
@@ -124,6 +123,6 @@ async function getBeaconStat() {
   const stat = await app.call('getBeaconStat').toPromise()
   return {
     depositedValidators: +stat.depositedValidators,
-    beaconBalance: fromWei(stat.beaconBalance),
+    beaconBalance: stat.beaconBalance,
   }
 }

--- a/apps/lido/app/src/utils.js
+++ b/apps/lido/app/src/utils.js
@@ -1,0 +1,10 @@
+import BN from 'bn.js'
+
+const TEN_TO_15 = new BN(10).pow(new BN(15))
+
+/**
+ * Formats wei value to Eth rounded to 3 decimal places.
+ */
+export function formatEth(wei) {
+  return String(new BN(wei).div(TEN_TO_15) / 1000)
+}

--- a/apps/steth/app/package.json
+++ b/apps/steth/app/package.json
@@ -7,6 +7,7 @@
     "@aragon/api-react": "^2.0.0",
     "@aragon/ui": "^1.7.0",
     "@openzeppelin/contracts": "3.1.0",
+    "bn.js": "^5.1.3",
     "core-js": "^3.6.5",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/apps/steth/app/src/App.js
+++ b/apps/steth/app/src/App.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { useAragonApi } from '@aragon/api-react'
 import { Box, Header, Main, SyncIndicator, Button, useTheme } from '@aragon/ui'
 import ListItem from './components/ListItem'
+import { formatEth } from './utils'
 
 export default function App() {
   const { api, appState, currentApp, guiStyle } = useAragonApi()
@@ -53,7 +54,7 @@ export default function App() {
             // eslint-disable-next-line react/jsx-key
             ['Symbol', <strong>{tokenSymbol}</strong>],
             // eslint-disable-next-line react/jsx-key
-            ['Total supply', <strong>{totalSupply}</strong>],
+            ['Total supply', <strong>{formatEth(totalSupply)}</strong>],
             [
               'Status',
               isStopped ? (

--- a/apps/steth/app/src/script.js
+++ b/apps/steth/app/src/script.js
@@ -1,7 +1,6 @@
 import 'core-js/stable'
 import 'regenerator-runtime/runtime'
 import Aragon, { events } from '@aragon/api'
-import { fromWei } from 'web3-utils'
 
 const app = new Aragon()
 
@@ -17,6 +16,8 @@ app.store(
           return { ...nextState, isStopped: await getIsStopped() }
         case 'Resumed':
           return { ...nextState, isStopped: await getIsStopped() }
+        case 'Transfer':
+          return { ...nextState, totalSupply: await getTotalSupply() }
         case events.SYNC_STATUS_SYNCING:
           return { ...nextState, isSyncing: true }
         case events.SYNC_STATUS_SYNCED:
@@ -51,18 +52,18 @@ function initializeState() {
   }
 }
 
-async function getIsStopped() {
-  return await app.call('isStopped').toPromise()
+function getIsStopped() {
+  return app.call('isStopped').toPromise()
 }
 
-async function getTokenName() {
-  return await app.call('name').toPromise()
+function getTokenName() {
+  return app.call('name').toPromise()
 }
 
-async function getTokenSymbol() {
-  return await app.call('symbol').toPromise()
+function getTokenSymbol() {
+  return app.call('symbol').toPromise()
 }
 
-async function getTotalSupply() {
-  return fromWei(await app.call('totalSupply').toPromise())
+function getTotalSupply() {
+  return app.call('totalSupply').toPromise()
 }

--- a/apps/steth/app/src/utils.js
+++ b/apps/steth/app/src/utils.js
@@ -1,0 +1,10 @@
+import BN from 'bn.js'
+
+const TEN_TO_15 = new BN(10).pow(new BN(15))
+
+/**
+ * Formats wei value to Eth rounded to 3 decimal places.
+ */
+export function formatEth(wei) {
+  return String(new BN(wei).div(TEN_TO_15) / 1000)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -16187,6 +16187,7 @@ __metadata:
     "@openzeppelin/contracts": 3.1.0
     babel-eslint: ^10.1.0
     babel-plugin-styled-components: ^1.11.1
+    bn.js: ^5.1.3
     copyfiles: ^2.3.0
     core-js: ^3.6.5
     eslint: ^7.9.0
@@ -23092,6 +23093,7 @@ resolve@1.1.x:
     "@openzeppelin/contracts": 3.1.0
     babel-eslint: ^10.1.0
     babel-plugin-styled-components: ^1.11.1
+    bn.js: ^5.1.3
     copyfiles: ^2.3.0
     core-js: ^3.6.5
     eslint: ^7.9.0


### PR DESCRIPTION
Needed to avoid this:

<img width="376" alt="Снимок экрана 2020-11-22 в 15 01 05" src="https://user-images.githubusercontent.com/1699593/100011077-447f8a00-2de2-11eb-8296-867f1a6bfe61.png">

Given the current conversion rate, the precision is more than enough: `0.001 Eth` is `0.6 USD`.