### PR TITLE
Fix return statements #156

### DIFF
--- a/contracts/0.4.24/Lido.sol
+++ b/contracts/0.4.24/Lido.sol
@@ -123,9 +123,9 @@ contract Lido is ILido, IsContract, Pausable, AragonApp {
     /**
     * @notice Send funds to the pool with optional _referral parameter
     * @dev This function is alternative way to submit funds. Supports optional referral address.
-    * @return StETH Amount of StETH tokens generated
+    * @return Amount of StETH shares generated
     */
-    function submit(address _referral) external payable returns (uint256 StETH) {
+    function submit(address _referral) external payable returns (uint256) {
         return _submit(_referral);
     }
 
@@ -424,9 +424,9 @@ contract Lido is ILido, IsContract, Pausable, AragonApp {
     /**
     * @dev Process user deposit, mints liquid tokens and increase the pool buffer
     * @param _referral address of referral.
-    * @return StETH amount of tokens generated
+    * @return amount of StETH shares generated
     */
-    function _submit(address _referral) internal whenNotStopped returns (uint256 StETH) {
+    function _submit(address _referral) internal whenNotStopped returns (uint256) {
         address sender = msg.sender;
         uint256 deposit = msg.value;
         require(deposit != 0, "ZERO_DEPOSIT");
@@ -443,6 +443,8 @@ contract Lido is ILido, IsContract, Pausable, AragonApp {
         }
 
         _submitted(sender, deposit, _referral);
+
+        return sharesAmount;
     }
 
     /**

--- a/contracts/0.4.24/nos/NodeOperatorsRegistry.sol
+++ b/contracts/0.4.24/nos/NodeOperatorsRegistry.sol
@@ -111,6 +111,8 @@ contract NodeOperatorsRegistry is INodeOperatorsRegistry, IsContract, AragonApp 
         operator.stakingLimit = _stakingLimit;
 
         emit NodeOperatorAdded(id, _name, _rewardAddress, _stakingLimit);
+
+        return id;
     }
 
     /**
@@ -508,5 +510,7 @@ contract NodeOperatorsRegistry is INodeOperatorsRegistry, IsContract, AragonApp 
             }
             offset++;
         }
+
+        return (key, signature);
     }
 }


### PR DESCRIPTION
Closes #156
- Lido.submit() now returns shares amount generated instead of token amount because this value is fixed and carries more information than dynamically changing balance. if we return anything at all, that would be better.