### PR TITLE
[WIP] Add Transfer event indicating mint on submit

### DIFF
--- a/contracts/0.4.24/Lido.sol
+++ b/contracts/0.4.24/Lido.sol
@@ -447,7 +447,6 @@ contract Lido is ILido, IsContract, Pausable, AragonApp {
         } else {
             token.mintShares(sender, sharesAmount);
         }
-
         _submitted(sender, deposit, _referral);
 
         return sharesAmount;
@@ -636,7 +635,7 @@ contract Lido is ILido, IsContract, Pausable, AragonApp {
     */
     function _submitted(address _sender, uint256 _value, address _referral) internal {
         BUFFERED_ETHER_VALUE_POSITION.setStorageUint256(_getBufferedEther().add(_value));
-
+        emit Transfer(address(0), _sender, _value);
         emit Submitted(_sender, _value, _referral);
     }
 


### PR DESCRIPTION
There's not Transfer event on submit indicating token minted. This leads to bad UX for stakers - e.g. they can't see their tx on etherscan etc.  Added it to `_submitted` function, though might not be the best place - token's `mintShare` might be better, but more expensive gas-wise.

@skozin @ongrid WDYT?