### PR TITLE
impose a limit on max signing keys per submission

### DIFF
--- a/apps/node-operators-registry/app/package.json
+++ b/apps/node-operators-registry/app/package.json
@@ -43,7 +43,7 @@
     "serve": "parcel serve index.html --out-dir ../dist/ --no-cache",
     "watch": "yarn watch:script",
     "sync-assets": "copy-aragon-ui-assets ../dist && copyfiles -u 1 './public/**/*' ../dist",
-    "start": "yarn sync-assets && yarn watch:script & yarn serve",
+    "start": "yarn sync-assets && yarn watch:script & SK_LIMIT=20 yarn serve",
     "dev": "yarn sync-assets && yarn watch:script & yarn serve -- --port 3010"
   }
 }

--- a/apps/node-operators-registry/app/src/components/AddSigningKeysSidePanel.js
+++ b/apps/node-operators-registry/app/src/components/AddSigningKeysSidePanel.js
@@ -5,6 +5,9 @@ import * as yup from 'yup'
 import TextField from './TextField'
 import { formatJsonData, isHexadecimal } from '../utils/helpers'
 
+const DEFAULT_LIMIT = 20
+const LIMIT = process.env.SK_LIMIT || DEFAULT_LIMIT
+
 const initialValues = {
   json: '',
 }
@@ -32,6 +35,12 @@ const validationSchema = yup.object().shape({
         return this.createError({
           path: 'json',
           message: `Expected one or more keys but got ${quantity}.`,
+        })
+
+      if (quantity > LIMIT)
+        return this.createError({
+          path: 'json',
+          message: `Expected ${LIMIT} signing keys max per submission but got ${quantity}.`,
         })
 
       for (let i = 0; i < data.length; i++) {


### PR DESCRIPTION
This PR features an additional validation rule for the signing keys submission. It disallows users to submit more than 20 keys in one go. The limit can be specified as an environment variable in package.json, otherwise defaults to 20.