### PR TITLE
limit signing keys to 20 per submission & advanced validation

### DIFF
--- a/apps/lido/app/src/utils.js
+++ b/apps/lido/app/src/utils.js
@@ -4,7 +4,29 @@ const TEN_TO_15 = new BN(10).pow(new BN(15))
 
 /**
  * Formats wei value to Eth rounded to 3 decimal places.
+ * @param {number} wei wei amount
+ * @returns {string} equivalent value in Eth
  */
 export function formatEth(wei) {
   return String(new BN(wei).div(TEN_TO_15) / 1000)
+}
+
+/**
+ * Safely multiplies a number by 100
+ * @param {number} number an integer or up to 2 decimal places
+ * @returns {number} sum
+ */
+export function toBasisPoints(number) {
+  return Math.round(number * 100)
+}
+
+/**
+ * Safely adds three nums together
+ * @param {number} n1 first num
+ * @param {number} n2 second num
+ * @param {number} n3 third num
+ * @returns {string} sum total
+ */
+export function sum(n1, n2, n3) {
+  return String(new BN(n1).add(new BN(n2)).add(new BN(n3)))
 }

--- a/apps/node-operators-registry/app/.gitignore
+++ b/apps/node-operators-registry/app/.gitignore
@@ -14,6 +14,7 @@
 /dist
 
 # misc
+.env
 .DS_Store
 .env.local
 .env.development.local

--- a/apps/node-operators-registry/app/package.json
+++ b/apps/node-operators-registry/app/package.json
@@ -43,7 +43,7 @@
     "serve": "parcel serve index.html --out-dir ../dist/ --no-cache",
     "watch": "yarn watch:script",
     "sync-assets": "copy-aragon-ui-assets ../dist && copyfiles -u 1 './public/**/*' ../dist",
-    "start": "yarn sync-assets && yarn watch:script & yarn serve",
+    "start": "yarn sync-assets && yarn watch:script & SK_LIMIT=20 yarn serve",
     "dev": "yarn sync-assets && yarn watch:script & yarn serve -- --port 3010"
   }
 }

--- a/apps/node-operators-registry/app/package.json
+++ b/apps/node-operators-registry/app/package.json
@@ -43,7 +43,7 @@
     "serve": "parcel serve index.html --out-dir ../dist/ --no-cache",
     "watch": "yarn watch:script",
     "sync-assets": "copy-aragon-ui-assets ../dist && copyfiles -u 1 './public/**/*' ../dist",
-    "start": "yarn sync-assets && yarn watch:script & SK_LIMIT=20 yarn serve",
+    "start": "yarn sync-assets && yarn watch:script & yarn serve",
     "dev": "yarn sync-assets && yarn watch:script & yarn serve -- --port 3010"
   }
 }

--- a/apps/node-operators-registry/app/sample.env
+++ b/apps/node-operators-registry/app/sample.env
@@ -1,0 +1,3 @@
+SK_LIMIT=20
+SUBGRAPH_ENDPOINT=https://goerli.lido.fi/key-checker/api/subgraph
+SIGNATURE_VERIFY_ENDPOINT=https://goerli.lido.fi/key-checker/api/signature

--- a/apps/node-operators-registry/app/src/App.js
+++ b/apps/node-operators-registry/app/src/App.js
@@ -174,6 +174,7 @@ function App() {
         primary={
           <DataView
             fields={[
+              '#',
               'Node Operator',
               'Address',
               'Staking Limit',
@@ -191,6 +192,8 @@ function App() {
               active,
               id,
             }) => [
+              // eslint-disable-next-line react/jsx-key
+              <strong>{id} </strong>,
               // eslint-disable-next-line react/jsx-key
               <strong>
                 {name} {currentUserOperatorId === id && '(you)'}

--- a/apps/node-operators-registry/app/src/components/AddSigningKeysSidePanel.js
+++ b/apps/node-operators-registry/app/src/components/AddSigningKeysSidePanel.js
@@ -9,6 +9,8 @@ import {
   hasDuplicatePubkeys,
   hasDuplicateSigs,
   isHexadecimal,
+  SIGNATURE_VERIFY_ENDPOINT,
+  SUBGRAPH_ENDPOINT,
   verifySignaturesAsync,
 } from '../utils/helpers'
 import CheckBox from './CheckBox'
@@ -155,7 +157,9 @@ function PanelContent({ api, onClose }) {
               component={TextField}
               multiline
             />
-            <Field name="useAdvancedV8n" component={CheckBox} />
+            {SIGNATURE_VERIFY_ENDPOINT && SUBGRAPH_ENDPOINT && (
+              <Field name="useAdvancedV8n" component={CheckBox} />
+            )}
             <Button
               mode="strong"
               wide

--- a/apps/node-operators-registry/app/src/components/AddSigningKeysSidePanel.js
+++ b/apps/node-operators-registry/app/src/components/AddSigningKeysSidePanel.js
@@ -5,6 +5,9 @@ import * as yup from 'yup'
 import TextField from './TextField'
 import { formatJsonData, isHexadecimal } from '../utils/helpers'
 
+const DEFAULT_LIMIT = 20
+const LIMIT = process.env.SK_LIMIT || DEFAULT_LIMIT
+
 const initialValues = {
   json: '',
 }
@@ -32,6 +35,12 @@ const validationSchema = yup.object().shape({
         return this.createError({
           path: 'json',
           message: `Expected one or more keys but got ${quantity}.`,
+        })
+
+      if (quantity > LIMIT)
+        return this.createError({
+          path: 'json',
+          message: `Expected ${LIMIT} signing keys max per submission but got ${quantity}.`,
         })
 
       for (let i = 0; i < data.length; i++) {

--- a/apps/node-operators-registry/app/src/components/AddSigningKeysSidePanel.js
+++ b/apps/node-operators-registry/app/src/components/AddSigningKeysSidePanel.js
@@ -1,70 +1,114 @@
-import { Button, GU, SidePanel, Info } from '@aragon/ui'
+import { Button, GU, SidePanel, Info, SyncIndicator } from '@aragon/ui'
 import React, { useCallback } from 'react'
 import { Formik, Field } from 'formik'
 import * as yup from 'yup'
 import TextField from './TextField'
-import { formatJsonData, isHexadecimal } from '../utils/helpers'
+import {
+  checkForDuplicatesAsync,
+  formatJsonData,
+  hasDuplicatePubkeys,
+  hasDuplicateSigs,
+  isHexadecimal,
+  verifySignaturesAsync,
+} from '../utils/helpers'
+import CheckBox from './CheckBox'
 
 const DEFAULT_LIMIT = 20
 const LIMIT = process.env.SK_LIMIT || DEFAULT_LIMIT
 
 const initialValues = {
   json: '',
+  useAdvancedV8n: false,
 }
 
-const validationSchema = yup.object().shape({
-  json: yup
-    .string()
-    .required()
-    .test('json', 'Invalid json file', function (json) {
-      let data
-      try {
-        data = JSON.parse(json)
-        if (!Array.isArray(data)) {
-          throw new Error('JSON must be an array')
-        }
-      } catch (e) {
-        return this.createError({
-          path: 'json',
-          message: e.message || 'Invalid JSON',
-        })
+const validationSchema = yup
+  .object()
+  .shape({
+    json: yup.string().required(),
+  })
+  .test('basic', 'Invalid json file', function ({ json }) {
+    let data
+    try {
+      data = JSON.parse(json)
+      if (!Array.isArray(data)) {
+        throw new Error('JSON must be an array')
       }
+    } catch (e) {
+      return this.createError({
+        path: 'json',
+        message: e.message || 'Invalid JSON',
+      })
+    }
 
-      const quantity = data.length
-      if (quantity < 1)
+    const quantity = data.length
+    if (quantity < 1)
+      return this.createError({
+        path: 'json',
+        message: `Expected one or more keys but got ${quantity}.`,
+      })
+
+    if (quantity > LIMIT)
+      return this.createError({
+        path: 'json',
+        message: `Expected ${LIMIT} signing keys max per submission but got ${quantity}.`,
+      })
+
+    if (hasDuplicatePubkeys(data))
+      return this.createError({
+        path: 'json',
+        message: 'Includes duplicate public keys',
+      })
+
+    if (hasDuplicateSigs(data))
+      return this.createError({
+        path: 'json',
+        message: 'Includes duplicate signatures',
+      })
+
+    for (let i = 0; i < data.length; i++) {
+      const { pubkey, signature } = data[i]
+
+      if (!isHexadecimal(pubkey, 96))
         return this.createError({
           path: 'json',
-          message: `Expected one or more keys but got ${quantity}.`,
+          message: `Invalid pubkey at index ${i}.`,
         })
-
-      if (quantity > LIMIT)
+      if (!isHexadecimal(signature, 192))
         return this.createError({
           path: 'json',
-          message: `Expected ${LIMIT} signing keys max per submission but got ${quantity}.`,
+          message: `Invalid signature at index ${i}.`,
         })
+    }
 
-      for (let i = 0; i < data.length; i++) {
-        const { pubkey, signature } = data[i]
+    return true
+  })
+  .test('advanced', 'Invalid keys', async function ({ json, useAdvancedV8n }) {
+    if (!useAdvancedV8n) return true
 
-        if (!isHexadecimal(pubkey, 96))
-          return this.createError({
-            path: 'json',
-            message: `Invalid pubkey at index ${i}.`,
-          })
-        if (!isHexadecimal(signature, 192))
-          return this.createError({
-            path: 'json',
-            message: `Invalid signature at index ${i}.`,
-          })
-      }
+    const signingKeys = JSON.parse(json)
 
-      return true
-    }),
-})
+    const duplicates = await checkForDuplicatesAsync(signingKeys)
+    if (duplicates.length) {
+      return this.createError({
+        path: 'json',
+        message: `Public keys already in use: ${duplicates.join(', ')}`,
+      })
+    }
+
+    const invalidSignatures = await verifySignaturesAsync(signingKeys)
+    if (invalidSignatures.length) {
+      return this.createError({
+        path: 'json',
+        message: `Invalid signatures: ${invalidSignatures.join(', ')}`,
+      })
+    }
+
+    return true
+  })
 
 function PanelContent({ api, onClose }) {
   const onSubmit = useCallback(
-    ({ json }) => {
+    async ({ json }) => {
       const { quantity, pubkeys, signatures } = formatJsonData(json)
 
       api(quantity, pubkeys, signatures)
@@ -111,6 +155,7 @@ function PanelContent({ api, onClose }) {
               component={TextField}
               multiline
             />
+            <Field name="useAdvancedV8n" component={CheckBox} />
             <Button
               mode="strong"
               wide
@@ -119,6 +164,9 @@ function PanelContent({ api, onClose }) {
               label="Add Signing Keys"
               type="submit"
             />
+            <SyncIndicator visible={isValidating} shift={50}>
+              Validation is in progress. This may take a couple of minutes...
+            </SyncIndicator>
           </form>
         )
       }}

--- a/apps/node-operators-registry/app/src/components/CheckBox.js
+++ b/apps/node-operators-registry/app/src/components/CheckBox.js
@@ -1,0 +1,44 @@
+import { Info, Checkbox as AragonCheckbox, GU } from '@aragon/ui'
+import React, { useCallback } from 'react'
+
+const CheckBox = React.forwardRef(({ label, field, form }, ref) => {
+  const handleChange = useCallback(
+    (checked) => {
+      form.setFieldValue('useAdvancedV8n', checked)
+    },
+    [form]
+  )
+
+  return (
+    <div
+      css={`
+        margin-bottom: ${GU * 3}px;
+      `}
+    >
+      <label
+        css={`
+          display: flex;
+          align-items: center;
+        `}
+      >
+        <AragonCheckbox
+          ref={ref}
+          checked={field.value}
+          // eslint-disable-next-line react/jsx-handler-names
+          onChange={handleChange}
+          css={`
+            margin-right: ${GU}px;
+          `}
+        />
+        Use advanced validation
+      </label>
+      <Info style={{ marginTop: 5 }} mode="warning">
+        By checking this box, you agree to using an external api to check your
+        signing keys for duplicates against already submitted keys and to verify
+        your signatures.
+      </Info>
+    </div>
+  )
+})
+
+export default CheckBox

--- a/apps/node-operators-registry/app/src/utils/helpers.js
+++ b/apps/node-operators-registry/app/src/utils/helpers.js
@@ -74,9 +74,7 @@ export async function myFetch(url, method = 'GET', body) {
   return response.json()
 }
 
-const SIGNATURE_VERIFY_ENDPOINT =
-  process.env.SIGNATURE_VERIFY_ENDPOINT ||
-  'https://goerli.lido.fi/key-checker/api/signature'
+export const SIGNATURE_VERIFY_ENDPOINT = process.env.SIGNATURE_VERIFY_ENDPOINT
 
 function withoutPrefix(hexString) {
   if (hexString.slice(0, 2) === '0x') {
@@ -102,9 +100,7 @@ export async function verifySignaturesAsync(signingKeys) {
   return invalidSigs.map(shortenHex)
 }
 
-const SUBGRAPH_ENDPOINT =
-  process.env.SUBGRAPH_ENDPOINT ||
-  'https://goerli.lido.fi/key-checker/api/subgraph'
+export const SUBGRAPH_ENDPOINT = process.env.SUBGRAPH_ENDPOINT
 
 function prefixEach(arrayOfkeys) {
   return arrayOfkeys.map(({ pubkey }) => '0x' + pubkey)

--- a/apps/node-operators-registry/app/src/utils/helpers.js
+++ b/apps/node-operators-registry/app/src/utils/helpers.js
@@ -42,3 +42,95 @@ export function isHexadecimal(hexString, length) {
   const regex = new RegExp(`^[a-fA-F0-9]{${length}}$`)
   return regex.test(hexString)
 }
+
+export function hasDuplicatePubkeys(signingKeys) {
+  const length = signingKeys.length
+  const pubkeys = signingKeys.map((key) => key.pubkey)
+
+  const pubkeySet = new Set(pubkeys)
+  if (length !== pubkeySet.size) return true
+
+  return false
+}
+
+export function hasDuplicateSigs(signingKeys) {
+  const length = signingKeys.length
+
+  const sigs = signingKeys.map((key) => key.signature)
+  const sigSet = new Set(sigs)
+  if (length !== sigSet.size) return true
+
+  return false
+}
+
+export async function myFetch(url, method = 'GET', body) {
+  const response = await fetch(url, {
+    method,
+    body: JSON.stringify(body),
+    headers: {
+      'Content-type': 'application/json',
+    },
+  })
+  return response.json()
+}
+
+const SIGNATURE_VERIFY_ENDPOINT =
+  process.env.SIGNATURE_VERIFY_ENDPOINT ||
+  'https://goerli.lido.fi/key-checker/api/signature'
+
+function withoutPrefix(hexString) {
+  if (hexString.slice(0, 2) === '0x') {
+    return hexString.slice(2)
+  }
+  return hexString
+}
+
+function shortenHex(hexString) {
+  const hexNoPrefix = withoutPrefix(hexString)
+  const len = hexNoPrefix.length
+  const upTo = 4
+  return `${hexNoPrefix.slice(0, upTo)}...${hexNoPrefix.slice(len - upTo)}`
+}
+
+export async function verifySignaturesAsync(signingKeys) {
+  const body = signingKeys.map(({ pubkey, signature }) => ({
+    pubkey,
+    signature,
+  }))
+
+  const invalidSigs = await myFetch(SIGNATURE_VERIFY_ENDPOINT, 'POST', body)
+  return invalidSigs.map(shortenHex)
+}
+
+const SUBGRAPH_ENDPOINT =
+  process.env.SUBGRAPH_ENDPOINT ||
+  'https://goerli.lido.fi/key-checker/api/subgraph'
+
+function prefixEach(arrayOfkeys) {
+  return arrayOfkeys.map(({ pubkey }) => '0x' + pubkey)
+}
+
+export async function checkForDuplicatesAsync(signingKeys) {
+  const pubkeys = JSON.stringify(prefixEach(signingKeys))
+  const response = await fetch(SUBGRAPH_ENDPOINT, {
+    method: 'POST',
+    body: JSON.stringify({
+      query: `
+        query {
+          nodeOperatorSigningKeys(
+              where: {
+                  pubkey_in: ${pubkeys}
+              }
+          ) {
+            pubkey
+          }
+        }
+      `,
+    }),
+    headers: {
+      'Content-type': 'application/json',
+    },
+  })
+  const { data } = await response.json()
+  return data.nodeOperatorSigningKeys.map(({ pubkey }) => shortenHex(pubkey))
+}


### PR DESCRIPTION
This PR features an additional validation rule for the signing keys submission. It disallows users to submit more than 20 keys in one go. The limit can be specified as an environment variable in package.json, otherwise defaults to 20.

Also, fixes for some cases in which addition of floats returns unexpected results.