### PR TITLE
Fix reward distribution algorithm

### DIFF
--- a/contracts/0.4.24/Lido.sol
+++ b/contracts/0.4.24/Lido.sol
@@ -609,11 +609,12 @@ contract Lido is ILido, IsContract, StETH, AragonApp {
         _emitTransferAfterMintingShares(treasury, toTreasury);
     }
 
-    function _distributeNodeOperatorsReward(uint256 _sharesToDistribute) internal returns (uint256) {
+    function _distributeNodeOperatorsReward(uint256 _sharesToDistribute) internal returns (uint256 distributed) {
         (address[] memory recipients, uint256[] memory shares) = getOperators().getRewardsDistribution(_sharesToDistribute);
 
         assert(recipients.length == shares.length);
 
+        distributed = 0;
         for (uint256 idx = 0; idx < recipients.length; ++idx) {
             _transferShares(
                 address(this),
@@ -621,12 +622,7 @@ contract Lido is ILido, IsContract, StETH, AragonApp {
                 shares[idx]
             );
             _emitTransferAfterMintingShares(recipients[idx], shares[idx]);
-        }
-
-        if (recipients.length > 0) {
-            return _sharesToDistribute;
-        } else {
-            return 0;
+            distributed = distributed.add(shares[idx]);
         }
     }
 

--- a/contracts/0.4.24/Lido.sol
+++ b/contracts/0.4.24/Lido.sol
@@ -448,15 +448,12 @@ contract Lido is ILido, IsContract, StETH, AragonApp {
         if (sharesAmount == 0) {
             // totalControlledEther is 0: either the first-ever deposit or complete slashing
             // assume that shares correspond to Ether 1-to-1
-            _mintShares(sender, deposit);
-            _emitTransferAfterMintingShares(sender, deposit);
-        } else {
-            _mintShares(sender, sharesAmount);
-            _emitTransferAfterMintingShares(sender, sharesAmount);
+            sharesAmount = deposit;
         }
 
+        _mintShares(sender, sharesAmount);
         _submitted(sender, deposit, _referral);
-
+        _emitTransferAfterMintingShares(sender, sharesAmount);
         return sharesAmount;
     }
 

--- a/contracts/0.4.24/interfaces/INodeOperatorsRegistry.sol
+++ b/contracts/0.4.24/interfaces/INodeOperatorsRegistry.sol
@@ -76,6 +76,10 @@ interface INodeOperatorsRegistry {
         uint64 totalSigningKeys,
         uint64 usedSigningKeys);
 
+    /**
+      * @notice Returns the rewards distribution proportional to the effective stake for each node operator.
+      * @param _totalRewardShares Total amount of reward shares to distribute.
+      */
     function getRewardsDistribution(uint256 _totalRewardShares) external view returns (
         address[] memory recipients,
         uint256[] memory shares

--- a/contracts/0.4.24/interfaces/INodeOperatorsRegistry.sol
+++ b/contracts/0.4.24/interfaces/INodeOperatorsRegistry.sol
@@ -76,20 +76,17 @@ interface INodeOperatorsRegistry {
         uint64 totalSigningKeys,
         uint64 usedSigningKeys);
 
+    function getRewardsDistribution(uint256 _totalRewardShares) external view returns (
+        address[] memory recipients,
+        uint256[] memory shares
+    );
+
     event NodeOperatorAdded(uint256 id, string name, address rewardAddress, uint64 stakingLimit);
     event NodeOperatorActiveSet(uint256 indexed id, bool active);
     event NodeOperatorNameSet(uint256 indexed id, string name);
     event NodeOperatorRewardAddressSet(uint256 indexed id, address rewardAddress);
     event NodeOperatorStakingLimitSet(uint256 indexed id, uint64 stakingLimit);
     event NodeOperatorTotalStoppedValidatorsReported(uint256 indexed id, uint64 totalStopped);
-
-    /**
-      * @notice Distributes rewards among node operators.
-      * @dev Function is used by the pool
-      * @param _token Reward token (must be ERC20-compatible)
-      * @param _totalReward Total amount to distribute (must be transferred to this contract beforehand)
-      */
-    function distributeRewards(address _token, uint256 _totalReward) external;
 
     /**
      * @notice Selects and returns at most `_numKeys` signing keys (as well as the corresponding

--- a/contracts/0.4.24/nos/NodeOperatorsRegistry.sol
+++ b/contracts/0.4.24/nos/NodeOperatorsRegistry.sol
@@ -388,14 +388,21 @@ contract NodeOperatorsRegistry is INodeOperatorsRegistry, IsContract, AragonApp 
             effectiveStakeTotal = effectiveStakeTotal.add(effectiveStake);
 
             recipients[idx] = operator.rewardAddress;
-            shares[idx] = effectiveStake.mul(_totalRewardShares);
+            shares[idx] = effectiveStake;
 
             ++idx;
         }
 
+        if (effectiveStakeTotal == 0)
+            return (recipients, shares);
+
+        uint256 perValidatorReward = _totalRewardShares.div(effectiveStakeTotal);
+
         for (idx = 0; idx < activeCount; ++idx) {
-            shares[idx] = shares[idx].div(effectiveStakeTotal);
+            shares[idx] = shares[idx].mul(perValidatorReward);
         }
+
+        return (recipients, shares);
     }
 
     /**

--- a/contracts/0.4.24/nos/test_helpers/PoolMock.sol
+++ b/contracts/0.4.24/nos/test_helpers/PoolMock.sol
@@ -23,8 +23,4 @@ contract PoolMock {
     function trimUnusedKeys() external {
         operators.trimUnusedKeys();
     }
-
-    function distributeRewards(address _token, uint256 _totalReward) external {
-        operators.distributeRewards(_token, _totalReward);
-    }
 }

--- a/test/0.4.24/lido.test.js
+++ b/test/0.4.24/lido.test.js
@@ -219,7 +219,10 @@ contract('Lido', ([appManager, voting, user1, user2, user3, nobody]) => {
     assertBn(await app.totalSupply(), tokens(1))
 
     // +2 ETH
-    await app.submit(ZERO_ADDRESS, { from: user2, value: ETH(2) }) // another form of a deposit call
+    const receipt = await app.submit(ZERO_ADDRESS, { from: user2, value: ETH(2) }) // another form of a deposit call
+
+    assertEvent(receipt, 'Transfer', { expectedArgs: { from: ZERO_ADDRESS, to: user2, value: ETH(2) } })
+
     await checkStat({ depositedValidators: 0, beaconValidators: 0, beaconBalance: ETH(0) })
     assertBn(await validatorRegistration.totalCalls(), 0)
     assertBn(await app.getTotalPooledEther(), ETH(3))

--- a/test/0.4.24/lido.test.js
+++ b/test/0.4.24/lido.test.js
@@ -32,13 +32,14 @@ const hexConcat = (first, ...rest) => {
 }
 
 // Divides a BN by 1e15
-const div15 = (bn) => bn.div(new BN(1000000)).div(new BN(1000000)).div(new BN(1000))
+
+const div15 = (bn) => bn.div(new BN('1000000000000000'))
 
 const ETH = (value) => web3.utils.toWei(value + '', 'ether')
 const tokens = ETH
 
 contract('Lido', ([appManager, voting, user1, user2, user3, nobody]) => {
-  let appBase, nodeOperatorsRegistryBase, app, token, oracle, validatorRegistration, operators
+  let appBase, nodeOperatorsRegistryBase, app, oracle, validatorRegistration, operators
   let treasuryAddr, insuranceAddr
 
   before('deploy base app', async () => {
@@ -596,7 +597,7 @@ contract('Lido', ([appManager, voting, user1, user2, user3, nobody]) => {
     await oracle.reportBeacon(300, 1, ETH(36))
     await checkStat({ depositedValidators: 1, beaconValidators: 1, beaconBalance: ETH(36) })
     assertBn(await app.totalSupply(), tokens(38)) // remote + buffered
-    await checkRewards({ treasury: 599, insurance: 399, operator: 1000 })
+    await checkRewards({ treasury: 600, insurance: 399, operator: 999 })
   })
 
   it('rewards distribution works', async () => {
@@ -659,7 +660,7 @@ contract('Lido', ([appManager, voting, user1, user2, user3, nobody]) => {
     await oracle.reportBeacon(300, 1, ETH(36))
     await checkStat({ depositedValidators: 1, beaconValidators: 1, beaconBalance: ETH(36) })
     assertBn(await app.totalSupply(), tokens(68))
-    await checkRewards({ treasury: 599, insurance: 399, operator: 1000 })
+    await checkRewards({ treasury: 600, insurance: 399, operator: 999 })
   })
 
   it('Node Operators filtering during deposit works when doing a huge deposit', async () => {
@@ -972,11 +973,11 @@ contract('Lido', ([appManager, voting, user1, user2, user3, nobody]) => {
 
   context('treasury', () => {
     it('treasury adddress has been set after init', async () => {
-      assert.notEqual(await app.getTreasury(), ZERO_ADDRESS);
+      assert.notEqual(await app.getTreasury(), ZERO_ADDRESS)
     })
 
     it(`treasury can't be set by an arbitary address`, async () => {
-      await assertRevert(app.setTreasury(user1, { from: nobody  }))
+      await assertRevert(app.setTreasury(user1, { from: nobody }))
       await assertRevert(app.setTreasury(user1, { from: user1 }))
     })
 
@@ -986,20 +987,17 @@ contract('Lido', ([appManager, voting, user1, user2, user3, nobody]) => {
     })
 
     it('reverts when treasury is zero address', async () => {
-      await assertRevert(
-        app.setTreasury(ZERO_ADDRESS, { from: voting }),
-        "SET_TREASURY_ZERO_ADDRESS"
-      )
+      await assertRevert(app.setTreasury(ZERO_ADDRESS, { from: voting }), 'SET_TREASURY_ZERO_ADDRESS')
     })
   })
 
   context('insurance fund', () => {
     it('insurance fund adddress has been set after init', async () => {
-      assert.notEqual(await app.getInsuranceFund(), ZERO_ADDRESS);
+      assert.notEqual(await app.getInsuranceFund(), ZERO_ADDRESS)
     })
 
     it(`insurance fund can't be set by an arbitary address`, async () => {
-      await assertRevert(app.setInsuranceFund(user1, { from: nobody   }))
+      await assertRevert(app.setInsuranceFund(user1, { from: nobody }))
       await assertRevert(app.setInsuranceFund(user1, { from: user1 }))
     })
 
@@ -1009,10 +1007,7 @@ contract('Lido', ([appManager, voting, user1, user2, user3, nobody]) => {
     })
 
     it('reverts when insurance fund is zero address', async () => {
-      await assertRevert(
-        app.setInsuranceFund(ZERO_ADDRESS, { from: voting }),
-        "SET_INSURANCE_FUND_ZERO_ADDRESS"
-      )
+      await assertRevert(app.setInsuranceFund(ZERO_ADDRESS, { from: voting }), 'SET_INSURANCE_FUND_ZERO_ADDRESS')
     })
   })
 })

--- a/test/0.4.24/node-operators-registry.test.js
+++ b/test/0.4.24/node-operators-registry.test.js
@@ -612,37 +612,4 @@ contract('NodeOperatorsRegistry', ([appManager, voting, user1, user2, user3, nob
     await app.removeSigningKey(1, 0, { from: voting })
     await assertRevert(app.getSigningKey(1, 0, { from: nobody }), 'KEY_NOT_FOUND')
   })
-
-  it('distributeRewards works', async () => {
-    await app.addNodeOperator('fo o', ADDRESS_1, 10, { from: voting })
-    await app.addNodeOperator(' bar', ADDRESS_2, UNLIMITED, { from: voting })
-    await app.addNodeOperator('3', ADDRESS_3, UNLIMITED, { from: voting })
-
-    await app.addSigningKeys(0, 2, hexConcat(pad('0x010101', 48), pad('0x020202', 48)), hexConcat(pad('0x01', 96), pad('0x02', 96)), {
-      from: voting
-    })
-    await app.addSigningKeys(1, 2, hexConcat(pad('0x050505', 48), pad('0x060606', 48)), hexConcat(pad('0x04', 96), pad('0x03', 96)), {
-      from: voting
-    })
-    await app.addSigningKeys(2, 2, hexConcat(pad('0x070707', 48), pad('0x080808', 48)), hexConcat(pad('0x05', 96), pad('0x06', 96)), {
-      from: voting
-    })
-
-    await pool.assignNextSigningKeys(6)
-    assertBn((await app.getNodeOperator(0, false)).usedSigningKeys, 2, 'op 0 used keys')
-    assertBn((await app.getNodeOperator(1, false)).usedSigningKeys, 2, 'op 1 used keys')
-    assertBn((await app.getNodeOperator(2, false)).usedSigningKeys, 2, 'op 2 used keys')
-
-    await app.reportStoppedValidators(0, 1, { from: voting })
-    await app.setNodeOperatorActive(2, false, { from: voting })
-
-    const token = await ERC20Mock.new()
-    await token.mint(app.address, tokens(900))
-    await pool.distributeRewards(token.address, tokens(900))
-
-    assertBn(await token.balanceOf(ADDRESS_1, { from: nobody }), tokens(300))
-    assertBn(await token.balanceOf(ADDRESS_2, { from: nobody }), tokens(600))
-    assertBn(await token.balanceOf(ADDRESS_3, { from: nobody }), 0)
-    assertBn(await token.balanceOf(app.address, { from: nobody }), 0)
-  })
 })

--- a/test/0.4.24/node-operators-registry.test.js
+++ b/test/0.4.24/node-operators-registry.test.js
@@ -612,4 +612,33 @@ contract('NodeOperatorsRegistry', ([appManager, voting, user1, user2, user3, nob
     await app.removeSigningKey(1, 0, { from: voting })
     await assertRevert(app.getSigningKey(1, 0, { from: nobody }), 'KEY_NOT_FOUND')
   })
+
+  it('getRewardsDistribution works', async () => {
+    await app.addNodeOperator('fo o', ADDRESS_1, 10, { from: voting })
+    await app.addNodeOperator(' bar', ADDRESS_2, UNLIMITED, { from: voting })
+    await app.addNodeOperator('3', ADDRESS_3, UNLIMITED, { from: voting })
+
+    await app.addSigningKeys(0, 2, hexConcat(pad('0x010101', 48), pad('0x020202', 48)), hexConcat(pad('0x01', 96), pad('0x02', 96)), {
+      from: voting
+    })
+    await app.addSigningKeys(1, 2, hexConcat(pad('0x050505', 48), pad('0x060606', 48)), hexConcat(pad('0x04', 96), pad('0x03', 96)), {
+      from: voting
+    })
+    await app.addSigningKeys(2, 2, hexConcat(pad('0x070707', 48), pad('0x080808', 48)), hexConcat(pad('0x05', 96), pad('0x06', 96)), {
+      from: voting
+    })
+
+    await pool.assignNextSigningKeys(6)
+    assertBn((await app.getNodeOperator(0, false)).usedSigningKeys, 2, 'op 0 used keys')
+    assertBn((await app.getNodeOperator(1, false)).usedSigningKeys, 2, 'op 1 used keys')
+    assertBn((await app.getNodeOperator(2, false)).usedSigningKeys, 2, 'op 2 used keys')
+
+    await app.reportStoppedValidators(0, 1, { from: voting })
+    await app.setNodeOperatorActive(2, false, { from: voting })
+
+    const {recipients, shares} = await app.getRewardsDistribution(tokens(900));
+
+    assert.sameOrderedMembers(recipients, [ADDRESS_1, ADDRESS_2], 'recipients')
+    assert.sameOrderedMembers(shares.map(x => String(x)), [tokens(300), tokens(600)], 'shares')
+  })
 })

--- a/test/scenario/lido_happy_path.js
+++ b/test/scenario/lido_happy_path.js
@@ -330,8 +330,7 @@ contract('Lido: happy path', (addresses) => {
     // and node operators
     // treasuryTokenBalance ~= mintedAmount * treasuryFeePoints / 10000
     // insuranceTokenBalance ~= mintedAmount * insuranceFeePoints / 10000
-
-    assertBn(await token.balanceOf(treasuryAddr), new BN('95999999999999998'), 'treasury tokens')
+    assertBn(await token.balanceOf(treasuryAddr), new BN('96000000000000001'), 'treasury tokens')
     assertBn(await token.balanceOf(insuranceAddr), new BN('63999999999999998'), 'insurance tokens')
 
     // The node operators' fee is distributed between all active node operators,

--- a/test/scenario/lido_penalties_slashing.js
+++ b/test/scenario/lido_penalties_slashing.js
@@ -179,7 +179,7 @@ contract('Lido: penalties, slashing, operator stops', (addresses) => {
   it(`new validator doesn't get buffered ether even if there's 32 ETH deposit in the pool`, async () => {
     assertBn(await pool.getBufferedEther(), ETH(32), `all ether is buffered until there's a validator to deposit it`)
     assertBn(await pool.getTotalPooledEther(), ETH(32), 'total pooled ether')
-    assertBn(await nodeOperatorRegistry.getUnusedSigningKeyCount(0), 1, 'no more available keys for the first validator')
+    assertBn(await nodeOperatorRegistry.getUnusedSigningKeyCount(0), 1, 'one key available for the first validator')
   })
 
   it(`pushes pooled eth to the available validator`, async () => {

--- a/test/scenario/lido_penalties_slashing.js
+++ b/test/scenario/lido_penalties_slashing.js
@@ -506,9 +506,62 @@ contract('Lido: penalties, slashing, operator stops', (addresses) => {
     )
   })
 
+  it(`voting stops the second operator`, async () => {
+    const activeOperatorsBefore = await nodeOperatorRegistry.getActiveNodeOperatorsCount()
+    await nodeOperatorRegistry.setNodeOperatorActive(1, false, { from: voting })
+    const activeOperatorsAfter = await nodeOperatorRegistry.getActiveNodeOperatorsCount()
+    assertBn(activeOperatorsAfter, activeOperatorsBefore.sub(new BN(1)), 'deactivated one operator')
+    assertBn(activeOperatorsAfter, new BN(0), 'no active operators')
+  })
+
+  it(`without active node operators node operator's fee is sent to treasury`, async () => {
+    const nodeOperator1TokenSharesBefore = await token.sharesOf(nodeOperator1.address)
+    const nodeOperator2TokenSharesBefore = await token.sharesOf(nodeOperator2.address)
+    const insuranceSharesBefore = await token.sharesOf(insuranceAddr)
+    const treasurySharesBefore = await token.sharesOf(treasuryAddr)
+    const prevTotalShares = await token.getTotalShares()
+
+    await oracleMock.reportBeacon(105, 2, tokens(98)) // 105 is an epoch number
+
+    const nodeOperator1TokenSharesAfter = await token.sharesOf(nodeOperator1.address)
+    const nodeOperator2TokenSharesAfter = await token.sharesOf(nodeOperator2.address)
+    const insuranceSharesAfter = await token.sharesOf(insuranceAddr)
+    const treasurySharesAfter = await token.sharesOf(treasuryAddr)
+    const totalPooledEther = await token.getTotalPooledEther()
+
+    assertBn(nodeOperator1TokenSharesAfter, nodeOperator1TokenSharesBefore, `first node operator hasn't got fees`)
+    assertBn(nodeOperator2TokenSharesAfter, nodeOperator2TokenSharesBefore, `second node operator hasn't got fees`)
+
+    const tenKBN = new BN(10000)
+    const totalFeeToDistribute = new BN(ETH(2)).mul(new BN(totalFeePoints)).div(tenKBN)
+
+    const sharesToMint = totalFeeToDistribute.mul(prevTotalShares).div(totalPooledEther.sub(totalFeeToDistribute))
+    const insuranceFee = sharesToMint.mul(new BN(insuranceFeePoints)).div(tenKBN)
+    const treasuryFeeTotalMinusInsurance = sharesToMint.sub(insuranceFee)
+
+    const treasuryFeeTotalTreasuryPlusNodeOperators = sharesToMint
+      .mul(new BN(treasuryFeePoints).add(new BN(nodeOperatorsFeePoints)))
+      .div(tenKBN)
+
+    assertBn(insuranceSharesAfter.sub(insuranceSharesBefore), insuranceFee, 'insurance got the regular fee')
+    assertBn(treasurySharesAfter.sub(treasurySharesBefore), treasuryFeeTotalMinusInsurance, 'treasury got the total fee - insurance fee')
+    assertBn(
+      treasurySharesAfter.sub(treasurySharesBefore),
+      treasuryFeeTotalTreasuryPlusNodeOperators.add(new BN(1)),
+      'treasury got the regular fee + node operators fee'
+    )
+  })
+
   it(`voting starts the first operator back`, async () => {
     const activeOperatorsBefore = await nodeOperatorRegistry.getActiveNodeOperatorsCount()
     await nodeOperatorRegistry.setNodeOperatorActive(0, true, { from: voting })
+    const activeOperatorsAfter = await nodeOperatorRegistry.getActiveNodeOperatorsCount()
+    assertBn(activeOperatorsAfter, activeOperatorsBefore.add(new BN(1)), 'activated one operator')
+  })
+
+  it(`voting starts the second operator back`, async () => {
+    const activeOperatorsBefore = await nodeOperatorRegistry.getActiveNodeOperatorsCount()
+    await nodeOperatorRegistry.setNodeOperatorActive(1, true, { from: voting })
     const activeOperatorsAfter = await nodeOperatorRegistry.getActiveNodeOperatorsCount()
     assertBn(activeOperatorsAfter, activeOperatorsBefore.add(new BN(1)), 'activated one operator')
   })
@@ -517,7 +570,7 @@ contract('Lido: penalties, slashing, operator stops', (addresses) => {
     const nodeOperator1TokenSharesBefore = await token.sharesOf(nodeOperator1.address)
     const nodeOperator2TokenSharesBefore = await token.sharesOf(nodeOperator2.address)
 
-    await oracleMock.reportBeacon(105, 2, tokens(100)) // 105 is an epoch number
+    await oracleMock.reportBeacon(106, 2, tokens(100)) // 106 is an epoch number
 
     const nodeOperator1TokenSharesAfter = await token.sharesOf(nodeOperator1.address)
     const nodeOperator2TokenSharesAfter = await token.sharesOf(nodeOperator2.address)


### PR DESCRIPTION
This PR refactors node operators’ reward distribution mechanics. Previously, `NodeOperatorsRegistry` distributed token rewards between operators on its own. Now, `Lido` gets a list of reward amounts and the corresponding operator addresses from `NodeOperatorRegistry` and performs transfers by itself. In the case of registering a profit without any active node operators, the new algorithm transfers all operators' fee tokens to the treasury. This approach is more gas efficient and prevents accumulating `StETH` dust on any contract involved.

Fix #237 
Fix #241 
Fix #240
