### PR TITLE
Prevent accidental submission of Ether by calling non-existing functions

### DIFF
--- a/contracts/0.4.24/Lido.sol
+++ b/contracts/0.4.24/Lido.sol
@@ -114,7 +114,7 @@ contract Lido is ILido, IsContract, StETH, AragonApp {
     */
     function() external payable {
         // protection against accidental submissions by calling non-existent function
-        require(msg.data.length == 0, "UNKNOWN_FUNCTION");
+        require(msg.data.length == 0, "NON_EMPTY_DATA");
         _submit(0);
     }
 

--- a/contracts/0.4.24/Lido.sol
+++ b/contracts/0.4.24/Lido.sol
@@ -113,6 +113,8 @@ contract Lido is ILido, IsContract, StETH, AragonApp {
     * depositBufferedEther() and pushes them to the ETH2 Deposit contract.
     */
     function() external payable {
+        // protection against accidental submissions by calling non-existent function
+        require(msg.data.length == 0, "UNKNOWN_FUNCTION");
         _submit(0);
     }
 

--- a/test/0.4.24/lido.test.js
+++ b/test/0.4.24/lido.test.js
@@ -334,6 +334,14 @@ contract('Lido', ([appManager, voting, user1, user2, user3, nobody]) => {
     assertEvent(receipt, 'Submitted', { expectedArgs: { sender: user2, amount: ETH(5), referral: ZERO_ADDRESS } })
   })
 
+  it('reverts when trying to call unknown function along with the non zero value', async () => {
+    const wrongMethodABI = '0x00'
+    await assertRevert(
+      web3.eth.sendTransaction({ to: app.address, from: user2, value: ETH(1), data: wrongMethodABI }),
+      'UNKNOWN_FUNCTION'
+    )
+  })
+
   it('key removal is taken into account during deposit', async () => {
     await operators.addNodeOperator('1', ADDRESS_1, UNLIMITED, { from: voting })
     await operators.addNodeOperator('2', ADDRESS_2, UNLIMITED, { from: voting })

--- a/test/0.4.24/lido.test.js
+++ b/test/0.4.24/lido.test.js
@@ -338,7 +338,7 @@ contract('Lido', ([appManager, voting, user1, user2, user3, nobody]) => {
     const wrongMethodABI = '0x00'
     await assertRevert(
       web3.eth.sendTransaction({ to: app.address, from: user2, value: ETH(1), data: wrongMethodABI }),
-      'UNKNOWN_FUNCTION'
+      'NON_EMPTY_DATA'
     )
   })
 

--- a/test/0.4.24/lido.test.js
+++ b/test/0.4.24/lido.test.js
@@ -334,10 +334,14 @@ contract('Lido', ([appManager, voting, user1, user2, user3, nobody]) => {
     assertEvent(receipt, 'Submitted', { expectedArgs: { sender: user2, amount: ETH(5), referral: ZERO_ADDRESS } })
   })
 
-  it('reverts when trying to call unknown function along with the non zero value', async () => {
+  it('reverts when trying to call unknown function', async () => {
     const wrongMethodABI = '0x00'
     await assertRevert(
       web3.eth.sendTransaction({ to: app.address, from: user2, value: ETH(1), data: wrongMethodABI }),
+      'NON_EMPTY_DATA'
+    )
+    await assertRevert(
+      web3.eth.sendTransaction({ to: app.address, from: user2, value: ETH(0), data: wrongMethodABI }),
       'NON_EMPTY_DATA'
     )
   })


### PR DESCRIPTION
Current `Lido` smart contract fallback function treats any call as funds submission. This may result in users accidentally locking their funds if they mistook the Lido contract for something else, or accessed it through an inaccurate interface. This PR fixes the issue by adding `require(msg.data.length == 0);` to the fallback function.