### PR TITLE
Add additional protection for implementations from accidental Ether submission

### DIFF
--- a/contracts/0.4.24/Lido.sol
+++ b/contracts/0.4.24/Lido.sol
@@ -256,7 +256,7 @@ contract Lido is ILido, IsContract, StETH, AragonApp {
     * @param _beaconValidators number of Lido's keys in the beacon state
     * @param _beaconBalance simmarized balance of Lido-controlled keys in wei
     */
-    function pushBeacon(uint256 _beaconValidators, uint256 _beaconBalance) external {
+    function pushBeacon(uint256 _beaconValidators, uint256 _beaconBalance) external whenNotStopped {
         require(msg.sender == getOracle(), "APP_AUTH_FAILED");
 
         uint256 depositedValidators = DEPOSITED_VALIDATORS_VALUE_POSITION.getStorageUint256();

--- a/contracts/0.4.24/Lido.sol
+++ b/contracts/0.4.24/Lido.sol
@@ -102,6 +102,8 @@ contract Lido is ILido, IsContract, StETH, AragonApp {
         _setTreasury(_treasury);
         _setInsuranceFund(_insuranceFund);
 
+        _resume();
+
         initialized();
     }
 

--- a/contracts/0.4.24/lib/Pausable.sol
+++ b/contracts/0.4.24/lib/Pausable.sol
@@ -13,29 +13,29 @@ contract Pausable {
     event Stopped();
     event Resumed();
 
-    bytes32 internal constant STOPPED_FLAG_POSITION = keccak256("lido.Pausable.stopped");
+    bytes32 internal constant UNSTOPPED_FLAG_POSITION = keccak256("lido.Pausable.unstopped");
 
     modifier whenNotStopped() {
-        require(!STOPPED_FLAG_POSITION.getStorageBool(), "CONTRACT_IS_STOPPED");
+        require(UNSTOPPED_FLAG_POSITION.getStorageBool(), "CONTRACT_IS_STOPPED");
         _;
     }
 
     modifier whenStopped() {
-        require(STOPPED_FLAG_POSITION.getStorageBool());
+        require(!UNSTOPPED_FLAG_POSITION.getStorageBool());
         _;
     }
 
     function isStopped() external view returns (bool) {
-        return STOPPED_FLAG_POSITION.getStorageBool();
+        return !UNSTOPPED_FLAG_POSITION.getStorageBool();
     }
 
     function _stop() internal whenNotStopped {
-        STOPPED_FLAG_POSITION.setStorageBool(true);
+        UNSTOPPED_FLAG_POSITION.setStorageBool(false);
         emit Stopped();
     }
 
     function _resume() internal whenStopped {
-        STOPPED_FLAG_POSITION.setStorageBool(false);
+        UNSTOPPED_FLAG_POSITION.setStorageBool(true);
         emit Resumed();
     }
 }

--- a/contracts/0.4.24/lib/Pausable.sol
+++ b/contracts/0.4.24/lib/Pausable.sol
@@ -13,29 +13,29 @@ contract Pausable {
     event Stopped();
     event Resumed();
 
-    bytes32 internal constant UNSTOPPED_FLAG_POSITION = keccak256("lido.Pausable.unstopped");
+    bytes32 internal constant RUNNING_FLAG_POSITION = keccak256("lido.Pausable.running");
 
     modifier whenNotStopped() {
-        require(UNSTOPPED_FLAG_POSITION.getStorageBool(), "CONTRACT_IS_STOPPED");
+        require(RUNNING_FLAG_POSITION.getStorageBool(), "CONTRACT_IS_STOPPED");
         _;
     }
 
     modifier whenStopped() {
-        require(!UNSTOPPED_FLAG_POSITION.getStorageBool());
+        require(!RUNNING_FLAG_POSITION.getStorageBool());
         _;
     }
 
     function isStopped() external view returns (bool) {
-        return !UNSTOPPED_FLAG_POSITION.getStorageBool();
+        return !RUNNING_FLAG_POSITION.getStorageBool();
     }
 
     function _stop() internal whenNotStopped {
-        UNSTOPPED_FLAG_POSITION.setStorageBool(false);
+        RUNNING_FLAG_POSITION.setStorageBool(false);
         emit Stopped();
     }
 
     function _resume() internal whenStopped {
-        UNSTOPPED_FLAG_POSITION.setStorageBool(true);
+        RUNNING_FLAG_POSITION.setStorageBool(true);
         emit Resumed();
     }
 }

--- a/contracts/0.4.24/lib/Pausable.sol
+++ b/contracts/0.4.24/lib/Pausable.sol
@@ -13,29 +13,29 @@ contract Pausable {
     event Stopped();
     event Resumed();
 
-    bytes32 internal constant RUNNING_FLAG_POSITION = keccak256("lido.Pausable.running");
+    bytes32 internal constant ACTIVE_FLAG_POSITION = keccak256("lido.Pausable.active");
 
     modifier whenNotStopped() {
-        require(RUNNING_FLAG_POSITION.getStorageBool(), "CONTRACT_IS_STOPPED");
+        require(ACTIVE_FLAG_POSITION.getStorageBool(), "CONTRACT_IS_STOPPED");
         _;
     }
 
     modifier whenStopped() {
-        require(!RUNNING_FLAG_POSITION.getStorageBool());
+        require(!ACTIVE_FLAG_POSITION.getStorageBool(), "CONTRACT_IS_ACTIVE");
         _;
     }
 
     function isStopped() external view returns (bool) {
-        return !RUNNING_FLAG_POSITION.getStorageBool();
+        return !ACTIVE_FLAG_POSITION.getStorageBool();
     }
 
     function _stop() internal whenNotStopped {
-        RUNNING_FLAG_POSITION.setStorageBool(false);
+        ACTIVE_FLAG_POSITION.setStorageBool(false);
         emit Stopped();
     }
 
     function _resume() internal whenStopped {
-        RUNNING_FLAG_POSITION.setStorageBool(true);
+        ACTIVE_FLAG_POSITION.setStorageBool(true);
         emit Resumed();
     }
 }

--- a/contracts/0.4.24/test_helpers/LidoPushableMock.sol
+++ b/contracts/0.4.24/test_helpers/LidoPushableMock.sol
@@ -34,6 +34,7 @@ contract LidoPushableMock is Lido {
 
     function initialize(address _oracle) public onlyInit {
         _setOracle(_oracle);
+        _resume();
         initialized();
     }
 

--- a/contracts/0.4.24/test_helpers/StETHMock.sol
+++ b/contracts/0.4.24/test_helpers/StETHMock.sol
@@ -13,6 +13,10 @@ import "../StETH.sol";
 contract StETHMock is StETH {
     uint256 private totalPooledEther;
 
+    constructor() public {
+        _resume();
+    }
+
     function _getTotalPooledEther() internal view returns (uint256) {
         return totalPooledEther;
     }


### PR DESCRIPTION
Fixes #243. This changes the `Pausable` contract’s logic to be paused by default and switches it on in `Lido.initialize()` using the `_resume()` method. Also, this adds the `whenNotStopped` modifier to the  `pushBeacon` method so it isn't possible to report oracle data until the protocol is initialized.