### PR TITLE
No side effects in an assertion

### DIFF
--- a/contracts/0.4.24/nos/NodeOperatorsRegistry.sol
+++ b/contracts/0.4.24/nos/NodeOperatorsRegistry.sol
@@ -317,7 +317,10 @@ contract NodeOperatorsRegistry is INodeOperatorsRegistry, IsContract, AragonApp 
             if (bestOperatorIdx == cache.length)  // not found
                 break;
 
-            assert(++cache[bestOperatorIdx].usedSigningKeys <= UINT64_MAX);
+            entry = cache[bestOperatorIdx];
+            assert(entry.usedSigningKeys < UINT64_MAX);
+
+            ++entry.usedSigningKeys;
             ++numAssignedKeys;
         }
 


### PR DESCRIPTION
Avoid modifying state in an assertion since the latter may be removed by automated tools.

Highlighted in: #250.