### PR TITLE
Fix possible precision loss issue while shares calculation

### DIFF
--- a/contracts/0.4.24/Lido.sol
+++ b/contracts/0.4.24/Lido.sol
@@ -442,10 +442,12 @@ contract Lido is ILido, IsContract, StETH, AragonApp {
         uint256 deposit = msg.value;
         require(deposit != 0, "ZERO_DEPOSIT");
 
-        uint256 sharesAmount = getSharesByPooledEth(deposit);
-        if (sharesAmount == 0) {
-            // totalControlledEther is 0: either the first-ever deposit or complete slashing
-            // assume that shares correspond to Ether 1-to-1
+        uint256 sharesAmount;
+        if (_getTotalPooledEther() != 0) {
+            sharesAmount = getSharesByPooledEth(deposit);
+        } else {
+            // totalPooledEther is 0: for first-ever deposit assume
+            // that shares correspond to Ether 1-to-1
             sharesAmount = deposit;
         }
 


### PR DESCRIPTION
This PR is fixing the issue described in #251 related to possible precision loss while sharesAmount computation in the _submit method. Indeed, for some extreme shares/ether ratios (e.g 1 wei of shares corresponds to 1e9 wei of ether) it's possible to submit a little deposit that is less than ether per share ratio (in our example it is 1e9 - 1 wei) and gets an unreasonably large number of tokens in exchange. The described situation is possible only if the protocol will profit during a significant amount of time (like many years) or in case of significant token burning.

As @Eenae suggests, this PR replace condition `(sharesAmount == 0)` to `(_getTotalPooledEther() != 0)` which prevents such situation. The best from the correctness perspective is to check both `(_getTotalPooledEther() != 0 && totalShares != 0)`, but this is not necessary because complete zeroing of the total controlled ether is impossible right now.

While the pull request removes the inconsistency, this change increases the amount of gas required per submission, which we want to keep as low as possible.