### PR TITLE
Methods for removing keys in batches

### DIFF
--- a/contracts/0.4.24/nos/NodeOperatorsRegistry.sol
+++ b/contracts/0.4.24/nos/NodeOperatorsRegistry.sol
@@ -265,6 +265,21 @@ contract NodeOperatorsRegistry is INodeOperatorsRegistry, IsContract, AragonApp 
     }
 
     /**
+      * @notice Removes an #`_amount` of validator signing keys starting from #`_index` of operator #`_id` usable keys. Executed on behalf of DAO.
+      * @param _operator_id Node Operator id
+      * @param _index Index of the key, starting with 0
+      * @param _amount Number of keys to remove
+      */
+    function removeSigningKeys(uint256 _operator_id, uint256 _index, uint256 _amount)
+        external
+        authP(MANAGE_SIGNING_KEYS, arr(_operator_id))
+    {
+        for (uint256 i = 1; i <= _amount ; ++i) {
+            _removeSigningKey(_operator_id, _index+_amount-i);
+        }
+    }
+
+    /**
       * @notice Removes a validator signing key #`_index` of operator #`_id` from the set of usable keys. Executed on behalf of Node Operator.
       * @param _operator_id Node Operator id
       * @param _index Index of the key, starting with 0
@@ -272,6 +287,19 @@ contract NodeOperatorsRegistry is INodeOperatorsRegistry, IsContract, AragonApp 
     function removeSigningKeyOperatorBH(uint256 _operator_id, uint256 _index) external {
         require(msg.sender == operators[_operator_id].rewardAddress, "APP_AUTH_FAILED");
         _removeSigningKey(_operator_id, _index);
+    }
+
+    /**
+      * @notice Removes an #`_amount` of validator signing keys starting from #`_index` of operator #`_id` usable keys. Executed on behalf of Node Operator.
+      * @param _operator_id Node Operator id
+      * @param _index Index of the key, starting with 0
+      * @param _amount Number of keys to remove
+      */
+    function removeSigningKeysOperatorBH(uint256 _operator_id, uint256 _index, uint256 _amount) external {
+        require(msg.sender == operators[_operator_id].rewardAddress, "APP_AUTH_FAILED");
+        for (uint256 i = 1; i <= _amount ; ++i) {
+            _removeSigningKey(_operator_id, _index+_amount-i);
+        }
     }
 
     /**

--- a/test/0.4.24/node-operators-registry.test.js
+++ b/test/0.4.24/node-operators-registry.test.js
@@ -623,6 +623,74 @@ contract('NodeOperatorsRegistry', ([appManager, voting, user1, user2, user3, nob
     await assertRevert(app.getSigningKey(1, 0, { from: nobody }), 'KEY_NOT_FOUND')
   })
 
+  it('removeSigningKeys works', async () => {
+    await app.addNodeOperator('1', user1, UNLIMITED, { from: voting })
+
+    const op0 = {
+      keys: [
+        pad('0xaa0101', 48),
+        pad('0xaa0202', 48),
+        pad('0xaa0303', 48),
+        pad('0xaa0404', 48),
+        pad('0xbb0505', 48),
+        pad('0xbb0606', 48),
+        pad('0xbb0707', 48),
+        pad('0xbb0808', 48)
+      ],
+      sigs: [
+        pad('0xa1', 96),
+        pad('0xa2', 96),
+        pad('0xa3', 96),
+        pad('0xa4', 96),
+        pad('0xb5', 96),
+        pad('0xb6', 96),
+        pad('0xb7', 96),
+        pad('0xb8', 96)
+      ]
+    }
+
+    await app.addSigningKeys(0, 8, hexConcat(...op0.keys), hexConcat(...op0.sigs), { from: voting })
+
+    assertBn(await app.getTotalSigningKeyCount(0, { from: nobody }), 8)
+    assertBn(await app.getUnusedSigningKeyCount(0, { from: nobody }), 8)
+
+    await assertRevert(app.removeSigningKeys(0, 0, 1, { from: user1 }), 'APP_AUTH_FAILED')
+    await assertRevert(app.removeSigningKeys(0, 0, 1, { from: nobody }), 'APP_AUTH_FAILED')
+
+    await app.removeSigningKeys(0, 0, 1, { from: voting })
+
+    assertBn(await app.getTotalSigningKeyCount(0, { from: nobody }), 7)
+    assertBn(await app.getUnusedSigningKeyCount(0, { from: nobody }), 7)
+    assert.equal((await app.getSigningKey(0, 0, { from: nobody })).key, op0.keys[7])
+    await assertRevert(app.removeSigningKeys(0, 7, 1, { from: voting }), 'KEY_NOT_FOUND')
+    await assertRevert(app.removeSigningKeys(0, 0, 8, { from: voting }), 'KEY_NOT_FOUND')
+
+    await app.removeSigningKeys(0, 1, 2, { from: voting })
+    assertBn(await app.getTotalSigningKeyCount(0, { from: nobody }), 5)
+    assertBn(await app.getUnusedSigningKeyCount(0, { from: nobody }), 5)
+
+    assert.equal((await app.getSigningKey(0, 0, { from: nobody })).key, op0.keys[7])
+    assert.equal((await app.getSigningKey(0, 1, { from: nobody })).key, op0.keys[5])
+    assert.equal((await app.getSigningKey(0, 2, { from: nobody })).key, op0.keys[6])
+
+    await assertRevert(app.removeSigningKeysOperatorBH(0, 3, 1, { from: voting }), 'APP_AUTH_FAILED')
+    await assertRevert(app.removeSigningKeysOperatorBH(0, 3, 1, { from: nobody }), 'APP_AUTH_FAILED')
+
+    await app.removeSigningKeysOperatorBH(0, 3, 1, { from: user1 })
+
+    await assertRevert(app.removeSigningKeysOperatorBH(0, 4, 1, { from: voting }), 'APP_AUTH_FAILED')
+    await assertRevert(app.removeSigningKeysOperatorBH(0, 4, 1, { from: user1 }), 'KEY_NOT_FOUND')
+
+    assertBn(await app.getTotalSigningKeyCount(0, { from: nobody }), 4)
+    assertBn(await app.getUnusedSigningKeyCount(0, { from: nobody }), 4)
+    assert.equal((await app.getSigningKey(0, 3, { from: nobody })).key, op0.keys[4])
+
+    await app.removeSigningKeysOperatorBH(0, 2, 2, { from: user1 })
+
+    assert.equal((await app.getSigningKey(0, 0, { from: nobody })).key, op0.keys[7])
+    assert.equal((await app.getSigningKey(0, 1, { from: nobody })).key, op0.keys[5])
+  })
+
   it('getRewardsDistribution works', async () => {
     const { empty_recipients, empty_shares } = await app.getRewardsDistribution(tokens(900))
 


### PR DESCRIPTION
The pull adds two methods for key removal in batches, `removeSigningKeys` callable by Voting contract & `removeSigningKeysOperatorBH` callable by the Node Operator's reward address