### PR TITLE
Initial version of Oracle initialization according to new LIP

### DIFF
--- a/contracts/0.4.24/interfaces/ILidoOracle.sol
+++ b/contracts/0.4.24/interfaces/ILidoOracle.sol
@@ -184,15 +184,30 @@ interface ILidoOracle {
         );
 
     /**
-     * @notice Initialize the contract v2 data, with sanity check bounds
-     * (`_allowedBeaconBalanceAnnualRelativeIncrease`, `_allowedBeaconBalanceRelativeDecrease`)
-     * @dev Original initialize function removed from v2 because it is invoked only once
+     * @notice Initialize the contract (version 3 for now) from scratch
+     * @dev TODO: Add link to the related LIP
+     * @param _lido Address of Lido contract
+     * @param _epochsPerFrame Number of epochs per frame
+     * @param _slotsPerEpoch Number of slots per epoch
+     * @param _secondsPerSlot Number of seconds per slot
+     * @param _genesisTime Genesis time
+     * @param _allowedBeaconBalanceAnnualRelativeIncrease Allowed beacon balance annual relative increase (e.g. 1000 means 10% yearly increase)
+     * @param _allowedBeaconBalanceRelativeDecrease Allowed beacon balance moment descreat (e.g. 500 means 5% moment decrease)
      */
-    function initialize_v2(
+    function initialize(
+        address _lido,
+        uint64 _epochsPerFrame,
+        uint64 _slotsPerEpoch,
+        uint64 _secondsPerSlot,
+        uint64 _genesisTime,
         uint256 _allowedBeaconBalanceAnnualRelativeIncrease,
-        uint256 _allowedBeaconBalanceRelativeDecrease
-    )
-        external;
+        uint256 _allowedBeaconBalanceRelativeDecrease) external;
+
+    /**
+     * @notice A function to finalize upgrade to v3 (from v1). Can be called only once
+     * @dev For more details see _initialize_v3()
+     */
+    function finalizeUpgrade_v3() external;
 
     /**
      * @notice Add `_member` to the oracle member committee list

--- a/contracts/0.4.24/interfaces/ILidoOracle.sol
+++ b/contracts/0.4.24/interfaces/ILidoOracle.sol
@@ -194,7 +194,6 @@ interface ILidoOracle {
      * @param _genesisTime Genesis time
      * @param _allowedBeaconBalanceAnnualRelativeIncrease Allowed beacon balance annual relative increase (e.g. 1000 means 10% yearly increase)
      * @param _allowedBeaconBalanceRelativeDecrease Allowed beacon balance moment descreat (e.g. 500 means 5% moment decrease)
-     * @param _lastCompletedEpochId Id of the last completed epoch TODO can it always be zero?
      */
     function initialize(
         address _lido,
@@ -203,8 +202,7 @@ interface ILidoOracle {
         uint64 _secondsPerSlot,
         uint64 _genesisTime,
         uint256 _allowedBeaconBalanceAnnualRelativeIncrease,
-        uint256 _allowedBeaconBalanceRelativeDecrease,
-        uint256 _lastCompletedEpochId
+        uint256 _allowedBeaconBalanceRelativeDecrease
     ) external;
 
     /**

--- a/contracts/0.4.24/interfaces/ILidoOracle.sol
+++ b/contracts/0.4.24/interfaces/ILidoOracle.sol
@@ -183,6 +183,7 @@ interface ILidoOracle {
             uint256 timeElapsed
         );
 
+    
     /**
      * @notice Initialize the contract (version 3 for now) from scratch
      * @dev TODO: Add link to the related LIP
@@ -193,6 +194,7 @@ interface ILidoOracle {
      * @param _genesisTime Genesis time
      * @param _allowedBeaconBalanceAnnualRelativeIncrease Allowed beacon balance annual relative increase (e.g. 1000 means 10% yearly increase)
      * @param _allowedBeaconBalanceRelativeDecrease Allowed beacon balance moment descreat (e.g. 500 means 5% moment decrease)
+     * @param _lastCompletedEpochId Id of the last completed epoch TODO can it always be zero?
      */
     function initialize(
         address _lido,
@@ -201,7 +203,9 @@ interface ILidoOracle {
         uint64 _secondsPerSlot,
         uint64 _genesisTime,
         uint256 _allowedBeaconBalanceAnnualRelativeIncrease,
-        uint256 _allowedBeaconBalanceRelativeDecrease) external;
+        uint256 _allowedBeaconBalanceRelativeDecrease,
+        uint256 _lastCompletedEpochId
+    ) external;
 
     /**
      * @notice A function to finalize upgrade to v3 (from v1). Can be called only once

--- a/contracts/0.4.24/oracle/LidoOracle.sol
+++ b/contracts/0.4.24/oracle/LidoOracle.sol
@@ -330,6 +330,7 @@ contract LidoOracle is ILidoOracle, AragonApp {
         preTotalPooledEther = PRE_COMPLETED_TOTAL_POOLED_ETHER_POSITION.getStorageUint256();
         timeElapsed = TIME_ELAPSED_POSITION.getStorageUint256();
     }
+
     /**
      * @notice Initialize the contract (version 3 for now) from scratch
      * @dev TODO: Add link to the related LIP
@@ -340,7 +341,6 @@ contract LidoOracle is ILidoOracle, AragonApp {
      * @param _genesisTime Genesis time
      * @param _allowedBeaconBalanceAnnualRelativeIncrease Allowed beacon balance annual relative increase (e.g. 1000 means 10% yearly increase)
      * @param _allowedBeaconBalanceRelativeDecrease Allowed beacon balance moment descreat (e.g. 500 means 5% moment decrease)
-     * @param _lastCompletedEpochId Id of the last completed epoch TODO can it always be zero?
      */
     function initialize(
         address _lido,
@@ -349,8 +349,7 @@ contract LidoOracle is ILidoOracle, AragonApp {
         uint64 _secondsPerSlot,
         uint64 _genesisTime,
         uint256 _allowedBeaconBalanceAnnualRelativeIncrease,
-        uint256 _allowedBeaconBalanceRelativeDecrease,
-        uint256 _lastCompletedEpochId
+        uint256 _allowedBeaconBalanceRelativeDecrease
     )
         external onlyInit
     {
@@ -381,17 +380,16 @@ contract LidoOracle is ILidoOracle, AragonApp {
             .setStorageUint256(_allowedBeaconBalanceRelativeDecrease);
         emit AllowedBeaconBalanceRelativeDecreaseSet(_allowedBeaconBalanceRelativeDecrease);
 
-        LAST_COMPLETED_EPOCH_ID_POSITION.setStorageUint256(_lastCompletedEpochId);
-        // set expected epoch to the first epoch for the next frame
+        // // set expected epoch to the first epoch for the next frame
         BeaconSpec memory beaconSpec = _getBeaconSpec();
-        uint256 expectedEpoch = _getFrameFirstEpochId(_lastCompletedEpochId, beaconSpec) + beaconSpec.epochsPerFrame;
+        uint256 expectedEpoch = _getFrameFirstEpochId(0, beaconSpec) + beaconSpec.epochsPerFrame;
         EXPECTED_EPOCH_ID_POSITION.setStorageUint256(expectedEpoch);
         emit ExpectedEpochIdUpdated(expectedEpoch);
 
         // Initializations for v2 --> v3
         _initialize_v3();
 
-        // Need this despite contract version check as Aragon requires it to handle auth() modificators properly
+        // Need this despite contract version check because Aragon requires it to handle auth() modificators properly
         initialized();
     }
 

--- a/contracts/0.4.24/oracle/LidoOracle.sol
+++ b/contracts/0.4.24/oracle/LidoOracle.sol
@@ -338,8 +338,8 @@ contract LidoOracle is ILidoOracle, AragonApp {
      * @param _slotsPerEpoch Number of slots per epoch
      * @param _secondsPerSlot Number of seconds per slot
      * @param _genesisTime Genesis time
-     * @param _allowedBeaconBalanceAnnualRelativeIncrease
-     * @param _allowedBeaconBalanceRelativeDecrease 
+     * @param _allowedBeaconBalanceAnnualRelativeIncrease Allowed beacon balance annual relative increase (e.g. 1000 means 10% yearly increase)
+     * @param _allowedBeaconBalanceRelativeDecrease Allowed beacon balance moment descreat (e.g. 500 means 5% moment decrease)
      */
     function initialize(
         address _lido,
@@ -379,17 +379,17 @@ contract LidoOracle is ILidoOracle, AragonApp {
             .setStorageUint256(_allowedBeaconBalanceRelativeDecrease);
         emit AllowedBeaconBalanceRelativeDecreaseSet(_allowedBeaconBalanceRelativeDecrease);
 
-        // set last completed epoch as V1's contract last reported epoch, in the vast majority of
-        // cases this is true, in others the error is within a frame
-        // TODO: restore value of V1_LAST_REPORTED_EPOCH_ID_POSITION
-        uint256 lastReportedEpoch = V1_LAST_REPORTED_EPOCH_ID_POSITION.getStorageUint256();
-        LAST_COMPLETED_EPOCH_ID_POSITION.setStorageUint256(lastReportedEpoch);
+        // // set last completed epoch as V1's contract last reported epoch, in the vast majority of
+        // // cases this is true, in others the error is within a frame
+        // // TODO: restore value of V1_LAST_REPORTED_EPOCH_ID_POSITION
+        // uint256 lastReportedEpoch = V1_LAST_REPORTED_EPOCH_ID_POSITION.getStorageUint256();
+        // LAST_COMPLETED_EPOCH_ID_POSITION.setStorageUint256(lastReportedEpoch);
 
-        // set expected epoch to the first epoch for the next frame
-        BeaconSpec memory beaconSpec = _getBeaconSpec();
-        uint256 expectedEpoch = _getFrameFirstEpochId(lastReportedEpoch, beaconSpec) + beaconSpec.epochsPerFrame;
-        EXPECTED_EPOCH_ID_POSITION.setStorageUint256(expectedEpoch);
-        emit ExpectedEpochIdUpdated(expectedEpoch);
+        // // set expected epoch to the first epoch for the next frame
+        // BeaconSpec memory beaconSpec = _getBeaconSpec();
+        // uint256 expectedEpoch = _getFrameFirstEpochId(lastReportedEpoch, beaconSpec) + beaconSpec.epochsPerFrame;
+        // EXPECTED_EPOCH_ID_POSITION.setStorageUint256(expectedEpoch);
+        // emit ExpectedEpochIdUpdated(expectedEpoch);
 
 
         // Initializations for v2 --> v3

--- a/contracts/0.4.24/oracle/LidoOracle.sol
+++ b/contracts/0.4.24/oracle/LidoOracle.sol
@@ -73,7 +73,8 @@ contract LidoOracle is ILidoOracle, AragonApp {
     bytes32 internal constant BEACON_SPEC_POSITION =
         0x805e82d53a51be3dfde7cfed901f1f96f5dad18e874708b082adb8841e8ca909; // keccak256("lido.LidoOracle.beaconSpec")
 
-    /// Version of the initialized contract data, v1 is 0
+    /// Version of the initialized contract data
+    /// Verstion at state right after deployment when no initializer is invoked yet is 0
     bytes32 internal constant CONTRACT_VERSION_POSITION =
         0x75be19a3f314d89bd1f84d30a6c84e2f1cd7afc7b6ca21876564c265113bb7e4; // keccak256("lido.LidoOracle.contractVersion")
 
@@ -112,7 +113,8 @@ contract LidoOracle is ILidoOracle, AragonApp {
     bytes32 internal constant ALLOWED_BEACON_BALANCE_RELATIVE_DECREASE_POSITION =
         0x92ba7776ed6c5d13cf023555a94e70b823a4aebd56ed522a77345ff5cd8a9109; // keccak256("lido.LidoOracle.allowedBeaconBalanceDecrease")
 
-    /// This variable is from v1: the last reported epoch, used only in the initializer
+    /// This is a dead variable: it was used only in v1 and in upgrade v1 --> v2
+    /// Just keep in mind that storage at this position is occupied but with no actual usage
     bytes32 internal constant V1_LAST_REPORTED_EPOCH_ID_POSITION =
         0xfe0250ed0c5d8af6526c6d133fccb8e5a55dd6b1aa6696ed0c327f8e517b5a94; // keccak256("lido.LidoOracle.lastReportedEpochId")
 
@@ -328,22 +330,46 @@ contract LidoOracle is ILidoOracle, AragonApp {
         preTotalPooledEther = PRE_COMPLETED_TOTAL_POOLED_ETHER_POSITION.getStorageUint256();
         timeElapsed = TIME_ELAPSED_POSITION.getStorageUint256();
     }
-
     /**
-     * @notice Initialize the contract v2 data, with sanity check bounds
-     * (`_allowedBeaconBalanceAnnualRelativeIncrease`, `_allowedBeaconBalanceRelativeDecrease`)
-     * @dev Original initialize function removed from v2 because it is invoked only once
+     * @notice Initialize the contract (version 3 for now) from scratch
+     * @dev TODO: Add link to the related LIP
+     * @param _lido Address of Lido contract
+     * @param _epochsPerFrame Number of epochs per frame
+     * @param _slotsPerEpoch Number of slots per epoch
+     * @param _secondsPerSlot Number of seconds per slot
+     * @param _genesisTime Genesis time
+     * @param _allowedBeaconBalanceAnnualRelativeIncrease
+     * @param _allowedBeaconBalanceRelativeDecrease 
      */
-    function initialize_v2(
+    function initialize(
+        address _lido,
+        uint64 _epochsPerFrame,
+        uint64 _slotsPerEpoch,
+        uint64 _secondsPerSlot,
+        uint64 _genesisTime,
         uint256 _allowedBeaconBalanceAnnualRelativeIncrease,
         uint256 _allowedBeaconBalanceRelativeDecrease
     )
-        external
     {
-        require(CONTRACT_VERSION_POSITION.getStorageUint256() == 0, "ALREADY_INITIALIZED");
-        CONTRACT_VERSION_POSITION.setStorageUint256(1);
-        emit ContractVersionSet(1);
+        assert(1 == ((1 << (MAX_MEMBERS - 1)) >> (MAX_MEMBERS - 1)));  // static assert
 
+        // Initializations for v0 --> v1
+        require(CONTRACT_VERSION_POSITION.getStorageUint256() == 0, "ALREADY_INITIALIZED");
+
+        _setBeaconSpec(
+            _epochsPerFrame,
+            _slotsPerEpoch,
+            _secondsPerSlot,
+            _genesisTime
+        );
+
+        LIDO_POSITION.setStorageAddress(_lido);
+
+        QUORUM_POSITION.setStorageUint256(1);
+        emit QuorumChanged(1);
+
+
+        // Initializations for v1 --> v2
         ALLOWED_BEACON_BALANCE_ANNUAL_RELATIVE_INCREASE_POSITION
             .setStorageUint256(_allowedBeaconBalanceAnnualRelativeIncrease);
         emit AllowedBeaconBalanceAnnualRelativeIncreaseSet(_allowedBeaconBalanceAnnualRelativeIncrease);
@@ -354,6 +380,7 @@ contract LidoOracle is ILidoOracle, AragonApp {
 
         // set last completed epoch as V1's contract last reported epoch, in the vast majority of
         // cases this is true, in others the error is within a frame
+        // TODO: restore value of V1_LAST_REPORTED_EPOCH_ID_POSITION
         uint256 lastReportedEpoch = V1_LAST_REPORTED_EPOCH_ID_POSITION.getStorageUint256();
         LAST_COMPLETED_EPOCH_ID_POSITION.setStorageUint256(lastReportedEpoch);
 
@@ -362,6 +389,22 @@ contract LidoOracle is ILidoOracle, AragonApp {
         uint256 expectedEpoch = _getFrameFirstEpochId(lastReportedEpoch, beaconSpec) + beaconSpec.epochsPerFrame;
         EXPECTED_EPOCH_ID_POSITION.setStorageUint256(expectedEpoch);
         emit ExpectedEpochIdUpdated(expectedEpoch);
+
+
+        // Initializations for v2 --> v3
+        initialize_v3();
+    }
+
+    /**
+     * @notice A dummy incremental v2 --> v3 initialize function. Just corrects version number
+     * @dev This function is introduced just for the sake of clarity and correspondence between number
+     * of version in initialize function name and number is CONTRACT_VERSION_POSITION.
+     * NB, that thus version 2 is skipped 
+     */
+    function initialize_v3() {
+        require(CONTRACT_VERSION_POSITION.getStorageUint256() == 1, "ALREADY_INITIALIZED");
+        CONTRACT_VERSION_POSITION.setStorageUint256(3);
+        emit ContractVersionSet(3);
     }
 
     /**

--- a/contracts/0.4.24/oracle/LidoOracle.sol
+++ b/contracts/0.4.24/oracle/LidoOracle.sol
@@ -350,6 +350,7 @@ contract LidoOracle is ILidoOracle, AragonApp {
         uint256 _allowedBeaconBalanceAnnualRelativeIncrease,
         uint256 _allowedBeaconBalanceRelativeDecrease
     )
+        external
     {
         assert(1 == ((1 << (MAX_MEMBERS - 1)) >> (MAX_MEMBERS - 1)));  // static assert
 
@@ -392,17 +393,27 @@ contract LidoOracle is ILidoOracle, AragonApp {
 
 
         // Initializations for v2 --> v3
-        initialize_v3();
+        _initialize_v3();
+    }
+
+
+    /**
+     * @notice A function to finalize upgrade to v3 (from v1). Can be called only once
+     * @dev For more details see _initialize_v3()
+     */
+    function finalizeUpgrade_v3() external {
+        require(CONTRACT_VERSION_POSITION.getStorageUint256() == 1, "WRONG_BASE_VERSION");
+
+        _initialize_v3();
     }
 
     /**
-     * @notice A dummy incremental v2 --> v3 initialize function. Just corrects version number
+     * @notice A dummy incremental v1/v2 --> v3 initialize function. Just corrects version number
      * @dev This function is introduced just for the sake of clarity and correspondence between number
      * of version in initialize function name and number is CONTRACT_VERSION_POSITION.
      * NB, that thus version 2 is skipped 
      */
-    function initialize_v3() {
-        require(CONTRACT_VERSION_POSITION.getStorageUint256() == 1, "ALREADY_INITIALIZED");
+    function _initialize_v3() {
         CONTRACT_VERSION_POSITION.setStorageUint256(3);
         emit ContractVersionSet(3);
     }

--- a/contracts/0.4.24/test_helpers/LidoOracleMock.sol
+++ b/contracts/0.4.24/test_helpers/LidoOracleMock.sol
@@ -13,29 +13,6 @@ import "../oracle/LidoOracle.sol";
 contract LidoOracleMock is LidoOracle {
     uint256 private time;
 
-    // Original initialize function from v1
-    function initialize(
-        address _lido,
-        uint64 _epochsPerFrame,
-        uint64 _slotsPerEpoch,
-        uint64 _secondsPerSlot,
-        uint64 _genesisTime
-    )
-        public onlyInit
-    {
-        assert(1 == ((1 << (MAX_MEMBERS - 1)) >> (MAX_MEMBERS - 1)));  // static assert
-        _setBeaconSpec(
-            _epochsPerFrame,
-            _slotsPerEpoch,
-            _secondsPerSlot,
-            _genesisTime
-        );
-        LIDO_POSITION.setStorageAddress(_lido);
-        QUORUM_POSITION.setStorageUint256(1);
-        emit QuorumChanged(1);
-        initialized();
-    }
-
     function setV1LastReportedEpochForTest(uint256 _epoch) public {
         V1_LAST_REPORTED_EPOCH_ID_POSITION.setStorageUint256(_epoch);
     }

--- a/deployed-goerli.json
+++ b/deployed-goerli.json
@@ -16,12 +16,12 @@
     "0x70B3284fD016a570146cE48fC54D7A81bCd94BBa"
   ],
   "daoTemplateDeployTx": "0xda8746bca23c7a4f7c58e1a3370cb1ffa1e250ace90fd4684dbb1842ee6ac921",
-  "lidoBaseDeployTx": "0x4553e47f6030b9b28a17e92b0e7cc9ac64964e48e3fe2c2077aec486b44508b1",
+  "lidoBaseDeployTx": "0xedff0d82dd32fdafa30a62388898e35b8c98759c15aa92ab1ba87b779d86c0bb",
   "oracleBaseDeployTx": "0x4ff91791cc0f969cf9fe0cc9a6241593d26b20ee27f785a2eb002258e25f4e43",
   "nodeOperatorsRegistryBaseDeployTx": "0x25cf4db41a4159e94826fd0495bafe02e4a015a9bcf0ffbc0e684a5cafe6eefc",
   "daoTemplateAddress": "0x9A4a36B5fe517f98BD6529d4317B0b723F600AaD",
   "app:lido": {
-    "baseAddress": "0x5D3891E3015AED193eC4502D98524c4a94CfA6B5",
+    "baseAddress": "0x25C29642Aa0263B8Bf0A621a264Be6b6238B90E6",
     "ipfsCid": "QmbmPW5r9HMdyUARNJjjE7MNqBUGrXashwoWvqRZhc1t5b",
     "contentURI": "0x697066733a516d626d5057357239484d64795541524e4a6a6a45374d4e714255477258617368776f577671525a686331743562",
     "name": "lido",
@@ -139,16 +139,16 @@
     "minDepositBlockDistance": 14,
     "pauseIntentValidityPeriodBlocks": 10,
     "guardians": [
-      "0x3dc4cf780f2599b528f37dedb34449fb65ef7d4a",
-      "0x401fd888b5e41113b7c0c47725a742bbc3a083ef",
-      "0x3db460f33838fdc91e804d7fce2adf9e61e9d654",
-      "0x96fd3d127abd0d77724d49b7bddecdc89f684bb6",
-      "0xda1a296f9df18d04e0aefcff658b80b3ef824ec9",
-      "0xc34d33b95d7d6df2255d6051ddb12f8bd7aef64c",
-      "0xad5eecc863d88d5d848b89aa8517388a3ee432c8",
-      "0x6c83f70ed019fdcafe6c6f78cb33ce15943e4cb9",
-      "0x43464fe06c18848a2e2e913194d64c1970f4326a",
-      "0xf060ab3d5dcfdc6a0dfd5ca0645ac569b8f105ca",
+      "0x3dc4cf780f2599b528f37dedb34449fb65ef7d4a", 
+      "0x401fd888b5e41113b7c0c47725a742bbc3a083ef", 
+      "0x3db460f33838fdc91e804d7fce2adf9e61e9d654", 
+      "0x96fd3d127abd0d77724d49b7bddecdc89f684bb6", 
+      "0xda1a296f9df18d04e0aefcff658b80b3ef824ec9", 
+      "0xc34d33b95d7d6df2255d6051ddb12f8bd7aef64c", 
+      "0xad5eecc863d88d5d848b89aa8517388a3ee432c8", 
+      "0x6c83f70ed019fdcafe6c6f78cb33ce15943e4cb9", 
+      "0x43464fe06c18848a2e2e913194d64c1970f4326a", 
+      "0xf060ab3d5dcfdc6a0dfd5ca0645ac569b8f105ca", 
       "0x79a132be0c25ced09e745629d47cf05e531bb2bb"
     ],
     "quorum": 1
@@ -163,7 +163,5 @@
     10
   ],
   "depositorDeployTx": "0x2811fab2d10abba764b672eb75f727e89a02f721af4e7fd1d153bad0b3c50d3b",
-  "depositorAddress": "0xEd23AD3EA5Fb9d10e7371Caef1b141AD1C23A80c",
-  "mevTxFeeVaultDeployTx": "0xa93e29b3fc45eef335fcbe84c3587e93313281e2ff31a3df091400079a6b564c",
-  "mevTxFeeVaultAddress": "0x44D92F61E2236A7d0e9879aB87CF34622E85124e"
+  "depositorAddress": "0xEd23AD3EA5Fb9d10e7371Caef1b141AD1C23A80c"
 }

--- a/deployed-goerli.json
+++ b/deployed-goerli.json
@@ -16,12 +16,12 @@
     "0x70B3284fD016a570146cE48fC54D7A81bCd94BBa"
   ],
   "daoTemplateDeployTx": "0xda8746bca23c7a4f7c58e1a3370cb1ffa1e250ace90fd4684dbb1842ee6ac921",
-  "lidoBaseDeployTx": "0xedff0d82dd32fdafa30a62388898e35b8c98759c15aa92ab1ba87b779d86c0bb",
+  "lidoBaseDeployTx": "0x4553e47f6030b9b28a17e92b0e7cc9ac64964e48e3fe2c2077aec486b44508b1",
   "oracleBaseDeployTx": "0x4ff91791cc0f969cf9fe0cc9a6241593d26b20ee27f785a2eb002258e25f4e43",
   "nodeOperatorsRegistryBaseDeployTx": "0x25cf4db41a4159e94826fd0495bafe02e4a015a9bcf0ffbc0e684a5cafe6eefc",
   "daoTemplateAddress": "0x9A4a36B5fe517f98BD6529d4317B0b723F600AaD",
   "app:lido": {
-    "baseAddress": "0x25C29642Aa0263B8Bf0A621a264Be6b6238B90E6",
+    "baseAddress": "0x5D3891E3015AED193eC4502D98524c4a94CfA6B5",
     "ipfsCid": "QmbmPW5r9HMdyUARNJjjE7MNqBUGrXashwoWvqRZhc1t5b",
     "contentURI": "0x697066733a516d626d5057357239484d64795541524e4a6a6a45374d4e714255477258617368776f577671525a686331743562",
     "name": "lido",
@@ -139,16 +139,16 @@
     "minDepositBlockDistance": 14,
     "pauseIntentValidityPeriodBlocks": 10,
     "guardians": [
-      "0x3dc4cf780f2599b528f37dedb34449fb65ef7d4a", 
-      "0x401fd888b5e41113b7c0c47725a742bbc3a083ef", 
-      "0x3db460f33838fdc91e804d7fce2adf9e61e9d654", 
-      "0x96fd3d127abd0d77724d49b7bddecdc89f684bb6", 
-      "0xda1a296f9df18d04e0aefcff658b80b3ef824ec9", 
-      "0xc34d33b95d7d6df2255d6051ddb12f8bd7aef64c", 
-      "0xad5eecc863d88d5d848b89aa8517388a3ee432c8", 
-      "0x6c83f70ed019fdcafe6c6f78cb33ce15943e4cb9", 
-      "0x43464fe06c18848a2e2e913194d64c1970f4326a", 
-      "0xf060ab3d5dcfdc6a0dfd5ca0645ac569b8f105ca", 
+      "0x3dc4cf780f2599b528f37dedb34449fb65ef7d4a",
+      "0x401fd888b5e41113b7c0c47725a742bbc3a083ef",
+      "0x3db460f33838fdc91e804d7fce2adf9e61e9d654",
+      "0x96fd3d127abd0d77724d49b7bddecdc89f684bb6",
+      "0xda1a296f9df18d04e0aefcff658b80b3ef824ec9",
+      "0xc34d33b95d7d6df2255d6051ddb12f8bd7aef64c",
+      "0xad5eecc863d88d5d848b89aa8517388a3ee432c8",
+      "0x6c83f70ed019fdcafe6c6f78cb33ce15943e4cb9",
+      "0x43464fe06c18848a2e2e913194d64c1970f4326a",
+      "0xf060ab3d5dcfdc6a0dfd5ca0645ac569b8f105ca",
       "0x79a132be0c25ced09e745629d47cf05e531bb2bb"
     ],
     "quorum": 1
@@ -163,5 +163,7 @@
     10
   ],
   "depositorDeployTx": "0x2811fab2d10abba764b672eb75f727e89a02f721af4e7fd1d153bad0b3c50d3b",
-  "depositorAddress": "0xEd23AD3EA5Fb9d10e7371Caef1b141AD1C23A80c"
+  "depositorAddress": "0xEd23AD3EA5Fb9d10e7371Caef1b141AD1C23A80c",
+  "mevTxFeeVaultDeployTx": "0xa93e29b3fc45eef335fcbe84c3587e93313281e2ff31a3df091400079a6b564c",
+  "mevTxFeeVaultAddress": "0x44D92F61E2236A7d0e9879aB87CF34622E85124e"
 }

--- a/test/0.4.24/lidooracle.test.js
+++ b/test/0.4.24/lidooracle.test.js
@@ -46,8 +46,9 @@ contract('LidoOracle', ([appManager, voting, user1, user2, user3, user4, user5, 
 
     // Initialize the app's proxy.
     await app.setTime(GENESIS_TIME)
-    await app.initialize(appLido.address, 1, 32, 12, GENESIS_TIME)
-    await app.initialize_v2(1000, 500) // initialize the second version: 10% yearly increase, 5% moment decrease
+
+    // 1000 and 500 stand for 10% yearly increase, 5% moment decrease
+    await app.initialize(appLido.address, 1, 32, 12, GENESIS_TIME, 1000, 500)
   })
 
   it('beaconSpec is correct', async () => {

--- a/test/0.4.24/lidooracle.test.js
+++ b/test/0.4.24/lidooracle.test.js
@@ -48,7 +48,7 @@ contract('LidoOracle', ([appManager, voting, user1, user2, user3, user4, user5, 
     await app.setTime(GENESIS_TIME)
 
     // 1000 and 500 stand for 10% yearly increase, 5% moment decrease
-    await app.initialize(appLido.address, 1, 32, 12, GENESIS_TIME, 1000, 500)
+    await app.initialize(appLido.address, 1, 32, 12, GENESIS_TIME, 1000, 500, 0)
   })
 
   it('beaconSpec is correct', async () => {

--- a/test/0.4.24/lidooracle.test.js
+++ b/test/0.4.24/lidooracle.test.js
@@ -48,7 +48,7 @@ contract('LidoOracle', ([appManager, voting, user1, user2, user3, user4, user5, 
     await app.setTime(GENESIS_TIME)
 
     // 1000 and 500 stand for 10% yearly increase, 5% moment decrease
-    await app.initialize(appLido.address, 1, 32, 12, GENESIS_TIME, 1000, 500, 0)
+    await app.initialize(appLido.address, 1, 32, 12, GENESIS_TIME, 1000, 500)
   })
 
   it('beaconSpec is correct', async () => {

--- a/test/scenario/changing_oracles_during_epoch.js
+++ b/test/scenario/changing_oracles_during_epoch.js
@@ -35,10 +35,9 @@ contract('LidoOracle', ([appManager, voting, malicious1, malicious2, user1, user
 
     // Initialize the app's proxy.
     await app.setTime(GENESIS_TIME + 225 * EPOCH_LENGTH)
-    await app.initialize(appLido.address, 225, 32, 12, GENESIS_TIME)
+    await app.initialize(appLido.address, 225, 32, 12, GENESIS_TIME, 1000, 500)
 
     await app.setV1LastReportedEpochForTest(123) // pretend we had epoch 123 completed in v1
-    await app.initialize_v2(1000, 500) // initialize the second version: 10% yearly increase, 5% moment decrease
 
     // Initialize the oracle time, quorum and basic oracles
     await app.setQuorum(4, { from: voting })

--- a/test/scenario/changing_oracles_during_epoch.js
+++ b/test/scenario/changing_oracles_during_epoch.js
@@ -35,9 +35,7 @@ contract('LidoOracle', ([appManager, voting, malicious1, malicious2, user1, user
 
     // Initialize the app's proxy.
     await app.setTime(GENESIS_TIME + 225 * EPOCH_LENGTH)
-    await app.initialize(appLido.address, 225, 32, 12, GENESIS_TIME, 1000, 500)
-
-    await app.setV1LastReportedEpochForTest(123) // pretend we had epoch 123 completed in v1
+    await app.initialize(appLido.address, 225, 32, 12, GENESIS_TIME, 1000, 500, 123) // pretend we had epoch 123 completed previously
 
     // Initialize the oracle time, quorum and basic oracles
     await app.setQuorum(4, { from: voting })

--- a/test/scenario/changing_oracles_during_epoch.js
+++ b/test/scenario/changing_oracles_during_epoch.js
@@ -35,7 +35,7 @@ contract('LidoOracle', ([appManager, voting, malicious1, malicious2, user1, user
 
     // Initialize the app's proxy.
     await app.setTime(GENESIS_TIME + 225 * EPOCH_LENGTH)
-    await app.initialize(appLido.address, 225, 32, 12, GENESIS_TIME, 1000, 500, 123) // pretend we had epoch 123 completed previously
+    await app.initialize(appLido.address, 225, 32, 12, GENESIS_TIME, 1000, 500)
 
     // Initialize the oracle time, quorum and basic oracles
     await app.setQuorum(4, { from: voting })


### PR DESCRIPTION
- restore initialize() function which performs up-to-date initialization from scratch
- keep the latest increment initialize function: namely dummy upgrade from v1 to v3 to correct version number
- still a few TODOs left