### PR TITLE
Deploy scripts for the LIP-6 and LIP-7 contracts

### DIFF
--- a/deployed-goerli.json
+++ b/deployed-goerli.json
@@ -19,6 +19,8 @@
   "lidoBaseDeployTx": "0xedff0d82dd32fdafa30a62388898e35b8c98759c15aa92ab1ba87b779d86c0bb",
   "oracleBaseDeployTx": "0x4ff91791cc0f969cf9fe0cc9a6241593d26b20ee27f785a2eb002258e25f4e43",
   "nodeOperatorsRegistryBaseDeployTx": "0x25cf4db41a4159e94826fd0495bafe02e4a015a9bcf0ffbc0e684a5cafe6eefc",
+  "compositePostRebaseBeaconReceiverDeployTx": "0xf0f2d207ac3693abb8aa58e885aeff12371bb033d64376a409a8dd43d28d85ea",
+  "selfOwnedStETHBurnerDeployTx": "0xa6267ebc56579f0c9e3f3b55908b851db971a83d5f97d4d2df9984396ae03b2f",
   "daoTemplateAddress": "0x9A4a36B5fe517f98BD6529d4317B0b723F600AaD",
   "app:lido": {
     "baseAddress": "0x25C29642Aa0263B8Bf0A621a264Be6b6238B90E6",
@@ -139,16 +141,16 @@
     "minDepositBlockDistance": 14,
     "pauseIntentValidityPeriodBlocks": 10,
     "guardians": [
-      "0x3dc4cf780f2599b528f37dedb34449fb65ef7d4a", 
-      "0x401fd888b5e41113b7c0c47725a742bbc3a083ef", 
-      "0x3db460f33838fdc91e804d7fce2adf9e61e9d654", 
-      "0x96fd3d127abd0d77724d49b7bddecdc89f684bb6", 
-      "0xda1a296f9df18d04e0aefcff658b80b3ef824ec9", 
-      "0xc34d33b95d7d6df2255d6051ddb12f8bd7aef64c", 
-      "0xad5eecc863d88d5d848b89aa8517388a3ee432c8", 
-      "0x6c83f70ed019fdcafe6c6f78cb33ce15943e4cb9", 
-      "0x43464fe06c18848a2e2e913194d64c1970f4326a", 
-      "0xf060ab3d5dcfdc6a0dfd5ca0645ac569b8f105ca", 
+      "0x3dc4cf780f2599b528f37dedb34449fb65ef7d4a",
+      "0x401fd888b5e41113b7c0c47725a742bbc3a083ef",
+      "0x3db460f33838fdc91e804d7fce2adf9e61e9d654",
+      "0x96fd3d127abd0d77724d49b7bddecdc89f684bb6",
+      "0xda1a296f9df18d04e0aefcff658b80b3ef824ec9",
+      "0xc34d33b95d7d6df2255d6051ddb12f8bd7aef64c",
+      "0xad5eecc863d88d5d848b89aa8517388a3ee432c8",
+      "0x6c83f70ed019fdcafe6c6f78cb33ce15943e4cb9",
+      "0x43464fe06c18848a2e2e913194d64c1970f4326a",
+      "0xf060ab3d5dcfdc6a0dfd5ca0645ac569b8f105ca",
       "0x79a132be0c25ced09e745629d47cf05e531bb2bb"
     ],
     "quorum": 1
@@ -163,5 +165,24 @@
     10
   ],
   "depositorDeployTx": "0x2811fab2d10abba764b672eb75f727e89a02f721af4e7fd1d153bad0b3c50d3b",
-  "depositorAddress": "0xEd23AD3EA5Fb9d10e7371Caef1b141AD1C23A80c"
+  "depositorAddress": "0xEd23AD3EA5Fb9d10e7371Caef1b141AD1C23A80c",
+  "compositePostRebaseBeaconReceiverConstructorArgs": [
+    "0xbc0B67b4553f4CF52a913DE9A6eD0057E2E758Db",
+    "0x24d8451BC07e7aF4Ba94F69aCDD9ad3c6579D9FB"
+  ],
+  "compositePostRebaseBeaconReceiverAddress": "0x1D2219E0A1e2F09309643fD8a69Ca0EF7093B739",
+  "selfOwnedStETHBurnerParams": {
+    "totalCoverSharesBurnt": 0,
+    "totalNonCoverSharesBurnt": 0,
+    "maxBurnAmountPerRunBasisPoints": 4
+  },
+  "selfOwnedStETHBurnerConstructorArgs": [
+    "0x4333218072D5d7008546737786663c38B4D561A4",
+    "0x1643E812aE58766192Cf7D2Cf9567dF2C37e9B7F",
+    "0xbc0B67b4553f4CF52a913DE9A6eD0057E2E758Db",
+    0,
+    0,
+    4
+  ],
+  "selfOwnedStETHBurnerAddress": "0xf6a64DcB06Ef7eB1ee94aDfD7D10ACB44D9A9888"
 }

--- a/scripts/multisig/21-deploy-composite-post-rebase-beacon-receiver.js
+++ b/scripts/multisig/21-deploy-composite-post-rebase-beacon-receiver.js
@@ -1,0 +1,50 @@
+const runOrWrapScript = require('../helpers/run-or-wrap-script')
+const { log, logSplitter, logWideSplitter, yl, gr } = require('../helpers/log')
+const { saveDeployTx } = require('../helpers/deploy')
+const { readNetworkState, assertRequiredNetworkState, persistNetworkState } = require('../helpers/persisted-network-state')
+
+const { APP_NAMES } = require('./constants')
+
+const DEPLOYER = process.env.DEPLOYER || ''
+
+const REQUIRED_NET_STATE = [
+  'lidoApmEnsName',
+  'ensAddress',
+  'daoAddress',
+  `app:${APP_NAMES.ARAGON_VOTING}`,
+  `app:${APP_NAMES.ORACLE}`
+]
+
+async function upgradeApp({ web3, artifacts }) {
+  const appArtifact = 'CompositePostRebaseBeaconReceiver'
+  const netId = await web3.eth.net.getId()
+
+  logWideSplitter()
+  log(`Network ID:`, yl(netId))
+
+  const state = readNetworkState(network.name, netId)
+  assertRequiredNetworkState(state, REQUIRED_NET_STATE)
+  const votingAddress = state[`app:${APP_NAMES.ARAGON_VOTING}`].proxyAddress
+  const lidoOracleAddress = state[`app:${APP_NAMES.ORACLE}`].proxyAddress
+  log(`Using Voting address:`, yl(votingAddress))
+  log(`Using LidoOracle address:`, yl(lidoOracleAddress))
+  logSplitter()
+
+  const args = [ votingAddress, lidoOracleAddress ]
+
+  await saveDeployTx(appArtifact, `tx-21-deploy-composite-post-rebase-beacon-receiver.json`, {
+    arguments: args,
+    from: DEPLOYER || state.multisigAddress
+  })
+  persistNetworkState(network.name, netId, state, {
+    compositePostRebaseBeaconReceiverConstructorArgs: args
+  })
+
+  logSplitter()
+  log(gr(`Before continuing the deployment, please send all contract creation transactions`))
+  log(gr(`that you can find in the files listed above. You may use a multisig address`))
+  log(gr(`if it supports deploying new contract instances.`))
+  logSplitter()
+}
+
+module.exports = runOrWrapScript(upgradeApp, module)

--- a/scripts/multisig/22-obtain-composite-post-rebase-beacon-receiver.js
+++ b/scripts/multisig/22-obtain-composite-post-rebase-beacon-receiver.js
@@ -1,0 +1,57 @@
+const runOrWrapScript = require("../helpers/run-or-wrap-script");
+const { log, logWideSplitter, logHeader, yl } = require('../helpers/log')
+const { useOrGetDeployed } = require('../helpers/deploy')
+const { assert } = require('../helpers/assert')
+const { readNetworkState, persistNetworkState, assertRequiredNetworkState } = require('../helpers/persisted-network-state')
+
+const { APP_NAMES } = require('./constants');
+const { network } = require("hardhat");
+
+const APP = process.env.APP || ''
+const REQUIRED_NET_STATE = [
+  'compositePostRebaseBeaconReceiverDeployTx',
+  'lidoApmEnsName',
+  'ensAddress',
+  'daoAddress',
+  `app:${APP_NAMES.ARAGON_VOTING}`,
+  `app:${APP_NAMES.ORACLE}`
+]
+
+async function obtainInstance({ web3, artifacts, appName = APP }) {
+  // convert dash-ed appName to camel case-d
+  const appArtifact = 'CompositePostRebaseBeaconReceiver'
+  const netId = await web3.eth.net.getId()
+
+  logWideSplitter()
+  log(`Network ID:`, yl(netId))
+
+  const state = readNetworkState(network.name, netId)
+  assertRequiredNetworkState(state, REQUIRED_NET_STATE)
+
+  logHeader(`${appArtifact} app base`)
+  const compositePostRebaseBeaconReceiver = await useOrGetDeployed(
+    appArtifact,
+    null,
+    state.compositePostRebaseBeaconReceiverDeployTx
+  )
+  log(`Checking...`)
+  const votingAddress = state[`app:${APP_NAMES.ARAGON_VOTING}`].proxyAddress
+  const lidoOracleAddress = state[`app:${APP_NAMES.ORACLE}`].proxyAddress
+
+  await assertAddresses({
+    votingAddress,
+    lidoOracleAddress
+  }, compositePostRebaseBeaconReceiver, appArtifact)
+
+  persistNetworkState(network.name, netId, state, {
+    compositePostRebaseBeaconReceiverAddress: compositePostRebaseBeaconReceiver.address
+  })
+}
+
+async function assertAddresses({ votingAddress, lidoOracleAddress }, instance, desc) {
+  assert.addressEqual(await instance.VOTING(), votingAddress, `${desc}: wrong address`)
+  assert.addressEqual(await instance.ORACLE(), lidoOracleAddress, `${desc}: wrong address`)
+  log.success(`Lido addresses are correct`)
+}
+
+module.exports = runOrWrapScript(obtainInstance, module)

--- a/scripts/multisig/23-deploy-self-owned-steth-burner.js
+++ b/scripts/multisig/23-deploy-self-owned-steth-burner.js
@@ -1,0 +1,81 @@
+const runOrWrapScript = require('../helpers/run-or-wrap-script')
+const { log, logSplitter, logWideSplitter, yl, gr } = require('../helpers/log')
+const { saveDeployTx } = require('../helpers/deploy')
+const { readNetworkState, assertRequiredNetworkState, persistNetworkState }
+  = require('../helpers/persisted-network-state')
+
+const { APP_NAMES, APP_ARTIFACTS } = require('./constants')
+const { assert } = require('../helpers/assert')
+
+const DEPLOYER = process.env.DEPLOYER || ''
+
+const REQUIRED_NET_STATE = [
+  'lidoApmEnsName',
+  'ensAddress',
+  'daoAddress',
+  'compositePostRebaseBeaconReceiverAddress',
+  'selfOwnedStETHBurnerParams',
+  `app:${APP_NAMES.ARAGON_VOTING}`,
+  `app:${APP_NAMES.ORACLE}`,
+  `app:${APP_NAMES.ARAGON_AGENT}`
+]
+
+async function upgradeApp({ web3, artifacts }) {
+  const appArtifact = 'SelfOwnedStETHBurner'
+  const netId = await web3.eth.net.getId()
+
+  logWideSplitter()
+  log(`Network ID:`, yl(netId))
+
+  const state = readNetworkState(network.name, netId)
+  assertRequiredNetworkState(state, REQUIRED_NET_STATE)
+  const votingAddress = state[`app:${APP_NAMES.ARAGON_VOTING}`].proxyAddress
+  const lidoOracleAddress = state[`app:${APP_NAMES.ORACLE}`].proxyAddress
+  const lidoAddress = state[`app:${APP_NAMES.LIDO}`].proxyAddress
+  const treasuryAddress = state[`app:${APP_NAMES.ARAGON_AGENT}`].proxyAddress
+  log(`Using Treasury address:`, yl(treasuryAddress))
+  log(`Using Lido address:`, yl(lidoAddress))
+  log(`Using Voting address:`, yl(votingAddress))
+
+  logSplitter()
+
+  const {
+    totalCoverSharesBurnt,
+    totalNonCoverSharesBurnt,
+    maxBurnAmountPerRunBasisPoints
+  } = state.selfOwnedStETHBurnerParams
+
+  log(`Total cover shares burnt / init:`, yl(totalCoverSharesBurnt))
+  log(`Total non-cover shares burnt / init:`, yl(totalNonCoverSharesBurnt))
+  log(`Burn amount per run quota, basis points / init:`, yl(maxBurnAmountPerRunBasisPoints))
+
+  const lidoInstance = await artifacts.require(`${APP_ARTIFACTS.lido}`).at(lidoAddress)
+
+  assert.addressEqual(await lidoInstance.getOracle(), lidoOracleAddress, 'Lido: wrong oracle address')
+  assert.addressEqual(await lidoInstance.getInsuranceFund(), treasuryAddress, 'Lido: wrong treasury address')
+
+  const args = [
+    treasuryAddress,
+    lidoAddress,
+    votingAddress,
+    totalCoverSharesBurnt,
+    totalNonCoverSharesBurnt,
+    maxBurnAmountPerRunBasisPoints
+  ]
+
+  await saveDeployTx(appArtifact, `tx-23-deploy-self-owned-steth-burner.json`, {
+    arguments: args,
+    from: DEPLOYER || state.multisigAddress
+  })
+  persistNetworkState(network.name, netId, state, {
+    selfOwnedStETHBurnerConstructorArgs: args
+  })
+
+  logSplitter()
+  log(gr(`Before continuing the deployment, please send all contract creation transactions`))
+  log(gr(`that you can find in the files listed above. You may use a multisig address`))
+  log(gr(`if it supports deploying new contract instances.`))
+  logSplitter()
+}
+
+module.exports = runOrWrapScript(upgradeApp, module)

--- a/scripts/multisig/24-obtain-self-owned-steth-burner.js
+++ b/scripts/multisig/24-obtain-self-owned-steth-burner.js
@@ -1,0 +1,82 @@
+const runOrWrapScript = require('../helpers/run-or-wrap-script')
+const { log, logSplitter, logWideSplitter, logHeader, yl } = require('../helpers/log')
+const { useOrGetDeployed } = require('../helpers/deploy')
+const { assert } = require('../helpers/assert')
+const {
+  readNetworkState,
+  persistNetworkState,
+  assertRequiredNetworkState
+} = require('../helpers/persisted-network-state')
+
+const { APP_NAMES, APP_ARTIFACTS } = require('./constants')
+
+const APP = process.env.APP || ''
+const REQUIRED_NET_STATE = [
+  'selfOwnedStETHBurnerDeployTx',
+  'lidoApmEnsName',
+  'ensAddress',
+  'daoAddress',
+  'compositePostRebaseBeaconReceiverAddress',
+  'selfOwnedStETHBurnerParams',
+  `app:${APP_NAMES.ARAGON_VOTING}`,
+  `app:${APP_NAMES.ORACLE}`,
+  `app:${APP_NAMES.ARAGON_AGENT}`
+]
+
+async function obtainInstance({ web3, artifacts, appName = APP }) {
+  // convert dash-ed appName to camel case-d
+  const appArtifact = 'SelfOwnedStETHBurner'
+  const netId = await web3.eth.net.getId()
+
+  logWideSplitter()
+  log(`Network ID:`, yl(netId))
+
+  const state = readNetworkState(network.name, netId)
+  assertRequiredNetworkState(state, REQUIRED_NET_STATE)
+
+  logHeader(`${appArtifact} app base`)
+  const selfOwnedStETHBurner = await useOrGetDeployed(appArtifact, null, state.selfOwnedStETHBurnerDeployTx)
+  log(`Checking...`)
+  const lidoAddress = state[`app:${APP_NAMES.LIDO}`].proxyAddress
+  const votingAddress = state[`app:${APP_NAMES.ARAGON_VOTING}`].proxyAddress
+  const treasuryAddress = state[`app:${APP_NAMES.ARAGON_AGENT}`].proxyAddress
+
+  await assertParams(state.selfOwnedStETHBurnerParams, selfOwnedStETHBurner, appArtifact)
+  await assertAddresses({ lidoAddress, votingAddress, treasuryAddress }, selfOwnedStETHBurner, appArtifact)
+  persistNetworkState(network.name, netId, state, {
+    selfOwnedStETHBurnerAddress: selfOwnedStETHBurner.address
+  })
+}
+
+async function assertParams(
+  {
+    totalCoverSharesBurnt,
+    totalNonCoverSharesBurnt,
+    maxBurnAmountPerRunBasisPoints
+  },
+  instance, desc
+) {
+  assert.bnEqual(
+    await instance.getCoverSharesBurnt(),
+    totalCoverSharesBurnt,
+    `${desc}: wrong totalCoverSharesBurnt`
+  )
+  assert.bnEqual(
+    await instance.getNonCoverSharesBurnt(),
+    totalNonCoverSharesBurnt,
+    `${desc}: wrong totalNonCoverSharesBurnt`
+  )
+  assert.bnEqual(
+    await instance.getBurnAmountPerRunQuota(),
+    maxBurnAmountPerRunBasisPoints,
+    `${desc}: wrong burn amount per run quota`
+  )
+}
+
+async function assertAddresses({ treasuryAddress, lidoAddress, votingAddress }, instance, desc) {
+  assert.addressEqual(await instance.LIDO(), lidoAddress, `${desc}: wrong lido address`)
+  assert.addressEqual(await instance.TREASURY(), treasuryAddress, `${desc}: wrong treasury address`)
+  assert.addressEqual(await instance.VOTING(), votingAddress, `${desc}: wrong voting address`)
+}
+
+module.exports = runOrWrapScript(obtainInstance, module)

--- a/scripts/multisig/25-vote-self-owned-steth-burner.js
+++ b/scripts/multisig/25-vote-self-owned-steth-burner.js
@@ -1,0 +1,161 @@
+const { encodeCallScript } = require('@aragon/contract-helpers-test/src/aragon-os')
+
+const runOrWrapScript = require('../helpers/run-or-wrap-script')
+const { log, logSplitter, logWideSplitter, yl, gr } = require('../helpers/log')
+const { saveCallTxData } = require('../helpers/tx-data')
+const { readNetworkState, assertRequiredNetworkState } = require('../helpers/persisted-network-state')
+
+const { APP_NAMES, APP_ARTIFACTS } = require('./constants')
+
+const DEPLOYER = process.env.DEPLOYER || ''
+const REQUIRED_NET_STATE = [
+  'lidoApmEnsName',
+  'ensAddress',
+  'daoAddress',
+  'compositePostRebaseBeaconReceiverAddress',
+  'selfOwnedStETHBurnerAddress',
+  `app:${APP_NAMES.ARAGON_VOTING}`,
+  `app:${APP_NAMES.ORACLE}`,
+  `app:${APP_NAMES.LIDO}`,
+  `app:${APP_NAMES.ARAGON_TOKEN_MANAGER}`
+]
+
+const padWithoutPrefix = (hex, bytesLength) => {
+  const absentZeroes = bytesLength * 2 + 2 - hex.length
+  if (absentZeroes > 0) hex = '0'.repeat(absentZeroes) + hex.substr(2)
+  return hex
+}
+
+const composePermissionParam = (addr) => {
+  const argId = '0x00' // arg 0
+  const op = '01' // operation eq (Op.Eq == 1)
+  const value = padWithoutPrefix(addr, 240 / 8) // pad 160bit -> 240bit, remove '0x'
+  assert.equal(value.length, (240 / 8) * 2) // check the value length explicitly
+
+  const paramStr = `${argId}${op}${value}`
+  assert.equal(paramStr.length, (256 / 8) * 2 + 2)
+
+  return paramStr
+}
+
+async function setupCoverageMechanismImpl({ web3, artifacts }) {
+  const netId = await web3.eth.net.getId()
+
+  logWideSplitter()
+  log(`Network ID:`, yl(netId))
+
+  const state = readNetworkState(network.name, netId)
+  assertRequiredNetworkState(state, REQUIRED_NET_STATE)
+
+  logSplitter()
+
+  const voting = await artifacts.require('Voting')
+    .at(state[`app:${APP_NAMES.ARAGON_VOTING}`].proxyAddress)
+  const tokenManager = await artifacts.require('TokenManager')
+    .at(state[`app:${APP_NAMES.ARAGON_TOKEN_MANAGER}`].proxyAddress)
+  const kernel = await artifacts.require('Kernel')
+    .at(state.daoAddress)
+  const acl = await artifacts.require('ACL')
+    .at(await kernel.acl())
+  const compositePostRebaseBeaconReceiver = await artifacts.require('CompositePostRebaseBeaconReceiver')
+    .at(state.compositePostRebaseBeaconReceiverAddress)
+  const selfOwnedStETHBurner = await artifacts.require('SelfOwnedStETHBurner')
+    .at(state.selfOwnedStETHBurnerAddress)
+  const lidoOracle = await artifacts.require(`${APP_ARTIFACTS.oracle}`)
+    .at(state[`app:${APP_NAMES.ORACLE}`].proxyAddress)
+  const lido = await artifacts.require(`${APP_ARTIFACTS.lido}`)
+    .at(state[`app:${APP_NAMES.LIDO}`].proxyAddress)
+
+  log(`Voting address:`, yl(voting.address))
+  log(`TokenManager address:`, yl(tokenManager.address))
+  log(`Kernel address:`, yl(kernel.address))
+  log(`ACL address:`, yl(acl.address))
+  log(`CompositePostRebaseBeaconReceiver address`, yl(compositePostRebaseBeaconReceiver.address))
+  log(`SelfOwnedStETHBurner`, yl(selfOwnedStETHBurner.address))
+  log(`LidoOracle address:`, yl(lidoOracle.address))
+  log(`Lido address`, yl(lido.address))
+
+  log.splitter()
+
+  const wrapStETHBurnerIntoCompositeCallData = {
+    to: compositePostRebaseBeaconReceiver.address,
+    calldata: await compositePostRebaseBeaconReceiver.contract.methods
+      .addCallback(
+        selfOwnedStETHBurner.address
+      )
+      .encodeABI()
+  }
+
+  const setupCompositeAsReceiverCallData = {
+    to: lidoOracle.address,
+    calldata: await lidoOracle.contract.methods
+      .setBeaconReportReceiver(
+          compositePostRebaseBeaconReceiver.address
+      )
+      .encodeABI()
+  }
+
+  const burnRoleHash = await lido.BURN_ROLE()
+  log(`BURN_ROLE hash:`, yl(burnRoleHash))
+
+  const revokeBurnPermissionsFromVotingCallData = {
+    to: acl.address,
+    calldata: await acl.contract.methods
+      .revokePermission(
+        voting.address,
+        lido.address,
+        burnRoleHash
+      )
+      .encodeABI()
+  }
+
+  const permParam = composePermissionParam(selfOwnedStETHBurner.address)
+  log(`Permission param:`, yl(permParam))
+
+  const grantGranularBurnPermissionsToStETHBurner = {
+    to: acl.address,
+    calldata: await acl.contract.methods
+      .grantPermissionP(
+        selfOwnedStETHBurner.address,
+        lido.address,
+        burnRoleHash,
+        [permParam]
+      )
+      .encodeABI()
+  }
+
+  const encodedSetupCallData = encodeCallScript([
+    wrapStETHBurnerIntoCompositeCallData,
+    setupCompositeAsReceiverCallData,
+    revokeBurnPermissionsFromVotingCallData,
+    grantGranularBurnPermissionsToStETHBurner
+  ])
+
+  log(`encodedSetupCallData:`, yl(encodedSetupCallData))
+  const votingCallData = encodeCallScript([
+    {
+      to: voting.address,
+      calldata: await voting.contract.methods.forward(encodedSetupCallData).encodeABI()
+    }
+  ])
+
+  const txName = `tx-25-vote-self-owned-steth-burner.json`
+  const votingDesc = `
+    1) Wrap stETH burner into the composite receiver
+    2) Attach composite receiver to lido oracle as beacon report callback
+    3) Revoke 'BURN_ROLE' permissions from Voting
+    4) Grant 'BURN_ROLE' constrained permissions to stETH burner
+  `
+
+  await saveCallTxData(votingDesc, tokenManager, 'forward', txName, {
+      arguments: [votingCallData],
+      from: DEPLOYER || state.multisigAddress
+  })
+
+  log.splitter()
+  log(gr(`Before continuing the deployment, please send all transactions listed above.`))
+  log(gr(`You MUST complete it positively and execute before continuing with the deployment!`))
+  log.splitter()
+}
+
+module.exports = runOrWrapScript(setupCoverageMechanismImpl, module)


### PR DESCRIPTION
Add deploy scripts for the [`SelfOwnedStETHBurner`](https://github.com/lidofinance/lido-dao/blob/develop/contracts/0.8.9/SelfOwnedStETHBurner.sol) and [`CompositePostRebaseBeaconReceiver`](https://github.com/lidofinance/lido-dao/blob/develop/contracts/0.8.9/CompositePostRebaseBeaconReceiver.sol) contracts.

Context:  https://research.lido.fi/t/lip-6-in-protocol-coverage-proposal/1468

LIP-6: https://github.com/lidofinance/lido-improvement-proposals/blob/develop/LIPS/lip-6.md
LIP-7: https://github.com/lidofinance/lido-improvement-proposals/blob/develop/LIPS/lip-7.md