### PR TITLE
refactor: rename withdrawal limit points to withdrawal limit for consistency

### DIFF
--- a/contracts/0.4.24/Lido.sol
+++ b/contracts/0.4.24/Lido.sol
@@ -101,7 +101,7 @@ contract Lido is ILido, StETH, AragonApp {
     bytes32 internal constant BEACON_VALIDATORS_POSITION = keccak256("lido.Lido.beaconValidators");
 
     /// @dev percent in basis points of total pooled ether allowed to withdraw from LidoExecutionLayerRewardsVault per LidoOracle report
-    bytes32 internal constant EL_REWARDS_WITHDRAWAL_LIMIT_POINTS_POSITION = keccak256("lido.Lido.ELRewardsWithdrawalLimitPoints");
+    bytes32 internal constant EL_REWARDS_WITHDRAWAL_LIMIT_POSITION = keccak256("lido.Lido.ELRewardsWithdrawalLimit");
 
     /// @dev Just a counter of total amount of execution layer rewards received by Lido contract
     /// Not used in the logic
@@ -428,7 +428,7 @@ contract Lido is ILido, StETH, AragonApp {
     function setELRewardsWithdrawalLimit(uint16 _limitPoints) external {
         _auth(SET_EL_REWARDS_WITHDRAWAL_LIMIT_ROLE);
 
-        _setBPValue(EL_REWARDS_WITHDRAWAL_LIMIT_POINTS_POSITION, _limitPoints);
+        _setBPValue(EL_REWARDS_WITHDRAWAL_LIMIT_POSITION, _limitPoints);
         emit ELRewardsWithdrawalLimitSet(_limitPoints);
     }
 
@@ -481,7 +481,7 @@ contract Lido is ILido, StETH, AragonApp {
 
         if (executionLayerRewardsVaultAddress != address(0)) {
             executionLayerRewards = ILidoExecutionLayerRewardsVault(executionLayerRewardsVaultAddress).withdrawRewards(
-                (_getTotalPooledEther() * EL_REWARDS_WITHDRAWAL_LIMIT_POINTS_POSITION.getStorageUint256()) / TOTAL_BASIS_POINTS
+                (_getTotalPooledEther() * EL_REWARDS_WITHDRAWAL_LIMIT_POSITION.getStorageUint256()) / TOTAL_BASIS_POINTS
             );
 
             if (executionLayerRewards != 0) {
@@ -594,8 +594,8 @@ contract Lido is ILido, StETH, AragonApp {
     * @notice Get limit in basis points to amount of ETH to withdraw per LidoOracle report
     * @return uint256 limit in basis points to amount of ETH to withdraw per LidoOracle report
     */
-    function getELRewardsWithdrawalLimitPoints() external view returns (uint256) {
-        return EL_REWARDS_WITHDRAWAL_LIMIT_POINTS_POSITION.getStorageUint256();
+    function getELRewardsWithdrawalLimit() external view returns (uint256) {
+        return EL_REWARDS_WITHDRAWAL_LIMIT_POSITION.getStorageUint256();
     }
 
     /**

--- a/test/0.4.24/lido.test.js
+++ b/test/0.4.24/lido.test.js
@@ -270,7 +270,7 @@ contract('Lido', ([appManager, voting, user1, user2, user3, nobody, depositor]) 
   })
 
   it('Attempt to set invalid execution layer rewards withdrawal limit', async () => {
-    const initialValue = await app.getELRewardsWithdrawalLimitPoints()
+    const initialValue = await app.getELRewardsWithdrawalLimit()
 
     assertEvent(await app.setELRewardsWithdrawalLimit(1, { from: voting }), 'ELRewardsWithdrawalLimitSet', {
       expectedArgs: { limitPoints: 1 }

--- a/test/scenario/execution_layer_rewards_after_the_merge.js
+++ b/test/scenario/execution_layer_rewards_after_the_merge.js
@@ -764,7 +764,7 @@ contract('Lido: merge acceptance', (addresses) => {
     let lastBeaconBalance = toE18(85)
     await pool.setELRewardsWithdrawalLimit(getELRewardsWithdrawalLimitFromEpoch(epoch), { from: voting })
 
-    let elRewardsWithdrawalLimitPoints = toNum(await pool.getELRewardsWithdrawalLimitPoints())
+    let elRewardsWithdrawalLimitPoints = toNum(await pool.getELRewardsWithdrawalLimit())
     let elRewardsVaultBalance = toNum(await web3.eth.getBalance(elRewardsVault.address))
     let totalPooledEther = toNum(await pool.getTotalPooledEther())
     let bufferedEther = toNum(await pool.getBufferedEther())
@@ -776,7 +776,7 @@ contract('Lido: merge acceptance', (addresses) => {
     while (elRewardsVaultBalance > 0) {
       const elRewardsWithdrawalLimit = getELRewardsWithdrawalLimitFromEpoch(epoch)
       await pool.setELRewardsWithdrawalLimit(elRewardsWithdrawalLimit, { from: voting })
-      elRewardsWithdrawalLimitPoints = toNum(await pool.getELRewardsWithdrawalLimitPoints())
+      elRewardsWithdrawalLimitPoints = toNum(await pool.getELRewardsWithdrawalLimit())
 
       const maxELRewardsAmountPerWithdrawal = Math.floor(
         ((totalPooledEther + beaconBalanceInc) * elRewardsWithdrawalLimitPoints) / TOTAL_BASIS_POINTS


### PR DESCRIPTION
This PR renames `EL_REWARDS_WITHDRAWAL_LIMIT_POINTS_POSITION` to `EL_REWARDS_WITHDRAWAL_LIMIT_POSITION` and `getELRewardsWithdrawalLimitPoints` to `getELRewardsWithdrawalLimit` to be consistent with the respective setter `setELRewardsWithdrawalLimit`, as well as make appropriate changes to some of the tests.