### PR TITLE
Chore: fix `yarn.lock` for lido hash replication

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8362,6 +8362,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cids@npm:^0.8.0, cids@npm:~0.8.0":
+  version: 0.8.3
+  resolution: "cids@npm:0.8.3"
+  dependencies:
+    buffer: ^5.6.0
+    class-is: ^1.1.0
+    multibase: ^1.0.0
+    multicodec: ^1.0.1
+    multihashes: ^1.0.1
+  checksum: 11139e4c978eb97d24ec3e80642337b65deee574a98690ea0cdd0861c437c6c18af431d36f56dd433ece7ce6793c8bd6ab71b28630375c7598aed7a4931cc01c
+  languageName: node
+  linkType: hard
+
 "cids@npm:^1.0.0, cids@npm:^1.1.6":
   version: 1.1.9
   resolution: "cids@npm:1.1.9"
@@ -8383,19 +8396,6 @@ __metadata:
     multicodec: ~0.5.0
     multihashes: ~0.4.14
   checksum: d27fbf02d6572fe4d5352915cf17b1879fa37c0b9055e1edd09d98ef4ddf2d22003335b55e0e07d34c59495bce55476697da1d848142eb2af0c558bf0d1e79e4
-  languageName: node
-  linkType: hard
-
-"cids@npm:~0.8.0":
-  version: 0.8.3
-  resolution: "cids@npm:0.8.3"
-  dependencies:
-    buffer: ^5.6.0
-    class-is: ^1.1.0
-    multibase: ^1.0.0
-    multicodec: ^1.0.1
-    multihashes: ^1.0.1
-  checksum: 11139e4c978eb97d24ec3e80642337b65deee574a98690ea0cdd0861c437c6c18af431d36f56dd433ece7ce6793c8bd6ab71b28630375c7598aed7a4931cc01c
   languageName: node
   linkType: hard
 
@@ -15430,7 +15430,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ipfs-block@npm:~0.8.0, ipfs-block@npm:~0.8.1":
+"ipfs-block@npm:^0.8.1, ipfs-block@npm:~0.8.0, ipfs-block@npm:~0.8.1":
   version: 0.8.1
   resolution: "ipfs-block@npm:0.8.1"
   dependencies:
@@ -15461,6 +15461,17 @@ __metadata:
     multiaddr: ^10.0.0
     multiformats: ^9.4.13
   checksum: 8dd924944e40c1eb5f6016e1e0e3f5a7dccc4828c3028ef1dc35a556d948d43122b7620d51a2519c16cf01b0e402929fd1957ca7c8258b5354eca3104fc28d15
+  languageName: node
+  linkType: hard
+
+"ipfs-core-utils@npm:^0.0.1":
+  version: 0.0.1
+  resolution: "ipfs-core-utils@npm:0.0.1"
+  dependencies:
+    buffer: ^5.4.2
+    err-code: ^2.0.0
+    ipfs-utils: ^1.0.0
+  checksum: c47f70156c1853f745de9f7e965176fe45dd39de3c75fc4d900acdb1a35115f8efcbc4b0594df9b3a2967e5ecd625b375051b439f4c413a664eb905a8d5c1f91
   languageName: node
   linkType: hard
 
@@ -15516,6 +15527,41 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ipfs-http-client@npm:43.0.0":
+  version: 43.0.0
+  resolution: "ipfs-http-client@npm:43.0.0"
+  dependencies:
+    abort-controller: ^3.0.0
+    bignumber.js: ^9.0.0
+    bs58: ^4.0.1
+    buffer: ^5.4.2
+    cids: ^0.8.0
+    debug: ^4.1.0
+    form-data: ^3.0.0
+    ipfs-block: ^0.8.1
+    ipfs-core-utils: ^0.0.1
+    ipfs-utils: ^1.0.0
+    ipld-dag-cbor: ^0.15.1
+    ipld-dag-pb: ^0.18.3
+    ipld-raw: ^4.0.1
+    iso-url: ^0.4.7
+    it-tar: ^1.2.1
+    it-to-buffer: ^1.0.0
+    it-to-stream: ^0.1.1
+    merge-options: ^2.0.0
+    multiaddr: ^7.2.1
+    multiaddr-to-uri: ^5.1.0
+    multibase: ^0.7.0
+    multicodec: ^1.0.0
+    multihashes: ^0.4.14
+    nanoid: ^3.0.2
+    node-fetch: ^2.6.0
+    parse-duration: ^0.1.2
+    stream-to-it: ^0.2.0
+  checksum: 2a80805870cc35c2883bd26d31a9614660e96c615211f27d2bd689c11f5c355030ed6136283adcc66ae7a111579d797388ea5217b3fc158b615a0893f10462ad
+  languageName: node
+  linkType: hard
+
 "ipfs-http-client@npm:^41.0.1":
   version: 41.0.1
   resolution: "ipfs-http-client@npm:41.0.1"
@@ -15556,39 +15602,6 @@ __metadata:
     peer-info: ~0.15.1
     promise-nodeify: ^3.0.1
   checksum: 4347ec686b961bb65b55e2b54086c636acf60e9edc40de4200756deea010ea58ed2a6a7b87863586722c1a69e9d064d6d4da5db24f2cf7ffcdfeb8f9952d4010
-  languageName: node
-  linkType: hard
-
-"ipfs-http-client@npm:^42.0.0":
-  version: 42.0.0
-  resolution: "ipfs-http-client@npm:42.0.0"
-  dependencies:
-    abort-controller: ^3.0.0
-    bignumber.js: ^9.0.0
-    bs58: ^4.0.1
-    buffer: ^5.4.2
-    cids: ~0.7.1
-    debug: ^4.1.0
-    form-data: ^3.0.0
-    ipfs-block: ~0.8.1
-    ipfs-utils: ^0.7.1
-    ipld-dag-cbor: ^0.15.1
-    ipld-dag-pb: ^0.18.2
-    ipld-raw: ^4.0.1
-    it-tar: ^1.1.1
-    it-to-stream: ^0.1.1
-    iterable-ndjson: ^1.1.0
-    ky: ^0.15.0
-    ky-universal: ^0.3.0
-    merge-options: ^2.0.0
-    multiaddr: ^7.2.1
-    multiaddr-to-uri: ^5.1.0
-    multibase: ~0.6.0
-    multicodec: ^1.0.0
-    multihashes: ~0.4.14
-    parse-duration: ^0.1.1
-    stream-to-it: ^0.2.0
-  checksum: 18a0caaa5ac32a9c84f96f400a6ff4ea9b24238b5604892c60107c39e40929c1687f8823fbf70c2cd5a7c401479c61b39ea68d4799ad4daa9e121b6607b01347
   languageName: node
   linkType: hard
 
@@ -15702,19 +15715,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ipfs-utils@npm:^0.7.1":
-  version: 0.7.2
-  resolution: "ipfs-utils@npm:0.7.2"
+"ipfs-utils@npm:^1.0.0":
+  version: 1.2.4
+  resolution: "ipfs-utils@npm:1.2.4"
   dependencies:
-    buffer: ^5.2.1
+    abort-controller: ^3.0.0
+    buffer: ^5.4.2
     err-code: ^2.0.0
-    fs-extra: ^8.1.0
+    fs-extra: ^9.0.0
     is-electron: ^2.2.0
+    iso-url: ^0.4.7
     it-glob: 0.0.7
-    ky: ^0.15.0
-    ky-universal: ^0.3.0
+    merge-options: ^2.0.0
+    nanoid: ^2.1.11
+    node-fetch: ^2.6.0
     stream-to-it: ^0.2.0
-  checksum: e6ebe71f8355b1bd7c2164d3c4035e7e78afd23f5f2528f311b3f369a665ec40771d8ee36d999446977a8e05cbe0c4925887bfa66d8d0855727cb541956cdbc0
+  checksum: 0ad1d0b6b3bd688b45442dd52bad9e1b2f3e9b22f9e1aafbbbcecd518e52344628dff74b1846cf72fef83a81d8c6e53ac9614d7e3c5cf2bf700b33aaf4f5d4ef
   languageName: node
   linkType: hard
 
@@ -15817,7 +15833,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ipld-dag-pb@npm:^0.18.1, ipld-dag-pb@npm:^0.18.2":
+"ipld-dag-pb@npm:^0.18.1, ipld-dag-pb@npm:^0.18.3":
   version: 0.18.5
   resolution: "ipld-dag-pb@npm:0.18.5"
   dependencies:
@@ -16747,17 +16763,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"iso-url@npm:^0.4.7, iso-url@npm:~0.4.7":
+  version: 0.4.7
+  resolution: "iso-url@npm:0.4.7"
+  checksum: 9bf6b011bfd13c24f9bd640c77ac7f84d4aa7dd434f34569d3dd7ca4fcfcf831927d255b6e7ca58a39af6b87d6d30d8be907b5423fd8dfba89fd3b661b69fa19
+  languageName: node
+  linkType: hard
+
 "iso-url@npm:^1.1.5":
   version: 1.2.1
   resolution: "iso-url@npm:1.2.1"
   checksum: 799ead9e2adf973349b651f3567ad58dcef2f37399540b6d309e83c9a188f3b9764ef44099a9458a7b207570a4473a974e8a19453d260427fb90e1b1a496ef00
-  languageName: node
-  linkType: hard
-
-"iso-url@npm:~0.4.7":
-  version: 0.4.7
-  resolution: "iso-url@npm:0.4.7"
-  checksum: 9bf6b011bfd13c24f9bd640c77ac7f84d4aa7dd434f34569d3dd7ca4fcfcf831927d255b6e7ca58a39af6b87d6d30d8be907b5423fd8dfba89fd3b661b69fa19
   languageName: node
   linkType: hard
 
@@ -16952,7 +16968,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"it-tar@npm:^1.1.1":
+"it-tar@npm:^1.1.1, it-tar@npm:^1.2.1":
   version: 1.2.2
   resolution: "it-tar@npm:1.2.2"
   dependencies:
@@ -16977,6 +16993,15 @@ __metadata:
     it-reader: ^3.0.0
     p-defer: ^3.0.0
   checksum: 8d4fd849b4da6819b2ac97184bea38c12345d05c07d78baa94292206bfe3e86685fe3eb710e5202a4c98695a763d756cd8416c3d009256d64704f88acc955af3
+  languageName: node
+  linkType: hard
+
+"it-to-buffer@npm:^1.0.0":
+  version: 1.0.5
+  resolution: "it-to-buffer@npm:1.0.5"
+  dependencies:
+    buffer: ^5.5.0
+  checksum: 5bf31c9abde46d2319ab2d4d15a8430bcfaacb3e7b03ff9ce0c0032b6873b44c80675394ad0d02c0997845496bd902994eb2e1f03bfb15c1d8e3a38381bd72f3
   languageName: node
   linkType: hard
 
@@ -19857,7 +19882,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"multihashes@npm:^0.4.15, multihashes@npm:~0.4.13, multihashes@npm:~0.4.14, multihashes@npm:~0.4.15, multihashes@npm:~0.4.19":
+"multihashes@npm:^0.4.14, multihashes@npm:^0.4.15, multihashes@npm:~0.4.13, multihashes@npm:~0.4.14, multihashes@npm:~0.4.15, multihashes@npm:~0.4.19":
   version: 0.4.21
   resolution: "multihashes@npm:0.4.21"
   dependencies:
@@ -20022,6 +20047,13 @@ __metadata:
   version: 0.1.2
   resolution: "nano-json-stream-parser@npm:0.1.2"
   checksum: c28d8719fe63f6ada031434ab4eaeb595d8ae8ff78be87dda24f00b5807f43c4f3d9a234468cfdadf848928eda938ab19a7e872e9e847a4afe1e8c58599955d2
+  languageName: node
+  linkType: hard
+
+"nanoid@npm:^2.1.11":
+  version: 2.1.11
+  resolution: "nanoid@npm:2.1.11"
+  checksum: 41453e344e3abb189cd3baa3ab52685601d7220f86ce73f6a1d9594ebae286c2acf47a20b5aa9cf11933b587b69c6007e88f190ca266450c2fbe20be6db43a29
   languageName: node
   linkType: hard
 
@@ -21512,7 +21544,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parse-duration@npm:^0.1.1":
+"parse-duration@npm:^0.1.1, parse-duration@npm:^0.1.2":
   version: 0.1.3
   resolution: "parse-duration@npm:0.1.3"
   checksum: b20b1a62ccb44283190e9103cccfaa101556c59e70a0cb4029e9f31a793e7483afd9a2578ef0c1cddfcae0cf6885bc55a83b2fb2d43d53f8574f0f5332ce05dd


### PR DESCRIPTION
This PR includes an updated `yarn.lock` with which one can replicate Lido frontend IPFS hash.

To reproduce the hash, make sure to install dependencies without updating this lockfile
```bash
$ yarn install --immutable
$ export APPS=lido
$ npx hardhat run scripts/build-apps-frontend.js
$ ipfs add -qr --only-hash apps/lido/dist/ | tail -n 1
```