### PR TITLE
Reduce NodeOperatorsRegistry contract size

### DIFF
--- a/contracts/0.4.24/nos/NodeOperatorsRegistry.sol
+++ b/contracts/0.4.24/nos/NodeOperatorsRegistry.sol
@@ -347,7 +347,7 @@ contract NodeOperatorsRegistry is INodeOperatorsRegistry, AragonApp, IStakingMod
     function _updateExitedValidatorsKeysCount(
         uint256 _nodeOperatorId,
         uint256 _exitedValidatorsKeysCount,
-        bool allowDecrease
+        bool _allowDecrease
     ) internal {
         _onlyExistedNodeOperator(_nodeOperatorId);
         _auth(UPDATE_EXITED_VALIDATORS_KEYS_COUNT_ROLE);
@@ -360,7 +360,7 @@ contract NodeOperatorsRegistry is INodeOperatorsRegistry, AragonApp, IStakingMod
         }
 
         require(_exitedValidatorsKeysCount <= depositedSigningKeysCount, "INVALID_EXITED_VALIDATORS_COUNT");
-        require(allowDecrease || _exitedValidatorsKeysCount > exitedValidatorsCountBefore, "EXITED_VALIDATORS_COUNT_DECREASED");
+        require(_allowDecrease || _exitedValidatorsKeysCount > exitedValidatorsCountBefore, "EXITED_VALIDATORS_COUNT_DECREASED");
 
         _nodeOperators[_nodeOperatorId].exitedSigningKeysCount = uint64(_exitedValidatorsKeysCount);
 

--- a/contracts/0.4.24/test_helpers/NodeOperatorsRegistryMock.sol
+++ b/contracts/0.4.24/test_helpers/NodeOperatorsRegistryMock.sol
@@ -42,15 +42,14 @@ contract NodeOperatorsRegistryMock is NodeOperatorsRegistry {
         }
     }
 
-    function testing_markAllKeysDeposited(uint256 _nodeOperatorId) external onlyExistedNodeOperator(_nodeOperatorId) {
+    function testing_markAllKeysDeposited(uint256 _nodeOperatorId) external {
+        _onlyExistedNodeOperator(_nodeOperatorId);
         NodeOperator storage nodeOperator = _nodeOperators[_nodeOperatorId];
         testing_setDepositedSigningKeysCount(_nodeOperatorId, nodeOperator.vettedSigningKeysCount);
     }
 
-    function testing_setDepositedSigningKeysCount(uint256 _nodeOperatorId, uint256 _depositedSigningKeysCount)
-        public
-        onlyExistedNodeOperator(_nodeOperatorId)
-    {
+    function testing_setDepositedSigningKeysCount(uint256 _nodeOperatorId, uint256 _depositedSigningKeysCount) public {
+        _onlyExistedNodeOperator(_nodeOperatorId);
         NodeOperator storage nodeOperator = _nodeOperators[_nodeOperatorId];
         uint64 depositedSigningKeysCountBefore = nodeOperator.depositedSigningKeysCount;
         if (_depositedSigningKeysCount == depositedSigningKeysCountBefore) {


### PR DESCRIPTION
The next modifications were applied to the `NodeOperatorsRegistry` contract to reduce the bytecode size from **27.511 Kb** to **23.507 Kb**:

* Replace modifiers with internal methods
* Refactor `updateExitedValidatorsKeysCount()` & `unsafeUpdateExitedValidatorsKeysCount()` to use the same internal method `_updateExitedValidatorsKeysCount()`
* Refactor `addSigningKeys()`, `addSigningKeysOperatorBH()` to use the same internal method `_addSigningKeys()`
* Refactor `removeSigningKey()`, `removeSigningKeys()`, `removeSigningKeyOperatorBH()`, and `removeSigningKeysOperatorBH()` to use the same internal method `_removeUnusedSigningKeys()`