### PR TITLE
Tests: trivial fixes about `permit` and `StakingRouter`

### DIFF
--- a/test/0.4.24/lido.test.js
+++ b/test/0.4.24/lido.test.js
@@ -28,6 +28,7 @@ const RewardEmulatorMock = artifacts.require('RewardEmulatorMock.sol')
 const StakingRouter = artifacts.require('StakingRouterMock.sol')
 const BeaconChainDepositorMock = artifacts.require('BeaconChainDepositorMock.sol')
 const WithdrawalVault = artifacts.require('WithdrawalVault.sol')
+const EIP712StETH = artifacts.require('EIP712StETH')
 
 const ADDRESS_1 = '0x0000000000000000000000000000000000000001'
 const ADDRESS_2 = '0x0000000000000000000000000000000000000002'
@@ -129,8 +130,18 @@ contract('Lido', ([appManager, voting, user1, user2, user3, nobody, depositor, t
     )
 
     elRewardsVault = await ELRewardsVault.new(app.address, treasury)
+    const eip712StETH = await EIP712StETH.new()
+
     // Initialize the app's proxy.
-    await app.initialize(oracle.address, treasury, stakingRouter.address, depositor, elRewardsVault.address, ZERO_ADDRESS)
+    await app.initialize(
+      oracle.address,
+      treasury,
+      stakingRouter.address,
+      depositor,
+      elRewardsVault.address,
+      ZERO_ADDRESS,
+      eip712StETH.address
+    )
 
     await stakingRouter.addModule(
       'Curated',

--- a/test/0.8.9/lido-exec-layer-rewards-vault.js
+++ b/test/0.8.9/lido-exec-layer-rewards-vault.js
@@ -11,6 +11,7 @@ const NodeOperatorsRegistry = artifacts.require('NodeOperatorsRegistry')
 const LidoMock = artifacts.require('LidoMock.sol')
 const LidoOracleMock = artifacts.require('OracleMock.sol')
 const DepositContractMock = artifacts.require('DepositContractMock.sol')
+const EIP712StETH = artifacts.require('EIP712StETH')
 
 const ERC20OZMock = artifacts.require('ERC20OZMock.sol')
 const ERC721OZMock = artifacts.require('ERC721OZMock.sol')
@@ -40,9 +41,18 @@ contract('LidoExecutionLayerRewardsVault', ([appManager, voting, deployer, depos
     await acl.createPermission(voting, lido.address, await lido.BURN_ROLE(), appManager, { from: appManager })
 
     elRewardsVault = await LidoELRewardsVault.new(lido.address, treasury, { from: deployer })
+    const eip712StETH = await EIP712StETH.new({ from: deployer })
 
     // Initialize the app's proxy.
-    await lido.initialize(oracle.address, treasury, ZERO_ADDRESS, ZERO_ADDRESS, elRewardsVault.address, ZERO_ADDRESS)
+    await lido.initialize(
+      oracle.address,
+      treasury,
+      ZERO_ADDRESS,
+      ZERO_ADDRESS,
+      elRewardsVault.address,
+      ZERO_ADDRESS,
+      eip712StETH.address
+    )
 
     await oracle.setPool(lido.address)
     await depositContract.reset()

--- a/test/0.8.9/self-owned-steth-burner.test.js
+++ b/test/0.8.9/self-owned-steth-burner.test.js
@@ -14,6 +14,7 @@ const LidoOracleMock = artifacts.require('OracleMock.sol')
 const DepositContractMock = artifacts.require('DepositContractMock.sol')
 const RewardEmulatorMock = artifacts.require('RewardEmulatorMock.sol')
 const CompositePostRebaseBeaconReceiver = artifacts.require('CompositePostRebaseBeaconReceiver.sol')
+const EIP712StETH = artifacts.require('EIP712StETH')
 
 const ERC20OZMock = artifacts.require('ERC20OZMock.sol')
 const ERC721OZMock = artifacts.require('ERC721OZMock.sol')
@@ -48,9 +49,18 @@ contract('SelfOwnedStETHBurner', ([appManager, voting, deployer, anotherAccount,
 
     // Init the BURN_ROLE role and assign in to voting
     await acl.createPermission(voting, lido.address, await lido.BURN_ROLE(), appManager, { from: appManager })
+    const eip712StETH = await EIP712StETH.new({ from: deployer })
 
     // Initialize the app's proxy.
-    await lido.initialize(oracle.address, treasury, ZERO_ADDRESS, ZERO_ADDRESS, ZERO_ADDRESS, ZERO_ADDRESS)
+    await lido.initialize(
+      oracle.address,
+      treasury,
+      ZERO_ADDRESS,
+      ZERO_ADDRESS,
+      ZERO_ADDRESS,
+      ZERO_ADDRESS,
+      eip712StETH.address
+    )
 
     await oracle.setPool(lido.address)
     await depositContract.reset()

--- a/test/0.8.9/staking-router-deposits.test.js
+++ b/test/0.8.9/staking-router-deposits.test.js
@@ -13,6 +13,7 @@ const StakingModuleMock = artifacts.require('StakingModuleMock.sol')
 const DepositContractMock = artifacts.require('DepositContractMock.sol')
 const DepositSecurityModule = artifacts.require('DepositSecurityModule.sol')
 const StakingRouterMockForDepositSecurityModule = artifacts.require('StakingRouterMockForDepositSecurityModule')
+const EIP712StETH = artifacts.require('EIP712StETH')
 
 const ADDRESS_1 = '0x0000000000000000000000000000000000000001'
 const ADDRESS_2 = '0x0000000000000000000000000000000000000002'
@@ -112,7 +113,17 @@ contract('StakingRouter', (accounts) => {
     await stakingRouter.grantRole(MODULE_PAUSE_ROLE, voting, { from: admin })
     await stakingRouter.grantRole(MODULE_MANAGE_ROLE, voting, { from: admin })
 
-    await lido.initialize(oracle.address, treasury, stakingRouter.address, depositSecurityModule.address, ZERO_ADDRESS, ZERO_ADDRESS)
+    const eip712StETH = await EIP712StETH.new({ from: deployer })
+
+    await lido.initialize(
+      oracle.address,
+      treasury,
+      stakingRouter.address,
+      depositSecurityModule.address,
+      ZERO_ADDRESS,
+      ZERO_ADDRESS,
+      eip712StETH.address
+    )
 
     evmSnapshotId = await hre.ethers.provider.send('evm_snapshot', [])
   })

--- a/test/deposit.test.js
+++ b/test/deposit.test.js
@@ -16,6 +16,7 @@ const OracleMock = artifacts.require('OracleMock.sol')
 const DepositContract = artifacts.require('DepositContract')
 const VaultMock = artifacts.require('VaultMock.sol')
 const StakingRouter = artifacts.require('StakingRouterMock.sol')
+const EIP712StETH = artifacts.require('EIP712StETH')
 
 const ADDRESS_1 = '0x0000000000000000000000000000000000000001'
 const ADDRESS_2 = '0x0000000000000000000000000000000000000002'
@@ -114,8 +115,18 @@ contract('Lido with official deposit contract', ([appManager, voting, user1, use
       }
     )
 
+    const eip712StETH = await EIP712StETH.new({ from: appManager })
+
     // Initialize the app's proxy.
-    await app.initialize(oracle.address, treasury, stakingRouter.address, depositor, ZERO_ADDRESS, ZERO_ADDRESS)
+    await app.initialize(
+      oracle.address,
+      treasury,
+      stakingRouter.address,
+      depositor,
+      ZERO_ADDRESS,
+      ZERO_ADDRESS,
+      eip712StETH.address
+    )
 
     await oracle.setPool(app.address)
   })

--- a/test/scenario/helpers/deploy.js
+++ b/test/scenario/helpers/deploy.js
@@ -11,7 +11,7 @@ const OracleMock = artifacts.require('OracleMock.sol')
 const DepositContractMock = artifacts.require('DepositContractMock.sol')
 const DepositSecurityModule = artifacts.require('DepositSecurityModule.sol')
 const StakingRouter = artifacts.require('StakingRouterMock.sol')
-
+const EIP712StETH = artifacts.require('EIP712StETH')
 
 const MAX_DEPOSITS_PER_BLOCK = 100
 const MIN_DEPOSIT_BLOCK_DISTANCE = 20
@@ -124,13 +124,16 @@ async function deployDaoAndPool(appManager, voting) {
     { from: voting }
   )
 
+  const eip712StETH = await EIP712StETH.new({ from: appManager })
+
   await pool.initialize(
     oracleMock.address,
     treasury.address,
     stakingRouter.address,
     depositSecurityModule.address,
     elRewardsVault.address,
-    ZERO_ADDRESS
+    ZERO_ADDRESS,
+    eip712StETH.address
   )
 
   await oracleMock.setPool(pool.address)

--- a/test/scenario/lido_happy_path.js
+++ b/test/scenario/lido_happy_path.js
@@ -34,7 +34,7 @@ contract('Lido: happy path', (addresses) => {
   let oracleMock, depositContractMock
   let treasuryAddr, guardians
   let depositSecurityModule, depositRoot
-  let withdrawalCredentials
+  let withdrawalCredentials, stakingRouter
 
   before('DAO, node operators registry, token, pool and deposit security module are deployed and initialized', async () => {
     const deployed = await deployDaoAndPool(appManager, voting)
@@ -62,10 +62,9 @@ contract('Lido: happy path', (addresses) => {
     guardians = deployed.guardians
 
     depositRoot = await depositContractMock.get_deposit_root()
+    withdrawalCredentials = '0x'.padEnd(66, '1234')
 
-    withdrawalCredentials = pad('0x0202', 32)
-
-    await pool.setWithdrawalCredentials(withdrawalCredentials, { from: voting })
+    await stakingRouter.setWithdrawalCredentials(withdrawalCredentials, { from: voting })
   })
 
   // Fee and its distribution are in basis points, 10000 corresponding to 100%
@@ -86,6 +85,7 @@ contract('Lido: happy path', (addresses) => {
     const wc = '0x'.padEnd(66, '1234')
     assert.equal(await pool.getWithdrawalCredentials({ from: nobody }), wc, 'withdrawal credentials')
 
+    withdrawalCredentials = '0x'.padEnd(66, '5678')
     await stakingRouter.setWithdrawalCredentials(withdrawalCredentials, { from: voting })
 
     // Withdrawal credentials were set

--- a/test/scenario/lido_penalties_slashing.js
+++ b/test/scenario/lido_penalties_slashing.js
@@ -62,7 +62,8 @@ contract('Lido: penalties, slashing, operator stops', (addresses) => {
 
     depositRoot = await depositContractMock.get_deposit_root()
     withdrawalCredentials = pad('0x0202', 32)
-    await pool.setWithdrawalCredentials(withdrawalCredentials, { from: voting })
+
+    await stakingRouter.setWithdrawalCredentials(withdrawalCredentials, { from: voting })
   })
 
   // Fee and its distribution are in basis points, 10000 corresponding to 100%

--- a/test/scenario/lido_rewards_distribution_math.js
+++ b/test/scenario/lido_rewards_distribution_math.js
@@ -103,6 +103,7 @@ contract('Lido: rewards distribution math', (addresses) => {
 
     depositRoot = await deployed.depositContractMock.get_deposit_root()
 
+    const withdrawalCredentials = pad('0x0202', 32)
     await stakingRouter.setWithdrawalCredentials(withdrawalCredentials, { from: voting })
   })
 


### PR DESCRIPTION
Revive all tests except:
- scenario/lido_rewards_distribution_math.js
- scenario/lido_penalties_slashing.js

Those exceptions need to be rewritten thoughtfully.