### PR TITLE
Unify solidify version pragma for contracts in common

### DIFF
--- a/contracts/common/interfaces/IEIP712.sol
+++ b/contracts/common/interfaces/IEIP712.sol
@@ -4,7 +4,7 @@
 
 // See contracts/COMPILERS.md
 // solhint-disable-next-line
-pragma solidity 0.4.24||0.8.9;
+pragma solidity >=0.4.24 <0.9.0;
 
 /**
  * @dev Helper interface of EIP712.

--- a/contracts/common/lib/MinFirstAllocationStrategy.sol
+++ b/contracts/common/lib/MinFirstAllocationStrategy.sol
@@ -3,7 +3,7 @@
 
 /* See contracts/COMPILERS.md */
 // solhint-disable-next-line
-pragma solidity 0.4.24||0.8.9;
+pragma solidity >=0.4.24 <0.9.0;
 
 import {Math256} from "./Math256.sol";
 


### PR DESCRIPTION
Unify to ">=0.4.24 <0.9.0". Why?
1. Unification is good
2. During deployments of aragon std apps via their old tooling I might need to "sed" this to 0.4.24 because the tooling gets broken.  At least as a temporary solution.🙈