### PR TITLE
fix: handle report resubmit case

### DIFF
--- a/contracts/0.8.9/oracle/BaseOracle.sol
+++ b/contracts/0.8.9/oracle/BaseOracle.sol
@@ -173,7 +173,7 @@ abstract contract BaseOracle is IReportAsyncProcessor, AccessControlEnumerable, 
             revert RefSlotMustBeGreaterThanProcessingOne(refSlot, prevProcessingRefSlot);
         }
 
-        if (prevProcessingRefSlot != prevSubmittedRefSlot) {
+        if (refSlot != prevSubmittedRefSlot && prevProcessingRefSlot != prevSubmittedRefSlot) {
             emit WarnProcessingMissed(prevSubmittedRefSlot);
         }
 


### PR DESCRIPTION
### Description

## Scenario

* initial report is submitted at `refSlot1`
* next report is submitted at `refSlot2`,  initial report is missed, warning event fired
  * WarnProcessingMissed(`refSlot1`) 
* next report is re-agreed by consensus and resubmitted with new data
  * expected: WarnProcessingMissed(`refSlot1`) 
  * actual:  WarnProcessingMissed(`refSlot2`)

## Solution

At resubmit we lack information about slot missed at prev submitting. So proposed solution is to prevent fire of `WarnProcessingMissed` event at resubmit. What will be achieved:

- Upholding 1 missed report - 1 event condition
- WarnProcessingMissed argument can be trusted to contain actual missed slot 

### Testing notes

Corresponding tests are located in the branh [feature/shapella-upgrade-tests-base-oracle](https://github.com/lidofinance/lido-dao/tree/feature/shapella-upgrade-tests-base-oracle)
