### PR TITLE
Mint some shares to initial holder on protocol deploy and optimize submit.

### DIFF
--- a/contracts/0.4.24/Lido.sol
+++ b/contracts/0.4.24/Lido.sol
@@ -250,6 +250,9 @@ contract Lido is Versioned, StETHPermit, AragonApp {
     /**
     * @dev As AragonApp, Lido contract must be initialized with following variables:
     *      NB: by default, staking and the whole Lido pool are in paused state
+    *
+    * The contract's balance must be non-zero to allow initial holder bootstrap.
+    *
     * @param _lidoLocator lido locator contract
     * @param _eip712StETH eip712 helper contract for StETH
     */
@@ -290,6 +293,8 @@ contract Lido is Versioned, StETHPermit, AragonApp {
     /**
      * @notice A function to finalize upgrade to v2 (from v1). Can be called only once
      * @dev Value "1" in CONTRACT_VERSION_POSITION is skipped due to change in numbering
+     *
+     * The initial protocol token holder must exist.
      *
      * For more details see https://github.com/lidofinance/lido-improvement-proposals/blob/develop/LIPS/lip-10.md
      */

--- a/contracts/0.4.24/StETH.sol
+++ b/contracts/0.4.24/StETH.sol
@@ -503,17 +503,21 @@ contract StETH is IERC20, Pausable {
     }
 
     /**
-     * @notice Mints amount of shares equal to contract balance to 0xdead address
-     *  It allows to get rid of zero checks and corner cases
-     * @dev should be invoked before using the token
+     * @notice Mints shares on behalf of 0xdead address,
+     * the shares amount is equal to the contract's balance.     *
+     *
+     * Allows to get rid of zero checks for `totalShares` and `totalPooledEther`
+     * and overcome corner cases.
+     *
+     * @dev must be invoked before using the token
      */
     function _bootstrapInitialHolder() internal returns (uint256) {
         uint256 balance = address(this).balance;
         require(balance != 0, "EMPTY_INIT_BALANCE");
 
         if (_getTotalShares() == 0) {
-             // if protocol is empty bootstrap it with the contract's balance
-            // 0xdead is a holder for initial shares
+            // if protocol is empty bootstrap it with the contract's balance
+            // address(0xdead) is a holder for initial shares
             _mintShares(INITIAL_TOKEN_HOLDER, balance);
 
             emit Transfer(0x0, INITIAL_TOKEN_HOLDER, balance);


### PR DESCRIPTION
before:
![telegram-cloud-document-2-5427247187782280867](https://user-images.githubusercontent.com/1414948/218507256-2c13eb90-7b51-48eb-a468-d738eac23c77.jpg)

after:
<img width="1153" alt="image" src="https://user-images.githubusercontent.com/1414948/218506995-da10c207-d044-4217-bb1e-bdb5adac423e.png">

It broke almost every test, working to fix it.