### PR TITLE
NFTDescriptor for WithdrawalQueueERC721

### DIFF
--- a/contracts/0.8.9/WithdrawalQueueERC721.sol
+++ b/contracts/0.8.9/WithdrawalQueueERC721.sol
@@ -16,6 +16,18 @@ import {Strings} from "@openzeppelin/contracts-v4.4/utils/Strings.sol";
 import {IWstETH, WithdrawalQueue} from "./WithdrawalQueue.sol";
 import {AccessControlEnumerable} from "./utils/access/AccessControlEnumerable.sol";
 import {UnstructuredRefStorage} from "./lib/UnstructuredRefStorage.sol";
+import {UnstructuredStorage} from "./lib/UnstructuredStorage.sol";
+
+/**
+  * @title Interface defining INFTDescriptor to generate ERC721 metadata
+  */
+interface INFTDescriptor {
+    /**
+      * @notice Returns ERC721 metadata
+      * @param _requestId is an id for particular withdrawal request
+      */
+    function constructTokenURI(uint256 _requestId) external view returns (string memory);
+}
 
 /// @title NFT implementation on top of {WithdrawalQueue}
 /// NFT is minted on every request and burned on claim
@@ -26,12 +38,14 @@ contract WithdrawalQueueERC721 is IERC721Metadata, WithdrawalQueue {
     using Strings for uint256;
     using EnumerableSet for EnumerableSet.UintSet;
     using UnstructuredRefStorage for bytes32;
+    using UnstructuredStorage for bytes32;
 
     bytes32 internal constant TOKEN_APPROVALS_POSITION = keccak256("lido.WithdrawalQueueERC721.tokenApprovals");
     bytes32 internal constant OPERATOR_APPROVALS_POSITION = keccak256("lido.WithdrawalQueueERC721.operatorApprovals");
     bytes32 internal constant BASE_URI_POSITION = keccak256("lido.WithdrawalQueueERC721.baseUri");
+    bytes32 internal constant NFT_DESCRIPTOR_ADDRESS_POSITION = keccak256("lido.WithdrawalQueueERC721.nftDescriptorAddress");
 
-    bytes32 public constant SET_BASE_URI_ROLE = keccak256("SET_BASE_URI_ROLE");
+    bytes32 public constant MANAGE_TOKEN_URI_ROLE = keccak256("MANAGE_TOKEN_URI_ROLE");
 
     // @notion simple wrapper for base URI string
     //  Solidity does not allow to store string in UnstructuredStorage
@@ -40,6 +54,7 @@ contract WithdrawalQueueERC721 is IERC721Metadata, WithdrawalQueue {
     }
 
     event BaseURISet(string baseURI);
+    event NftDescriptorAddressSet(address nftDescriptorAddress);
 
     error ApprovalToOwner();
     error ApproveToCaller();
@@ -90,11 +105,18 @@ contract WithdrawalQueueERC721 is IERC721Metadata, WithdrawalQueue {
     }
 
     /// @dev See {IERC721Metadata-tokenURI}.
+    /// @dev If NFTDescriptor address isn't set the `baseURI` would be used for generating erc721 metadata. In case
+    ///  NFTDescriptor address is set it would be used as a priority method.
     function tokenURI(uint256 _requestId) public view virtual override returns (string memory) {
         if (!_existsAndNotClaimed(_requestId)) revert InvalidRequestId(_requestId);
 
-        string memory baseURI = _getBaseURI().value;
-        return bytes(baseURI).length > 0 ? string(abi.encodePacked(baseURI, _requestId.toString())) : "";
+        address nftDescriptorAddress = NFT_DESCRIPTOR_ADDRESS_POSITION.getStorageAddress();
+        if (nftDescriptorAddress != address(0)) {
+            return INFTDescriptor(nftDescriptorAddress).constructTokenURI(_requestId);
+        } else {
+            string memory baseURI = _getBaseURI().value;
+            return bytes(baseURI).length > 0 ? string(abi.encodePacked(baseURI, _requestId.toString())) : "";
+        }
     }
 
     /// @notice Base URI for computing {tokenURI}. If set, the resulting URI for each
@@ -104,9 +126,24 @@ contract WithdrawalQueueERC721 is IERC721Metadata, WithdrawalQueue {
     }
 
     /// @notice Sets the Base URI for computing {tokenURI}
-    function setBaseURI(string calldata _baseURI) external onlyRole(SET_BASE_URI_ROLE) {
+    /// @dev If NFTDescriptor address isn't set the `baseURI` would be used for generating erc721 metadata. In case
+    ///  NFTDescriptor address is set it would be used as a priority method.
+    function setBaseURI(string calldata _baseURI) external onlyRole(MANAGE_TOKEN_URI_ROLE) {
         _getBaseURI().value = _baseURI;
         emit BaseURISet(_baseURI);
+    }
+
+    /// @notice Address of NFTDescriptor contract that is responsible for metadata generation.
+    function getNFTDescriptorAddress() external view returns (address) {
+        return NFT_DESCRIPTOR_ADDRESS_POSITION.getStorageAddress();
+    }
+
+    /// @notice Sets the address of NFTDescriptor contract that is responsible for metadata generation.
+    /// @dev If NFTDescriptor address isn't set the `baseURI` would be used for generating erc721 metadata. In case
+    ///  NFTDescriptor address is set it would be used as a priority method.
+    function setNFTDescriptorAddress(address _nftDescriptorAddress) external onlyRole(MANAGE_TOKEN_URI_ROLE) {
+        NFT_DESCRIPTOR_ADDRESS_POSITION.setStorageAddress(_nftDescriptorAddress);
+        emit NftDescriptorAddressSet(_nftDescriptorAddress);
     }
 
     /// @dev See {IERC721-balanceOf}.


### PR DESCRIPTION
add NFTDescriptor as an on-chain way of generating metadata for WithdrawalQueueERC721