### PR TITLE
Feat: forbid stETH transfers to the contract itself

### DIFF
--- a/contracts/0.4.24/StETH.sol
+++ b/contracts/0.4.24/StETH.sol
@@ -426,13 +426,14 @@ contract StETH is IERC20, Pausable {
      * Requirements:
      *
      * - `_sender` cannot be the zero address.
-     * - `_recipient` cannot be the zero address.
+     * - `_recipient` cannot be the zero address or the `stETH` token contract itself
      * - `_sender` must hold at least `_sharesAmount` shares.
      * - the contract must not be paused.
      */
     function _transferShares(address _sender, address _recipient, uint256 _sharesAmount) internal {
         require(_sender != address(0), "TRANSFER_FROM_ZERO_ADDR");
         require(_recipient != address(0), "TRANSFER_TO_ZERO_ADDR");
+        require(_recipient != address(this), "TRANSFER_TO_STETH_CONTRACT");
         _whenNotStopped();
 
         uint256 currentSenderShares = shares[_sender];

--- a/contracts/0.4.24/StETH.sol
+++ b/contracts/0.4.24/StETH.sol
@@ -512,11 +512,13 @@ contract StETH is IERC20, Pausable {
      * Allows to get rid of zero checks for `totalShares` and `totalPooledEther`
      * and overcome corner cases.
      *
+     * NB: reverts if the current contract's balance is zero.
+     *
      * @dev must be invoked before using the token
      */
     function _bootstrapInitialHolder() internal returns (uint256) {
         uint256 balance = address(this).balance;
-        require(balance != 0, "EMPTY_INIT_BALANCE");
+        assert(balance != 0);
 
         if (_getTotalShares() == 0) {
             // if protocol is empty bootstrap it with the contract's balance

--- a/test/0.4.24/steth.test.js
+++ b/test/0.4.24/steth.test.js
@@ -91,6 +91,10 @@ contract('StETH', ([_, __, user1, user2, user3, nobody]) => {
           await assert.reverts(stEth.transfer(ZERO_ADDRESS, tokens(1), { from: user1 }), 'TRANSFER_TO_ZERO_ADDR')
         })
 
+        it('reverts when recipient is the `stETH` contract itself', async () => {
+          await assert.reverts(stEth.transfer(stEth.address, tokens(1), { from: user1 }), 'TRANSFER_TO_STETH_CONTRACT')
+        })
+
         it('reverts when the sender does not have enough balance', async () => {
           await assert.reverts(stEth.transfer(user2, tokens(101), { from: user1 }), 'BALANCE_EXCEEDED')
           await assert.reverts(stEth.transfer(user1, bn('1'), { from: user2 }), 'BALANCE_EXCEEDED')
@@ -170,6 +174,13 @@ contract('StETH', ([_, __, user1, user2, user3, nobody]) => {
           await assert.reverts(
             stEth.transferFrom(user1, ZERO_ADDRESS, tokens(1), { from: user2 }),
             'TRANSFER_TO_ZERO_ADDR'
+          )
+        })
+
+        it('reverts when recipient is the `stETH` contract itself', async () => {
+          await assert.reverts(
+            stEth.transferFrom(user1, stEth.address, tokens(1), { from: user2 }),
+            'TRANSFER_TO_STETH_CONTRACT'
           )
         })
 


### PR DESCRIPTION
Prevent the possible deceptive flow of unstaking via sending `stETH` to the contract itself (i.e., the inverted legit flow of the staking).