### PR TITLE
Legacy oracle Lido report tests

### DIFF
--- a/contracts/0.4.24/test_helpers/MockLegacyOracle.sol
+++ b/contracts/0.4.24/test_helpers/MockLegacyOracle.sol
@@ -91,7 +91,11 @@ contract MockLegacyOracle is ILegacyOracle, LegacyOracle {
     }
 
     function initializeAsV3() external {
-        CONTRACT_VERSION_POSITION_DEPRECATED.setStorageUint256(3);
+        CONTRACT_VERSION_POSITION_DEPRECATED.setStorageUint256(3);    
+    }
+
+    function setLido(address lido) external {
+        LIDO_POSITION.setStorageAddress(lido);
     }
 
 }

--- a/contracts/0.8.9/test_helpers/oracle/MockLidoForAccountingOracle.sol
+++ b/contracts/0.8.9/test_helpers/oracle/MockLidoForAccountingOracle.sol
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.8.9;
 
-import { ILido } from "../../oracle/AccountingOracle.sol";
+import { ILido } from '../../oracle/AccountingOracle.sol';
 
 interface IPostTokenRebaseReceiver {
     function handlePostTokenRebase(
@@ -17,7 +17,6 @@ interface IPostTokenRebaseReceiver {
 }
 
 contract MockLidoForAccountingOracle is ILido {
-
     address legacyOracle;
 
     struct HandleOracleReportLastCall {
@@ -35,7 +34,11 @@ contract MockLidoForAccountingOracle is ILido {
 
     HandleOracleReportLastCall internal _handleOracleReportLastCall;
 
-    function getLastCall_handleOracleReport() external view returns (HandleOracleReportLastCall memory) {
+    function getLastCall_handleOracleReport()
+        external
+        view
+        returns (HandleOracleReportLastCall memory)
+    {
         return _handleOracleReportLastCall;
     }
 
@@ -58,19 +61,33 @@ contract MockLidoForAccountingOracle is ILido {
         uint256[] calldata withdrawalFinalizationBatches,
         uint256 simulatedShareRate
     ) external {
-        _handleOracleReportLastCall.currentReportTimestamp = currentReportTimestamp;
-        _handleOracleReportLastCall.secondsElapsedSinceLastReport = secondsElapsedSinceLastReport;
+        _handleOracleReportLastCall
+            .currentReportTimestamp = currentReportTimestamp;
+        _handleOracleReportLastCall
+            .secondsElapsedSinceLastReport = secondsElapsedSinceLastReport;
         _handleOracleReportLastCall.numValidators = numValidators;
         _handleOracleReportLastCall.clBalance = clBalance;
-        _handleOracleReportLastCall.withdrawalVaultBalance = withdrawalVaultBalance;
-        _handleOracleReportLastCall.elRewardsVaultBalance = elRewardsVaultBalance;
-        _handleOracleReportLastCall.sharesRequestedToBurn = sharesRequestedToBurn;
-        _handleOracleReportLastCall.withdrawalFinalizationBatches = withdrawalFinalizationBatches;
+        _handleOracleReportLastCall
+            .withdrawalVaultBalance = withdrawalVaultBalance;
+        _handleOracleReportLastCall
+            .elRewardsVaultBalance = elRewardsVaultBalance;
+        _handleOracleReportLastCall
+            .sharesRequestedToBurn = sharesRequestedToBurn;
+        _handleOracleReportLastCall
+            .withdrawalFinalizationBatches = withdrawalFinalizationBatches;
         _handleOracleReportLastCall.simulatedShareRate = simulatedShareRate;
         ++_handleOracleReportLastCall.callCount;
 
-        if(legacyOracle != address(0)){
-            IPostTokenRebaseReceiver(legacyOracle).handlePostTokenRebase(currentReportTimestamp,secondsElapsedSinceLastReport,0,0,1,1,1);
+        if (legacyOracle != address(0)) {
+            IPostTokenRebaseReceiver(legacyOracle).handlePostTokenRebase(
+                currentReportTimestamp /* IGNORED reportTimestamp */,
+                secondsElapsedSinceLastReport /* timeElapsed */,
+                0 /* IGNORED preTotalShares */,
+                0 /* preTotalEther */,
+                1 /* postTotalShares */,
+                1 /* postTotalEther */,
+                1 /* IGNORED sharesMintedAsFees */
+            );
         }
     }
 }

--- a/contracts/0.8.9/test_helpers/oracle/MockLidoForAccountingOracle.sol
+++ b/contracts/0.8.9/test_helpers/oracle/MockLidoForAccountingOracle.sol
@@ -4,8 +4,21 @@ pragma solidity 0.8.9;
 
 import { ILido } from "../../oracle/AccountingOracle.sol";
 
+interface IPostTokenRebaseReceiver {
+    function handlePostTokenRebase(
+        uint256 _reportTimestamp,
+        uint256 _timeElapsed,
+        uint256 _preTotalShares,
+        uint256 _preTotalEther,
+        uint256 _postTotalShares,
+        uint256 _postTotalEther,
+        uint256 _sharesMintedAsFees
+    ) external;
+}
 
 contract MockLidoForAccountingOracle is ILido {
+
+    address legacyOracle;
 
     struct HandleOracleReportLastCall {
         uint256 currentReportTimestamp;
@@ -24,6 +37,10 @@ contract MockLidoForAccountingOracle is ILido {
 
     function getLastCall_handleOracleReport() external view returns (HandleOracleReportLastCall memory) {
         return _handleOracleReportLastCall;
+    }
+
+    function setLegacyOracle(address addr) external {
+        legacyOracle = addr;
     }
 
     ///
@@ -51,5 +68,9 @@ contract MockLidoForAccountingOracle is ILido {
         _handleOracleReportLastCall.withdrawalFinalizationBatches = withdrawalFinalizationBatches;
         _handleOracleReportLastCall.simulatedShareRate = simulatedShareRate;
         ++_handleOracleReportLastCall.callCount;
+
+        if(legacyOracle != address(0)){
+            IPostTokenRebaseReceiver(legacyOracle).handlePostTokenRebase(currentReportTimestamp,secondsElapsedSinceLastReport,0,0,1,1,1);
+        }
     }
 }

--- a/contracts/0.8.9/test_helpers/oracle/MockLidoForAccountingOracle.sol
+++ b/contracts/0.8.9/test_helpers/oracle/MockLidoForAccountingOracle.sol
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.8.9;
 
-import { ILido } from '../../oracle/AccountingOracle.sol';
+import { ILido } from "../../oracle/AccountingOracle.sol";
 
 interface IPostTokenRebaseReceiver {
     function handlePostTokenRebase(

--- a/test/0.4.24/legacy-oracle.test.js
+++ b/test/0.4.24/legacy-oracle.test.js
@@ -227,8 +227,10 @@ contract('LegacyOracle', ([admin, stranger]) => {
       await deployedInfra.consensus.submitReport(refSlot, reportHash, CONSENSUS_VERSION, { from: admin })
       const oracleVersion = +(await deployedInfra.oracle.getContractVersion())
 
-      // first report since migration has off timeElapsed because lastProcessingRefSlot is calculated per legacy frame ref
+      // first report since migration has timeElapsed 1 slot off because lastProcessingRefSlot is calculated per legacy frame ref
+      // calculated as in code
       const timeElapsed = (+refSlot - +(await deployedInfra.oracle.getLastProcessingRefSlot())) * SECONDS_PER_SLOT
+      assert.equals(timeElapsed, SECONDS_PER_FRAME - SECONDS_PER_SLOT)
 
       const tx = await deployedInfra.oracle.submitReportData(reportItems, oracleVersion, { from: admin })
 


### PR DESCRIPTION
Added test for report passthrough on AccountingOracle->Lido->LegacyOracle. Discovered interesting `lastProcessedRefSlot` behavior in case of legacy oracle migration. 