### PR TITLE
Withdrawal Queue Gas Tests

### DIFF
--- a/test/0.8.9/withdrawal-queue-gas.test.js
+++ b/test/0.8.9/withdrawal-queue-gas.test.js
@@ -75,6 +75,8 @@ contract('WithdrawalQueue', ([owner, user]) => {
         user,
         {
           from: user,
+          // smap of large transactions causes local network baseFee rise in next blocks
+          // increase gasPrice a bit on every tx to make sure execute
           gasPrice: gasPrice++,
           gasLimit: 1000000000,
         },

--- a/test/0.8.9/withdrawal-queue-gas.test.js
+++ b/test/0.8.9/withdrawal-queue-gas.test.js
@@ -50,8 +50,11 @@ contract('WithdrawalQueue', ([owner, user]) => {
     await snapshot.make()
   })
 
-  after('clean up', async () => {
-    await snapshot.rollback()
+  after('clean up', async function () {
+    // only rollback if not skipped
+    if (process.env.REPORT_GAS) {
+      await snapshot.rollback()
+    }
   })
 
   context('requestWithdrawal', () => {


### PR DESCRIPTION
Added gas test for batch operations on WQ.
### Usage notes

Tests are skipped when not run with `test:gas`. Run time is pretty long and transactions pump block price and may interfere with other tests. Fiddle with `MAX_BATCH_SIZE` and `batchIncrement` to generate different results and insights.


### Findings

- `requestWithdrawals` fails on >~270 batch size. Could be hardhat limitation.
- `finalize` spikes in gas usage on first time.
-  `claimWithdrawals`overestimates gas, convergence at ~21% less gas used

### Results
![image](https://user-images.githubusercontent.com/3705803/226533338-206b821d-3836-48fd-9719-377c2131cf52.png)
![image](https://user-images.githubusercontent.com/3705803/226533372-b45b0d61-1ca6-438e-ad10-d1d0904ea4af.png)
