### PR TITLE
Fix: make isLimitReached more coherent

### DIFF
--- a/contracts/0.8.9/lib/PositiveTokenRebaseLimiter.sol
+++ b/contracts/0.8.9/lib/PositiveTokenRebaseLimiter.sol
@@ -102,16 +102,11 @@ library PositiveTokenRebaseLimiter {
      */
     function isLimitReached(TokenRebaseLimiterData memory _limiterState) internal pure returns (bool) {
         if (_limiterState.positiveRebaseLimit == UNLIMITED_REBASE) return false;
-        if (_limiterState.currentTotalPooledEther < _limiterState.preTotalPooledEther) return false;
 
-        uint256 accumulatedEther = _limiterState.currentTotalPooledEther - _limiterState.preTotalPooledEther;
-        uint256 accumulatedRebase;
+        uint256 maxTotalPooledEther = _limiterState.preTotalPooledEther +
+            (_limiterState.positiveRebaseLimit * _limiterState.preTotalPooledEther) / LIMITER_PRECISION_BASE;
 
-        if (_limiterState.preTotalPooledEther > 0) {
-            accumulatedRebase = accumulatedEther * LIMITER_PRECISION_BASE / _limiterState.preTotalPooledEther;
-        }
-
-        return accumulatedRebase >= _limiterState.positiveRebaseLimit;
+        return _limiterState.currentTotalPooledEther >= maxTotalPooledEther;
     }
 
     /**

--- a/contracts/0.8.9/lib/PositiveTokenRebaseLimiter.sol
+++ b/contracts/0.8.9/lib/PositiveTokenRebaseLimiter.sol
@@ -27,6 +27,7 @@ struct TokenRebaseLimiterData {
     uint256 preTotalShares;          // pre-rebase total shares
     uint256 currentTotalPooledEther; // intermediate total pooled ether amount while token rebase is in progress
     uint256 positiveRebaseLimit;     // positive rebase limit (target value) with 1e9 precision (`LIMITER_PRECISION_BASE`)
+    uint256 maxTotalPooledEther;     // maximum total pooled ether that still fits into the positive rebase limit (cached)
 }
 
 /**
@@ -93,6 +94,11 @@ library PositiveTokenRebaseLimiter {
         limiterState.currentTotalPooledEther = limiterState.preTotalPooledEther = _preTotalPooledEther;
         limiterState.preTotalShares = _preTotalShares;
         limiterState.positiveRebaseLimit = _rebaseLimit;
+
+        limiterState.maxTotalPooledEther = (_rebaseLimit == UNLIMITED_REBASE)
+            ? type(uint256).max
+            : limiterState.preTotalPooledEther
+                + (limiterState.positiveRebaseLimit * limiterState.preTotalPooledEther) / LIMITER_PRECISION_BASE;
     }
 
     /**
@@ -101,12 +107,7 @@ library PositiveTokenRebaseLimiter {
      * @return true if limit is reached
      */
     function isLimitReached(TokenRebaseLimiterData memory _limiterState) internal pure returns (bool) {
-        if (_limiterState.positiveRebaseLimit == UNLIMITED_REBASE) return false;
-
-        uint256 maxTotalPooledEther = _limiterState.preTotalPooledEther +
-            (_limiterState.positiveRebaseLimit * _limiterState.preTotalPooledEther) / LIMITER_PRECISION_BASE;
-
-        return _limiterState.currentTotalPooledEther >= maxTotalPooledEther;
+        return _limiterState.currentTotalPooledEther >= _limiterState.maxTotalPooledEther;
     }
 
     /**
@@ -142,11 +143,8 @@ library PositiveTokenRebaseLimiter {
         uint256 prevPooledEther = _limiterState.currentTotalPooledEther;
         _limiterState.currentTotalPooledEther += _etherAmount;
 
-        uint256 maxTotalPooledEther = _limiterState.preTotalPooledEther +
-            (_limiterState.positiveRebaseLimit * _limiterState.preTotalPooledEther) / LIMITER_PRECISION_BASE;
-
         _limiterState.currentTotalPooledEther
-            = Math256.min(_limiterState.currentTotalPooledEther, maxTotalPooledEther);
+            = Math256.min(_limiterState.currentTotalPooledEther, _limiterState.maxTotalPooledEther);
 
         assert(_limiterState.currentTotalPooledEther >= prevPooledEther);
 

--- a/test/0.8.9/oracle-report-sanity-checker.test.js
+++ b/test/0.8.9/oracle-report-sanity-checker.test.js
@@ -914,8 +914,8 @@ contract('OracleReportSanityChecker', ([deployer, admin, withdrawalVault, elRewa
         preTotalShares: ETH('1000000'),
         preCLBalance: ETH('1000000'),
         postCLBalance: ETH('1000000'),
-        elRewardsVaultBalance: ETH(500),
         withdrawalVaultBalance: ETH(500),
+        elRewardsVaultBalance: ETH(500),
         sharesRequestedToBurn: ETH(0),
         etherToLockForWithdrawals: ETH(40000),
         newSharesToBurnForWithdrawals: ETH(40000),
@@ -928,6 +928,33 @@ contract('OracleReportSanityChecker', ([deployer, admin, withdrawalVault, elRewa
       assert.equals(elRewards, ETH(500))
       assert.equals(simulatedSharesToBurn, ETH(0))
       assert.equals(sharesToBurn, '39960039960039960039960') // ETH(1000000 - 961000. / 1.001)
+    })
+
+    it('rounding case from Görli', async () => {
+      const newRebaseLimit = 750_000 // 0.075% or 7.5 basis points
+      await oracleReportSanityChecker.setMaxPositiveTokenRebase(newRebaseLimit, {
+        from: managersRoster.maxPositiveTokenRebaseManagers[0],
+      })
+
+      const rebaseParams = {
+        preTotalPooledEther: '125262263468962792235936',
+        preTotalShares: '120111767594397261197918',
+        preCLBalance: '113136253352529000000000',
+        postCLBalance: '113134996436274000000000',
+        withdrawalVaultBalance: '129959459000000000',
+        elRewardsVaultBalance: '6644376444653811679390',
+        sharesRequestedToBurn: '15713136097768852533',
+        etherToLockForWithdrawals: '0',
+        newSharesToBurnForWithdrawals: '0',
+      }
+
+      const { withdrawals, elRewards, simulatedSharesToBurn, sharesToBurn } =
+        await oracleReportSanityChecker.smoothenTokenRebase(...Object.values(rebaseParams))
+
+      assert.equals(withdrawals, '129959459000000000')
+      assert.equals(elRewards, '95073654397722094176')
+      assert.equals(simulatedSharesToBurn, '0')
+      assert.equals(sharesToBurn, '0')
     })
   })
 


### PR DESCRIPTION
- [x] Update the `isLimitReached()` impl
- [x] Add test case for [`TokenRebaseLimiter`](https://github.com/lidofinance/lido-dao/blob/fix/rebaseLimiter-isLimitReached/test/0.8.9/positive-token-rebase-limiter.test.js#L230-L244)
- [x] Add test case for [`OracleReportSanityChecker`](https://github.com/lidofinance/lido-dao/blob/fix/rebaseLimiter-isLimitReached/test/0.8.9/oracle-report-sanity-checker.test.js#L933-L959)

