### PR TITLE
Fix: HashConsensus fast lane calc when consensus is disabled

### DIFF
--- a/contracts/0.8.9/oracle/HashConsensus.sol
+++ b/contracts/0.8.9/oracle/HashConsensus.sol
@@ -768,9 +768,13 @@ contract HashConsensus is AccessControlEnumerable {
     function _getFastLaneSubset(uint256 frameIndex, uint256 totalMembers)
         internal view returns (uint256 startIndex, uint256 pastEndIndex)
     {
-        if (totalMembers != 0) {
+        uint256 quorum = _quorum;
+        if (quorum >= totalMembers) {
+            startIndex = 0;
+            pastEndIndex = totalMembers;
+        } else {
             startIndex = frameIndex % totalMembers;
-            pastEndIndex = startIndex + _quorum;
+            pastEndIndex = startIndex + quorum;
         }
     }
 

--- a/test/0.8.9/oracle/hash-consensus-fast-lane-members.test.js
+++ b/test/0.8.9/oracle/hash-consensus-fast-lane-members.test.js
@@ -1,6 +1,7 @@
 const { contract } = require('hardhat')
 const { assert } = require('../../helpers/assert')
 const { toNum } = require('../../helpers/utils')
+const { MAX_UINT256 } = require('../../helpers/constants')
 
 const { HASH_1, CONSENSUS_VERSION, deployHashConsensus } = require('./hash-consensus-deploy.test')
 
@@ -150,13 +151,13 @@ contract('HashConsensus', ([admin, member1, member2, member3, member4, member5, 
       frames.forEach(testFrame)
     })
 
-    context('Quorum size equal to total members', () => {
+    const testAllInFastLane = ({ quorumSize }) => {
       before(async () => {
         await deploy({ fastLaneLengthSlots: 10 })
 
-        await consensus.addMember(member1, 3, { from: admin })
-        await consensus.addMember(member2, 3, { from: admin })
-        await consensus.addMember(member3, 3, { from: admin })
+        await consensus.addMember(member1, quorumSize, { from: admin })
+        await consensus.addMember(member2, quorumSize, { from: admin })
+        await consensus.addMember(member3, quorumSize, { from: admin })
       })
 
       before(setTimeToFrame0)
@@ -189,6 +190,10 @@ contract('HashConsensus', ([admin, member1, member2, member3, member4, member5, 
         })
 
       Array.from({ length: 10 }, (_, i) => i).forEach(testFrame)
-    })
+    }
+
+    context('Quorum size equal to total members', () => testAllInFastLane({ quorumSize: 3 }))
+    context('Quorum size more than total members', () => testAllInFastLane({ quorumSize: 5 }))
+    context('Quorum is a max value', () => testAllInFastLane({ quorumSize: MAX_UINT256 }))
   })
 })


### PR DESCRIPTION
Fixes calculation of fast lane members subset when quorum is set to an unreachable value, i.e. when `quorum > totalMembers`.