### PR TITLE
Fix (AccountingOracle): extra data submission order check

### DIFF
--- a/contracts/0.8.9/oracle/AccountingOracle.sol
+++ b/contracts/0.8.9/oracle/AccountingOracle.sol
@@ -687,11 +687,14 @@ contract AccountingOracle is BaseOracle {
         internal view
     {
         _checkMsgSenderIsAllowedToSubmitData();
-        _checkProcessingDeadline();
 
-        if (procState.refSlot != LAST_PROCESSING_REF_SLOT_POSITION.getStorageUint256()) {
+        ConsensusReport memory report = _storageConsensusReport().value;
+
+        if (report.hash == bytes32(0) || procState.refSlot != report.refSlot) {
             revert CannotSubmitExtraDataBeforeMainData();
         }
+
+        _checkProcessingDeadline();
 
         if (procState.dataFormat != format) {
             revert UnexpectedExtraDataFormat(procState.dataFormat, format);


### PR DESCRIPTION
Fixes the check in `AccountingOracle` that enforces extra data submisison after the main data. It was possible to submit stale extra data even though a new report hash was already pushed by `HashConsensus`.