### PR TITLE
Fix (SignatureUtils): check the EIP-1271 call result more strictly

### DIFF
--- a/contracts/common/lib/SignatureUtils.sol
+++ b/contracts/common/lib/SignatureUtils.sol
@@ -38,7 +38,7 @@ library SignatureUtils {
             // Solidity <0.5 generates a regular CALL instruction even if the function being called
             // is marked as `view`, and the only way to perform a STATICCALL is to use assembly
             bytes memory data = abi.encodeWithSelector(ERC1271_IS_VALID_SIGNATURE_SELECTOR, msgHash, sig);
-            bytes4 retval;
+            bytes32 retval;
             /// @solidity memory-safe-assembly
             assembly {
                 // allocate memory for storing the return value
@@ -46,11 +46,11 @@ library SignatureUtils {
                 mstore(0x40, add(outDataOffset, 32))
                 // issue a static call and load the result if the call succeeded
                 let success := staticcall(gas(), signer, add(data, 32), mload(data), outDataOffset, 32)
-                if eq(success, 1) {
+                if and(eq(success, 1), eq(returndatasize(), 32)) {
                     retval := mload(outDataOffset)
                 }
             }
-            return retval == ERC1271_IS_VALID_SIGNATURE_SELECTOR;
+            return retval == bytes32(ERC1271_IS_VALID_SIGNATURE_SELECTOR);
         } else {
             return ECDSA.recover(msgHash, v, r, s) == signer;
         }

--- a/contracts/common/test_helpers/ERC1271SignerDumbMock.sol
+++ b/contracts/common/test_helpers/ERC1271SignerDumbMock.sol
@@ -8,7 +8,7 @@ contract ERC1271SignerDumbMock {
     error InvalidSignature();
 
     struct Config {
-        bytes4 retval;
+        bytes retval;
         bool reverts;
     }
 
@@ -20,6 +20,9 @@ contract ERC1271SignerDumbMock {
 
     function isValidSignature(bytes32 /* hash */, bytes memory /* sig */) external view returns (bytes4) {
         if (_config.reverts) revert InvalidSignature();
-        return _config.retval;
+        bytes memory retval = _config.retval;
+        assembly {
+            return(add(retval, 32), mload(retval))
+        }
     }
 }


### PR DESCRIPTION
Makes sure that:

1. the returned data is exactly 32 bytes long;
2. only the first 4 bytes are non-zero;
3. these 4 bytes contain the magic value.

This doesn't support contracts that right-pad the magic value with zeroes to a size longer than 32 bytes like the Solidity ABI decoder currently allows, but that's a really exotic edge case since it breaks the ABI specification for the `bytes4` return data type.