### PR TITLE
Add missing nonce updates to NodeOperatorsRegistry

### DIFF
--- a/contracts/0.4.24/nos/NodeOperatorsRegistry.sol
+++ b/contracts/0.4.24/nos/NodeOperatorsRegistry.sol
@@ -479,6 +479,7 @@ contract NodeOperatorsRegistry is AragonApp, Versioned {
             _requireValidRange(nodeOperatorId < totalNodeOperatorsCount);
             _updateStuckValidatorsCount(nodeOperatorId, validatorsCount);
         }
+        _increaseValidatorsKeysNonce();
     }
 
     /// @notice Called by StakingRouter to update the number of the validators in the EXITED state
@@ -515,6 +516,7 @@ contract NodeOperatorsRegistry is AragonApp, Versioned {
             _requireValidRange(nodeOperatorId < totalNodeOperatorsCount);
             _updateExitedValidatorsCount(nodeOperatorId, validatorsCount, false);
         }
+        _increaseValidatorsKeysNonce();
     }
 
     /// @notice Updates the number of the refunded validators for node operator with the given id
@@ -556,6 +558,7 @@ contract NodeOperatorsRegistry is AragonApp, Versioned {
 
         _updateExitedValidatorsCount(_nodeOperatorId, uint64(_exitedValidatorsCount), true /* _allowDecrease */ );
         _updateStuckValidatorsCount(_nodeOperatorId, uint64(_stuckValidatorsCount));
+        _increaseValidatorsKeysNonce();
     }
 
     function _updateExitedValidatorsCount(uint256 _nodeOperatorId, uint64 _exitedValidatorsKeysCount, bool _allowDecrease)
@@ -604,6 +607,7 @@ contract NodeOperatorsRegistry is AragonApp, Versioned {
         emit TargetValidatorsCountChanged(_nodeOperatorId, _targetLimit);
 
         _updateSummaryMaxValidatorsCount(_nodeOperatorId);
+        _increaseValidatorsKeysNonce();
     }
 
     /**
@@ -1231,6 +1235,7 @@ contract NodeOperatorsRegistry is AragonApp, Versioned {
         stuckPenaltyStats.set(STUCK_PENALTY_END_TIMESTAMP_OFFSET, 0);
         _saveOperatorStuckPenaltyStats(_nodeOperatorId, stuckPenaltyStats);
         _updateSummaryMaxValidatorsCount(_nodeOperatorId);
+        _increaseValidatorsKeysNonce();
     }
 
     /// @notice Returns total number of node operators

--- a/contracts/0.4.24/test_helpers/NodeOperatorsRegistryMock.sol
+++ b/contracts/0.4.24/test_helpers/NodeOperatorsRegistryMock.sol
@@ -201,4 +201,24 @@ contract NodeOperatorsRegistryMock is NodeOperatorsRegistry {
     function testing_distributeRewards() external returns (uint256) {
         return _distributeRewards();
     }
+
+     function testing_setNodeOperatorPenalty(
+        uint256 _nodeOperatorId,
+        uint256 _refundedValidatorsCount,
+        uint256 _stuckValidatorsCount,
+        uint256 _stuckPenaltyEndTimestamp
+    ) external {
+        _requireValidRange(_refundedValidatorsCount <= UINT64_MAX);
+        _requireValidRange(_stuckValidatorsCount <= UINT64_MAX);
+        _requireValidRange(_stuckPenaltyEndTimestamp <= UINT64_MAX);
+        Packed64x4.Packed memory stuckPenaltyStats = _loadOperatorStuckPenaltyStats(
+            _nodeOperatorId
+        );
+
+        stuckPenaltyStats.set(REFUNDED_VALIDATORS_COUNT_OFFSET, uint64(_refundedValidatorsCount));
+        stuckPenaltyStats.set(STUCK_VALIDATORS_COUNT_OFFSET, uint64(_stuckValidatorsCount));
+        stuckPenaltyStats.set(STUCK_PENALTY_END_TIMESTAMP_OFFSET, uint64(_stuckPenaltyEndTimestamp));
+        _saveOperatorStuckPenaltyStats(_nodeOperatorId, stuckPenaltyStats);
+        _updateSummaryMaxValidatorsCount(_nodeOperatorId);
+    }
 }

--- a/test/helpers/assert.js
+++ b/test/helpers/assert.js
@@ -12,7 +12,7 @@ chai.util.addMethod(chai.assert, 'emits', function (receipt, eventName, args = u
   if (args !== undefined) {
     chai.assert(
       findEventWithArgs(args, events) !== undefined,
-      () => `No '${eventName}' event was emitted with expected args ${JSON.stringify(args)}`
+      () => `No '${eventName}' event was emitted with expected args ${stringify(args)}`
     )
   }
 })
@@ -21,7 +21,7 @@ chai.util.addMethod(chai.assert, 'emitsAt', function (receipt, eventName, index,
   const event = getEventAt(receipt, eventName, index, args, options.abi)
   chai.assert(
     event !== undefined,
-    () => `Event '${eventName}' at index ${index} with args ${JSON.stringify(args)} wasn't found`
+    () => `Event '${eventName}' at index ${index} with args ${stringify(args)} wasn't found`
   )
 })
 
@@ -162,7 +162,7 @@ function findEventWithArgs(args, events) {
 }
 
 function normalizeArg(arg) {
-  if (isBn(arg) || Number.isFinite(arg)) {
+  if (isBn(arg) || Number.isFinite(arg) || typeof arg === 'bigint') {
     return arg.toString()
   } else if (isAddress(arg)) {
     return toChecksumAddress(arg)
@@ -172,6 +172,11 @@ function normalizeArg(arg) {
   }
 
   return arg
+}
+
+function stringify(obj) {
+  // Helps overcome the problem with BigInt serialization. Details: https://github.com/GoogleChromeLabs/jsbi/issues/30
+  return JSON.stringify(obj, (_, value) => (typeof value === 'bigint' ? value.toString() : value))
 }
 
 module.exports = { assert: chai.assert }


### PR DESCRIPTION
According to requirements from the `IStakingModule.getNonce()` method, its return value must update each time the deposit data set is changed. This requirement was violated in the following methods:
- `updaeStuckValidatorsCount()`
- `updateExitedValidatorsCount()`
- `unsafeUpdateValidatorsCount()`
- `updateTargetValidatorsLimits()`
- `clearNodeOperatorPenalty()`