### PR TITLE
Fix/lido fee distribution

### DIFF
--- a/contracts/0.8.9/StakingRouter.sol
+++ b/contracts/0.8.9/StakingRouter.sol
@@ -319,7 +319,7 @@ contract StakingRouter is AccessControlEnumerable, BeaconChainDepositor, Version
     /// @param _stakingModuleIds Ids of the staking modules to be updated.
     /// @param _exitedValidatorsCounts New counts of exited validators for the specified staking modules.
     ///
-    /// @return The total increase in the aggregate number of exited validators accross all updated modules.
+    /// @return The total increase in the aggregate number of exited validators across all updated modules.
     ///
     /// The total numbers are stored in the staking router and can differ from the totals obtained by calling
     /// `IStakingModule.getStakingModuleSummary()`. The overall process of updating validator counts is the following:
@@ -329,19 +329,19 @@ contract StakingRouter is AccessControlEnumerable, BeaconChainDepositor, Version
     ///    distribute new stake and staking fees between the modules. There can only be single call of this function
     ///    per oracle reporting frame.
     ///
-    /// 2. In the first part of the second data submittion phase, the oracle calls
+    /// 2. In the first part of the second data submission phase, the oracle calls
     ///    `StakingRouter.reportStakingModuleStuckValidatorsCountByNodeOperator` on the staking router which passes the
     ///    counts by node operator to the staking module by calling `IStakingModule.updateStuckValidatorsCount`.
     ///    This can be done multiple times for the same module, passing data for different subsets of node operators.
     ///
-    /// 3. In the second part of the second data submittion phase, the oracle calls
+    /// 3. In the second part of the second data submission phase, the oracle calls
     ///    `StakingRouter.reportStakingModuleExitedValidatorsCountByNodeOperator` on the staking router which passes
     ///    the counts by node operator to the staking module by calling `IStakingModule.updateExitedValidatorsCount`.
     ///    This can be done multiple times for the same module, passing data for different subsets of node
     ///    operators.
     ///
-    /// 4. At the end of the second data submission phase, it's expected for the aggragate exited validators count
-    ///    accross all module's node operators (stored in the module) to match the total count for this module
+    /// 4. At the end of the second data submission phase, it's expected for the aggregate exited validators count
+    ///    across all module's node operators (stored in the module) to match the total count for this module
     ///    (stored in the staking router). However, it might happen that the second phase of data submission doesn't
     ///    finish until the new oracle reporting frame is started, in which case staking router will emit a warning
     ///    event `StakingModuleExitedValidatorsIncompleteReporting` when the first data submission phase is performed
@@ -349,7 +349,7 @@ contract StakingRouter is AccessControlEnumerable, BeaconChainDepositor, Version
     ///    the exited and maybe stuck validator counts during the whole reporting frame. Handling this condition is
     ///    the responsibility of each staking module.
     ///
-    /// 5. When the second reporting phase is finshed, i.e. when the oracle submitted the complete data on the stuck
+    /// 5. When the second reporting phase is finished, i.e. when the oracle submitted the complete data on the stuck
     ///    and exited validator counts per node operator for the current reporting frame, the oracle calls
     ///    `StakingRouter.onValidatorsCountsByNodeOperatorReportingFinished` which, in turn, calls
     ///    `IStakingModule.onExitedAndStuckValidatorsCountsUpdated` on all modules.

--- a/test/scenario/lido_happy_path.test.js
+++ b/test/scenario/lido_happy_path.test.js
@@ -14,6 +14,13 @@ const { INITIAL_HOLDER } = require('../helpers/constants')
 
 const NodeOperatorsRegistry = artifacts.require('NodeOperatorsRegistry')
 const CURATED_MODULE_ID = 1
+const TOTAL_BASIS_POINTS = 10000
+const CURATED_MODULE_MODULE_FEE = 500
+const CURATED_MODULE_TREASURY_FEE = 500
+
+// Fee and its distribution are in basis points, 10000 corresponding to 100%
+// Total fee is 10%
+const totalFeePoints = 0.1 * TOTAL_BASIS_POINTS
 
 contract('Lido: happy path', (addresses) => {
   const [
@@ -41,14 +48,14 @@ contract('Lido: happy path', (addresses) => {
     async () => {
       const deployed = await deployProtocol({
         stakingModulesFactory: async (protocol) => {
-          const curatedModule = await setupNodeOperatorsRegistry(protocol)
+          const curatedModule = await setupNodeOperatorsRegistry(protocol, true)
           return [
             {
               module: curatedModule,
               name: 'Curated',
               targetShares: 10000,
-              moduleFee: 500,
-              treasuryFee: 500,
+              moduleFee: CURATED_MODULE_MODULE_FEE,
+              treasuryFee: CURATED_MODULE_TREASURY_FEE,
             },
           ]
         },
@@ -83,22 +90,6 @@ contract('Lido: happy path', (addresses) => {
       await stakingRouter.setWithdrawalCredentials(withdrawalCredentials, { from: voting })
     }
   )
-
-  // Fee and its distribution are in basis points, 10000 corresponding to 100%
-
-  // Total fee is 10%
-  const totalFeePoints = 0.1 * 10000
-
-  it.skip('voting sets fee and its distribution', async () => {
-    // Fee and distribution were set
-    assert.equals(await pool.getFee({ from: nobody }), totalFeePoints, 'total fee')
-    const distribution = await pool.getFeeDistribution({ from: nobody })
-    console.log('distribution', distribution)
-    const treasuryFeePoints = 0 // TODO
-    const nodeOperatorsFeePoints = 0 // TODO
-    assert.equals(distribution.treasuryFeeBasisPoints, treasuryFeePoints, 'treasury fee')
-    assert.equals(distribution.operatorsFeeBasisPoints, nodeOperatorsFeePoints, 'node operators fee')
-  })
 
   it('voting sets withdrawal credentials', async () => {
     const wc = '0x'.padEnd(66, '1234')
@@ -545,5 +536,31 @@ contract('Lido: happy path', (addresses) => {
     assert.equals(nodeOperatorInfo.totalSigningKeys, nodeOperatorInfo.usedSigningKeys)
     nodeOperatorInfo = await nodeOperatorsRegistry.getNodeOperator(nodeOperator2.id, false)
     assert.equals(nodeOperatorInfo.totalSigningKeys, nodeOperatorInfo.usedSigningKeys)
+  })
+
+  it('getFee and getFeeDistribution works as expected', async () => {
+    // Need to have at least single deposited key, otherwise StakingRouter.getStakingRewardsDistribution
+    // will return zero fees because no modules with non-zero total active validators
+    // This is done in the changes in the tests above, but assuming there are no such changes
+    // one could use the following:
+    // await nodeOperatorsRegistry.increaseNodeOperatorDepositedSigningKeysCount(0, 1)
+
+    function getFeeRelativeToTotalFee(absoluteFee) {
+      return (absoluteFee * TOTAL_BASIS_POINTS) / totalFeePoints
+    }
+
+    assert.equals(await pool.getFee({ from: nobody }), totalFeePoints, 'total fee')
+    const distribution = await pool.getFeeDistribution({ from: nobody })
+    assert.equals(distribution.insuranceFeeBasisPoints, 0, 'insurance fee')
+    assert.equals(
+      distribution.treasuryFeeBasisPoints,
+      getFeeRelativeToTotalFee(CURATED_MODULE_TREASURY_FEE),
+      'treasury fee'
+    )
+    assert.equals(
+      distribution.operatorsFeeBasisPoints,
+      getFeeRelativeToTotalFee(CURATED_MODULE_MODULE_FEE),
+      'node operators fee'
+    )
   })
 })


### PR DESCRIPTION
To keep backward compatibility `Lido.getFeeDistribution` must return fee values relative to the total protocol fee (result of `Lido.getFee()`. Before the fix it returned absolute values the same way as `StakingRouter.getStakingFeeAggregateDistributionE4Precision()` does