### PR TITLE
Fix: stake limit resume handling

### DIFF
--- a/contracts/0.4.24/lib/StakeLimitUtils.sol
+++ b/contracts/0.4.24/lib/StakeLimitUtils.sol
@@ -40,10 +40,10 @@ library StakeLimitState {
       * @dev Internal representation struct (slot-wide)
       */
     struct Data {
-        uint32 prevStakeBlockNumber;
-        uint96 prevStakeLimit;
-        uint32 maxStakeLimitGrowthBlocks;
-        uint96 maxStakeLimit;
+        uint32 prevStakeBlockNumber;      // block number of the previous stake submit
+        uint96 prevStakeLimit;            // limit value (<= `maxStakeLimit`) obtained on the previous stake submit
+        uint32 maxStakeLimitGrowthBlocks; // limit regeneration speed expressed in blocks
+        uint96 maxStakeLimit;             // maximum limit value
     }
 }
 
@@ -151,7 +151,7 @@ library StakeLimitUtils {
             _data.prevStakeBlockNumber == 0 ||
             // staking was unlimited or
             _data.maxStakeLimit == 0 ||
-            // new limit is lower than the previous
+            // new maximum limit value is lower than the value obtained on the previous stake submit
             _maxStakeLimit < _data.prevStakeLimit
         ) {
             _data.prevStakeLimit = uint96(_maxStakeLimit);

--- a/contracts/0.4.24/lib/StakeLimitUtils.sol
+++ b/contracts/0.4.24/lib/StakeLimitUtils.sol
@@ -145,13 +145,19 @@ library StakeLimitUtils {
             "TOO_SMALL_LIMIT_INCREASE"
         );
 
-        // if staking was paused or unlimited previously,
-        // or new limit is lower than previous, then
-        // reset prev stake limit to the new max stake limit
-        if ((_data.maxStakeLimit == 0) || (_maxStakeLimit < _data.prevStakeLimit)) {
+        // reset prev stake limit to the new max stake limit if
+        if (
+            // staking was paused or
+            _data.prevStakeBlockNumber == 0 ||
+            // staking was unlimited or
+            _data.maxStakeLimit == 0 ||
+            // new limit is lower than the previous
+            _maxStakeLimit < _data.prevStakeLimit
+        ) {
             _data.prevStakeLimit = uint96(_maxStakeLimit);
         }
-        _data.maxStakeLimitGrowthBlocks = _stakeLimitIncreasePerBlock != 0 ? uint32(_maxStakeLimit / _stakeLimitIncreasePerBlock) : 0;
+        _data.maxStakeLimitGrowthBlocks =
+            _stakeLimitIncreasePerBlock != 0 ? uint32(_maxStakeLimit / _stakeLimitIncreasePerBlock) : 0;
 
         _data.maxStakeLimit = uint96(_maxStakeLimit);
 

--- a/contracts/0.4.24/test_helpers/StakeLimitUtilsMock.sol
+++ b/contracts/0.4.24/test_helpers/StakeLimitUtilsMock.sol
@@ -67,13 +67,16 @@ contract StakeLimitUtilsMock {
         return STAKING_STATE_POSITION.getStorageStakeLimitStruct().isStakingLimitSet();
     }
 
-    function setStakingLimit(uint256 _slotValue, uint256 _maxStakeLimit, uint256 _stakeLimitIncreasePerBlock) public view {
+    function setStakingLimit(
+        uint256 _slotValue, uint256 _maxStakeLimit, uint256 _stakeLimitIncreasePerBlock
+    ) public view returns (uint256) {
         STAKING_STATE_POSITION.setStorageUint256(_slotValue);
         STAKING_STATE_POSITION.setStorageStakeLimitStruct(
             STAKING_STATE_POSITION.getStorageStakeLimitStruct().setStakingLimit(
                 _maxStakeLimit, _stakeLimitIncreasePerBlock
             )
         );
+        return STAKING_STATE_POSITION.getStorageUint256();
     }
 
     function removeStakingLimit(uint256 _slotValue) public view returns(uint256) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/961317/228948908-6ada8fca-bc2f-435e-a8b4-4252c2b5873d.png)

---

Test cases are in [`test/0.4.24/staking-limit.test.js`](https://github.com/lidofinance/lido-dao/blob/59b0476fef2c89a09e3b7cca264923eb6f9635b9/test/0.4.24/staking-limit.test.js#L244-L286)