### PR TITLE
transfer events order

### DIFF
--- a/contracts/0.4.24/Lido.sol
+++ b/contracts/0.4.24/Lido.sol
@@ -947,14 +947,6 @@ contract Lido is Versioned, StETHPermit, AragonApp {
     }
 
     /**
-     * @dev Emits {Transfer} and {TransferShares} events where `from` is 0 address. Indicates mint events.
-     */
-    function _emitTransferAfterMintingShares(address _to, uint256 _sharesAmount) internal {
-        emit Transfer(address(0), _to, getPooledEthByShares(_sharesAmount));
-        emit TransferShares(address(0), _to, _sharesAmount);
-    }
-
-    /**
      * @dev Staking router rewards distribution.
      *
      * Corresponds to the return value of `IStakingRouter.newTotalPooledEtherForRewards()`

--- a/contracts/0.4.24/Lido.sol
+++ b/contracts/0.4.24/Lido.sol
@@ -1400,9 +1400,9 @@ contract Lido is Versioned, StETHPermit, AragonApp {
             // if protocol is empty bootstrap it with the contract's balance
             // address(0xdead) is a holder for initial shares
             _setBufferedEther(balance);
-            _mintShares(INITIAL_TOKEN_HOLDER, balance);
+            // emitting `Submitted` before Transfer events to preserver events order in tx
             emit Submitted(INITIAL_TOKEN_HOLDER, balance, 0);
-            _emitTransferAfterMintingShares(INITIAL_TOKEN_HOLDER, balance);
+            _mintInitialShares(balance);
         }
     }
 }

--- a/contracts/0.4.24/Lido.sol
+++ b/contracts/0.4.24/Lido.sol
@@ -1381,8 +1381,7 @@ contract Lido is Versioned, StETHPermit, AragonApp {
         return getLidoLocator().treasury();
     }
 
-
-     /**
+    /**
      * @notice Mints shares on behalf of 0xdead address,
      * the shares amount is equal to the contract's balance.     *
      *

--- a/contracts/0.4.24/Lido.sol
+++ b/contracts/0.4.24/Lido.sol
@@ -342,6 +342,7 @@ contract Lido is Versioned, StETHPermit, AragonApp {
      */
     function resumeStaking() external {
         _auth(STAKING_CONTROL_ROLE);
+        require(hasInitialized(), "NOT_INITIALIZED");
 
         _resumeStaking();
     }

--- a/contracts/0.4.24/StETH.sol
+++ b/contracts/0.4.24/StETH.sol
@@ -517,4 +517,12 @@ contract StETH is IERC20, Pausable {
     function _emitTransferAfterMintingShares(address _to, uint256 _sharesAmount) internal {
         _emitTransferEvents(address(0), _to, getPooledEthByShares(_sharesAmount), _sharesAmount);
     }
+
+    /**
+     * @dev Mints shares to INITIAL_TOKEN_HOLDER
+     */
+    function _mintInitialShares(uint256 _sharesAmount) internal {
+        _mintShares(INITIAL_TOKEN_HOLDER, _sharesAmount);
+        _emitTransferAfterMintingShares(INITIAL_TOKEN_HOLDER, _sharesAmount);
+    }
 }

--- a/contracts/0.4.24/StETH.sol
+++ b/contracts/0.4.24/StETH.sol
@@ -331,9 +331,8 @@ contract StETH is IERC20, Pausable {
      */
     function transferShares(address _recipient, uint256 _sharesAmount) external returns (uint256) {
         _transferShares(msg.sender, _recipient, _sharesAmount);
-        emit TransferShares(msg.sender, _recipient, _sharesAmount);
         uint256 tokensAmount = getPooledEthByShares(_sharesAmount);
-        emit Transfer(msg.sender, _recipient, tokensAmount);
+        _emitTransferEvents(msg.sender, _recipient, tokensAmount, _sharesAmount);
         return tokensAmount;
     }
 
@@ -362,8 +361,7 @@ contract StETH is IERC20, Pausable {
 
         _transferShares(_sender, _recipient, _sharesAmount);
         _approve(_sender, msg.sender, currentAllowance.sub(tokensAmount));
-        emit TransferShares(_sender, _recipient, _sharesAmount);
-        emit Transfer(_sender, _recipient, tokensAmount);
+        _emitTransferEvents(_sender, _recipient, tokensAmount,  _sharesAmount);
         return tokensAmount;
     }
 
@@ -382,8 +380,7 @@ contract StETH is IERC20, Pausable {
     function _transfer(address _sender, address _recipient, uint256 _amount) internal {
         uint256 _sharesToTransfer = getSharesByPooledEth(_amount);
         _transferShares(_sender, _recipient, _sharesToTransfer);
-        emit Transfer(_sender, _recipient, _amount);
-        emit TransferShares(_sender, _recipient, _sharesToTransfer);
+        _emitTransferEvents(_sender, _recipient, _amount, _sharesToTransfer);
     }
 
     /**
@@ -504,5 +501,20 @@ contract StETH is IERC20, Pausable {
         // but we cannot reflect this as it would require sending an unbounded number of events.
 
         // We're emitting `SharesBurnt` event to provide an explicit rebase log record nonetheless.
+    }
+
+     /**
+     * @dev Emits {Transfer} and {TransferShares} events
+     */
+     function _emitTransferEvents(address _from, address _to, uint _amount, uint256 _sharesAmount) internal {
+        emit Transfer(_from, _to, _amount);
+        emit TransferShares(_from, _to, _sharesAmount);
+    }
+
+     /**
+     * @dev Emits {Transfer} and {TransferShares} events where `from` is 0 address. Indicates mint events.
+     */
+    function _emitTransferAfterMintingShares(address _to, uint256 _sharesAmount) internal {
+        _emitTransferEvents(address(0), _to, getPooledEthByShares(_sharesAmount), _sharesAmount);
     }
 }

--- a/contracts/0.4.24/StETH.sol
+++ b/contracts/0.4.24/StETH.sol
@@ -506,8 +506,8 @@ contract StETH is IERC20, Pausable {
     /**
      * @dev Emits {Transfer} and {TransferShares} events
      */
-     function _emitTransferEvents(address _from, address _to, uint _amount, uint256 _sharesAmount) internal {
-        emit Transfer(_from, _to, _amount);
+    function _emitTransferEvents(address _from, address _to, uint _tokenAmount, uint256 _sharesAmount) internal {
+        emit Transfer(_from, _to, _tokenAmount);
         emit TransferShares(_from, _to, _sharesAmount);
     }
 

--- a/contracts/0.4.24/StETH.sol
+++ b/contracts/0.4.24/StETH.sol
@@ -505,33 +505,4 @@ contract StETH is IERC20, Pausable {
 
         // We're emitting `SharesBurnt` event to provide an explicit rebase log record nonetheless.
     }
-
-    /**
-     * @notice Mints shares on behalf of 0xdead address,
-     * the shares amount is equal to the contract's balance.     *
-     *
-     * Allows to get rid of zero checks for `totalShares` and `totalPooledEther`
-     * and overcome corner cases.
-     *
-     * NB: reverts if the current contract's balance is zero.
-     *
-     * @dev must be invoked before using the token
-     */
-    function _bootstrapInitialHolder() internal returns (uint256) {
-        uint256 balance = address(this).balance;
-        assert(balance != 0);
-
-        if (_getTotalShares() == 0) {
-            // if protocol is empty bootstrap it with the contract's balance
-            // address(0xdead) is a holder for initial shares
-            _mintShares(INITIAL_TOKEN_HOLDER, balance);
-
-            emit Transfer(0x0, INITIAL_TOKEN_HOLDER, balance);
-            emit TransferShares(0x0, INITIAL_TOKEN_HOLDER, balance);
-
-            return balance;
-        }
-
-        return 0;
-    }
 }

--- a/contracts/0.4.24/StETH.sol
+++ b/contracts/0.4.24/StETH.sol
@@ -361,7 +361,7 @@ contract StETH is IERC20, Pausable {
 
         _transferShares(_sender, _recipient, _sharesAmount);
         _approve(_sender, msg.sender, currentAllowance.sub(tokensAmount));
-        _emitTransferEvents(_sender, _recipient, tokensAmount,  _sharesAmount);
+        _emitTransferEvents(_sender, _recipient, tokensAmount, _sharesAmount);
         return tokensAmount;
     }
 
@@ -503,7 +503,7 @@ contract StETH is IERC20, Pausable {
         // We're emitting `SharesBurnt` event to provide an explicit rebase log record nonetheless.
     }
 
-     /**
+    /**
      * @dev Emits {Transfer} and {TransferShares} events
      */
      function _emitTransferEvents(address _from, address _to, uint _amount, uint256 _sharesAmount) internal {
@@ -511,7 +511,7 @@ contract StETH is IERC20, Pausable {
         emit TransferShares(_from, _to, _sharesAmount);
     }
 
-     /**
+    /**
      * @dev Emits {Transfer} and {TransferShares} events where `from` is 0 address. Indicates mint events.
      */
     function _emitTransferAfterMintingShares(address _to, uint256 _sharesAmount) internal {

--- a/contracts/0.4.24/test_helpers/StETHMock.sol
+++ b/contracts/0.4.24/test_helpers/StETHMock.sol
@@ -14,7 +14,14 @@ contract StETHMock is StETH {
 
     constructor() public payable{
         _resume();
-        _bootstrapInitialHolder();
+        // _bootstrapInitialHolder
+        uint256 balance = address(this).balance;
+        assert(balance != 0);
+
+        // address(0xdead) is a holder for initial shares
+        setTotalPooledEther(balance);
+        _mintShares(INITIAL_TOKEN_HOLDER, balance);
+        _emitTransferAfterMintingShares(INITIAL_TOKEN_HOLDER, balance);
     }
 
     function _getTotalPooledEther() internal view returns (uint256) {
@@ -46,10 +53,5 @@ contract StETHMock is StETH {
 
     function burnShares(address _account, uint256 _sharesAmount) public returns (uint256 newTotalShares) {
         return _burnShares(_account, _sharesAmount);
-    }
-
-    function _emitTransferAfterMintingShares(address _to, uint256 _sharesAmount) internal {
-        emit Transfer(address(0), _to, getPooledEthByShares(_sharesAmount));
-        emit TransferShares(address(0), _to, _sharesAmount);
     }
 }

--- a/contracts/0.4.24/test_helpers/StETHMock.sol
+++ b/contracts/0.4.24/test_helpers/StETHMock.sol
@@ -20,8 +20,7 @@ contract StETHMock is StETH {
 
         // address(0xdead) is a holder for initial shares
         setTotalPooledEther(balance);
-        _mintShares(INITIAL_TOKEN_HOLDER, balance);
-        _emitTransferAfterMintingShares(INITIAL_TOKEN_HOLDER, balance);
+        _mintInitialShares(balance);
     }
 
     function _getTotalPooledEther() internal view returns (uint256) {


### PR DESCRIPTION
- fix transfer events order (for subgraph)
- check `hasInitialized` on `resume`
- refactor bootstrap initial holder