### PR TITLE
Make BatchMetadataUpdate touch more requests for further convenience

### DIFF
--- a/contracts/0.8.9/WithdrawalQueueERC721.sol
+++ b/contracts/0.8.9/WithdrawalQueueERC721.sol
@@ -150,11 +150,13 @@ contract WithdrawalQueueERC721 is IERC721Metadata, IERC4906, WithdrawalQueue {
         _checkResumed();
         _checkRole(FINALIZE_ROLE, msg.sender);
 
+        uint256 firstFinalizedRequestId = getLastFinalizedRequestId() + 1;
+
         _finalize(_lastRequestIdToBeFinalized, msg.value, _maxShareRate);
 
         // ERC4906 metadata update event
         // We are updating all unfinalized to make it look different as they move closer to finalization in the future
-        emit BatchMetadataUpdate(getLastFinalizedRequestId() + 1, getLastRequestId());
+        emit BatchMetadataUpdate(firstFinalizedRequestId, getLastRequestId());
     }
 
     /// @dev See {IERC721-balanceOf}.

--- a/contracts/0.8.9/WithdrawalQueueERC721.sol
+++ b/contracts/0.8.9/WithdrawalQueueERC721.sol
@@ -153,7 +153,8 @@ contract WithdrawalQueueERC721 is IERC721Metadata, IERC4906, WithdrawalQueue {
         _finalize(_lastRequestIdToBeFinalized, msg.value, _maxShareRate);
 
         // ERC4906 metadata update event
-        emit BatchMetadataUpdate(getLastFinalizedRequestId() + 1, _lastRequestIdToBeFinalized);
+        // We are updating all unfinalized to make it look different as they move closer to finalization in the future
+        emit BatchMetadataUpdate(getLastFinalizedRequestId() + 1, getLastRequestId());
     }
 
     /// @dev See {IERC721-balanceOf}.


### PR DESCRIPTION
Probably, in the future we can use changing the NFT as it moves along the queue.
So, we want to update metadata not only for final requests but for all that in the queue.