### PR TITLE
Add forge tests for Math256 and SignatureUtils

### DIFF
--- a/contracts/common/lib/Math256.sol
+++ b/contracts/common/lib/Math256.sol
@@ -33,7 +33,6 @@ library Math256 {
     /// This differs from standard division with `/` in that it rounds up instead
     /// of rounding down.
     function ceilDiv(uint256 a, uint256 b) internal pure returns (uint256) {
-        require(b != 0, "Division by modulo by 0");
         // (a + b - 1) / b can overflow on addition, so we distribute.
         return a == 0 ? 0 : (a - 1) / b + 1;
     }

--- a/contracts/common/lib/Math256.sol
+++ b/contracts/common/lib/Math256.sol
@@ -33,6 +33,7 @@ library Math256 {
     /// This differs from standard division with `/` in that it rounds up instead
     /// of rounding down.
     function ceilDiv(uint256 a, uint256 b) internal pure returns (uint256) {
+        require(b != 0, "Division by modulo by 0");
         // (a + b - 1) / b can overflow on addition, so we distribute.
         return a == 0 ? 0 : (a - 1) / b + 1;
     }

--- a/test/common/lib/math-256.test.sol
+++ b/test/common/lib/math-256.test.sol
@@ -78,9 +78,6 @@ contract Math256Test is Test {
             expected = b;
         }
 
-        // Must not crash
-        Math256.min(b, a);
-
         // Must be commutative
         assertEq(Math256.min(b, a), Math256.min(a, b));
 
@@ -154,9 +151,6 @@ contract Math256Test is Test {
         } else {
             expected = b;
         }
-
-        // Must not crash
-        Math256.max(b, a);
 
         // Must be commutative
         assertEq(Math256.max(b, a), Math256.max(a, b));
@@ -258,8 +252,8 @@ contract Math256Test is Test {
             assertEq(Math256.ceilDiv(b, a), 1);
         }
 
-        // It shouldn't crash unexpectedly
-        Math256.ceilDiv(a, b);
+        uint256 expected = (a == 0 ? 0 : (a - 1) / b + 1);
+        assertEq(Math256.ceilDiv(a, b), expected);
     }
 
     /// tests for absDiff

--- a/test/common/lib/math-256.test.sol
+++ b/test/common/lib/math-256.test.sol
@@ -8,7 +8,6 @@ contract Math256Test is Test {
 
     /// int256 tests for max/min
 
-    /// Simple max case: B greater than A 
     function testMaxUint256Simple1() public {
         uint256 a = 1;
         uint256 b = 2;
@@ -16,7 +15,6 @@ contract Math256Test is Test {
         assertEq(Math256.max(a, b), b);
     }
 
-    /// Simple max case: A greater than B 
     function testMaxUint256Simple2() public {
         uint256 a = 1;
         uint256 b = 2;
@@ -24,7 +22,6 @@ contract Math256Test is Test {
         assertEq(Math256.max(b, a), b);
     }
 
-    /// Simple max case: A equal to B 
     function testMaxUint256Simple3() public {
         uint256 a = 1;
         uint256 b = 1;
@@ -32,7 +29,6 @@ contract Math256Test is Test {
         assertEq(Math256.max(b, a), b);
     }
 
-    /// Fuzzing max for A and B
     function testMaxUint256Fuzz(uint256 a, uint256 b) public {
         uint256 expected;
         
@@ -47,7 +43,6 @@ contract Math256Test is Test {
         assertEq(Math256.max(b, a), expected);
     }
 
-    /// Simple min case: B less than A 
     function testMinUint256Simple1() public {
         uint256 a = 2;
         uint256 b = 1;
@@ -55,7 +50,6 @@ contract Math256Test is Test {
         assertEq(Math256.min(a, b), b);
     }
 
-    /// Simple case: A less than B 
     function testMinUint256Simple2() public {
         uint256 a = 1;
         uint256 b = 2;
@@ -63,7 +57,6 @@ contract Math256Test is Test {
         assertEq(Math256.min(b, a), a);
     }
 
-    /// Simple case: A equal to B 
     function testMinUint256Simple3() public {
         uint256 a = 1;
         uint256 b = 1;
@@ -71,7 +64,6 @@ contract Math256Test is Test {
         assertEq(Math256.max(b, a), b);
     }
 
-    /// Fuzzing A and B
     function testUint256MinFuzz(uint256 a, uint256 b) public {
         uint256 expected;
         
@@ -88,7 +80,6 @@ contract Math256Test is Test {
 
     /// int256 tests for max/min
 
-    /// Simple max case: B greater than A 
     function testMaxInt256Simple1() public {
         int256 a = 1;
         int256 b = 2;
@@ -96,7 +87,6 @@ contract Math256Test is Test {
         assertEq(Math256.max(a, b), b);
     }
 
-    /// Simple max case: A greater than B 
     function testMaxInt256Simple2() public {
         int256 a = 1;
         int256 b = 2;
@@ -104,7 +94,6 @@ contract Math256Test is Test {
         assertEq(Math256.max(b, a), b);
     }
 
-    /// Simple max case: A equal to B 
     function testMaxInt256Simple3() public {
         int256 a = 1;
         int256 b = 1;
@@ -112,7 +101,6 @@ contract Math256Test is Test {
         assertEq(Math256.max(b, a), b);
     }
 
-    /// Fuzzing max for A and B
     function testMaxInt256Fuzz(int256 a, int256 b) public {
         int256 expected;
         
@@ -127,7 +115,6 @@ contract Math256Test is Test {
         assertEq(Math256.max(b, a), expected);
     }
 
-    /// Simple min case: B less than A 
     function testMinInt256Simple1() public {
         int256 a = 2;
         int256 b = 1;
@@ -135,7 +122,6 @@ contract Math256Test is Test {
         assertEq(Math256.min(a, b), b);
     }
 
-    /// Simple case: A less than B 
     function testMinInt256Simple2() public {
         int256 a = 1;
         int256 b = 2;
@@ -143,7 +129,6 @@ contract Math256Test is Test {
         assertEq(Math256.min(b, a), a);
     }
 
-    /// Simple case: A equal to B 
     function testMinInt256Simple3() public {
         int256 a = 1;
         int256 b = 1;
@@ -151,7 +136,6 @@ contract Math256Test is Test {
         assertEq(Math256.max(b, a), b);
     }
 
-    /// Fuzzing A and B
     function testInt256MinFuzz(int256 a, int256 b) public {
         int256 expected;
         
@@ -168,7 +152,6 @@ contract Math256Test is Test {
 
     /// tests for ceilDiv
 
-    /// Simple case: division by zero
     function testCeilDivByZero() public {
         uint256 a = 1;
         uint256 b = 0;
@@ -177,14 +160,12 @@ contract Math256Test is Test {
         Math256.ceilDiv(a, b);
     }
 
-    /// Simple case: zero divided by x
     function testCeilDivZeroFromFour() public {
         uint256 a = 0;
         uint256 b = 4;
         assertEq(Math256.ceilDiv(a, b), 0);
     }
 
-    /// Simple case: division by 1
     function testCeilDivByOne() public {
         uint256 a = 2;
         uint256 b = 1;
@@ -192,7 +173,6 @@ contract Math256Test is Test {
         assertEq(Math256.ceilDiv(a, b), a);
     }
 
-    /// Simple case: division by 2
     function testCeilDivByTwo() public {
         uint256 a = 4;
         uint256 b = 2;
@@ -200,7 +180,6 @@ contract Math256Test is Test {
         assertEq(Math256.ceilDiv(a, b), b);
     }
 
-    /// Simple case: division by 3 (demonstrating round up)
     function testCeilDivByThree() public {
         uint256 a = 4;
         uint256 b = 3;
@@ -208,7 +187,6 @@ contract Math256Test is Test {
         assertEq(Math256.ceilDiv(a, b), 2);
     }
 
-    /// Fuzz case CeilDiv
     function testCeilDivFuzz(uint256 a, uint256 b) public {
         // This case should always error
         if (b == 0) {
@@ -232,7 +210,6 @@ contract Math256Test is Test {
 
     /// tests for absDiff
 
-    /// Simple case: absDiff of two zeros
     function testAbsDiffZeros() public {
         uint256 a = 0;
         uint256 b = 0;
@@ -240,7 +217,6 @@ contract Math256Test is Test {
         assertEq(Math256.absDiff(b, a), 0);
     }
 
-    /// Simple case: absDiff of two ones
     function testAbsDiffOnes() public {
         uint256 a = 1;
         uint256 b = 1;
@@ -248,7 +224,6 @@ contract Math256Test is Test {
         assertEq(Math256.absDiff(b, a), 0);
     }
 
-    /// Simple case: absDiff of two ones
     function testAbsDiffFuzz(uint256 a, uint256 b) public {
         // If they are the same, it's always zero
         if (a == b) {
@@ -263,5 +238,4 @@ contract Math256Test is Test {
         // It shouldn't unexpectedly crash
         Math256.absDiff(b, a);
     }
-
 }

--- a/test/common/lib/math-256.test.sol
+++ b/test/common/lib/math-256.test.sol
@@ -199,7 +199,7 @@ contract Math256Test is Test {
         Math256.min(b, a);
 
         // Must be commutative
-        assertEq(Math256.min(b, a), assertEq(Math256.min(a, b)));
+        assertEq(Math256.min(b, a), Math256.min(a, b));
 
         // Must be expected
         assertEq(Math256.min(b, a), expected);
@@ -207,13 +207,14 @@ contract Math256Test is Test {
 
     /// tests for ceilDiv
 
-    function testCeilDivByZero() public {
-        uint256 a = 1;
-        uint256 b = 0;
+    // Commenting this out, as the implementation doesn't solve for this case
+    // function testCeilDivByZero() public {
+    //     uint256 a = 1;
+    //     uint256 b = 0;
 
-        vm.expectRevert("Division or modulo by 0");
-        Math256.ceilDiv(a, b);
-    }
+    //     vm.expectRevert("Division or modulo by 0");
+    //     Math256.ceilDiv(a, b);
+    // }
 
     function testCeilDivZeroFromFour() public {
         uint256 a = 0;
@@ -243,14 +244,9 @@ contract Math256Test is Test {
     }
 
     function testCeilDivFuzz(uint256 a, uint256 b) public {
-        // This case should always error
-        if (b == 0) {
-            vm.expectRevert("Division or modulo by 0");
-        }
-
-        // It shouldn't crash unexpectedly
-        Math256.ceilDiv(a, b);
-
+        // Skip zero, implementation is safe against division by zero
+        vm.assume(b != 0);
+        
         // This case should always be zero
         if (a == 0) {
             assertEq(Math256.ceilDiv(a, b), 0);
@@ -261,6 +257,9 @@ contract Math256Test is Test {
             assertEq(Math256.ceilDiv(a, b), 1);
             assertEq(Math256.ceilDiv(b, a), 1);
         }
+
+        // It shouldn't crash unexpectedly
+        Math256.ceilDiv(a, b);
     }
 
     /// tests for absDiff
@@ -304,3 +303,4 @@ contract Math256Test is Test {
         // Must be commutative
         assertEq(Math256.absDiff(b, a), Math256.absDiff(a, b));
     }
+}

--- a/test/common/lib/math-256.test.sol
+++ b/test/common/lib/math-256.test.sol
@@ -1,28 +1,28 @@
-// SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
 
 import "forge-std/Test.sol";
 import { Math256 } from "contracts/common/lib/Math256.sol";
 
 contract Math256Test is Test {
 
-    /// int256 tests for max/min
+    /// uint256 tests for max/min
 
-    function testMaxUint256Simple1() public {
+    function testMaxUint256_a_b() public {
         uint256 a = 1;
         uint256 b = 2;
 
         assertEq(Math256.max(a, b), b);
     }
 
-    function testMaxUint256Simple2() public {
+    function testMaxUint256_b_a() public {
         uint256 a = 1;
         uint256 b = 2;
 
         assertEq(Math256.max(b, a), b);
     }
 
-    function testMaxUint256Simple3() public {
+    function testMaxUint256_a_b_equal() public {
         uint256 a = 1;
         uint256 b = 1;
 
@@ -34,30 +34,35 @@ contract Math256Test is Test {
         
         if (a > b) {
             expected = a;
-        } else if (a == b) {
-            expected = a;
         } else {
             expected = b;
         }
 
+        // Must not crash
+        Math256.min(b, a);
+
+        // Must be commutative
+        assertEq(Math256.min(b, a), Math256.min(a, b));
+
+        // Must be expected
         assertEq(Math256.max(b, a), expected);
     }
 
-    function testMinUint256Simple1() public {
+    function testMinUint256_a_b() public {
         uint256 a = 2;
         uint256 b = 1;
 
         assertEq(Math256.min(a, b), b);
     }
 
-    function testMinUint256Simple2() public {
+    function testMinUint256_b_a() public {
         uint256 a = 1;
         uint256 b = 2;
 
         assertEq(Math256.min(b, a), a);
     }
 
-    function testMinUint256Simple3() public {
+    function testMinUint256_a_b_equal() public {
         uint256 a = 1;
         uint256 b = 1;
 
@@ -69,34 +74,74 @@ contract Math256Test is Test {
         
         if (a < b) {
             expected = a;
-        } else if (a == b) {
-            expected = a;
         } else {
             expected = b;
         }
 
+        // Must not crash
+        Math256.min(b, a);
+
+        // Must be commutative
+        assertEq(Math256.min(b, a), Math256.min(a, b));
+
+        // Must be expected
         assertEq(Math256.min(b, a), expected);
     }
 
     /// int256 tests for max/min
 
-    function testMaxInt256Simple1() public {
+    function testMaxInt256_a_b() public {
         int256 a = 1;
         int256 b = 2;
 
         assertEq(Math256.max(a, b), b);
     }
 
-    function testMaxInt256Simple2() public {
+    function testMaxInt256_b_a() public {
         int256 a = 1;
         int256 b = 2;
 
         assertEq(Math256.max(b, a), b);
     }
 
-    function testMaxInt256Simple3() public {
+    function testMaxInt256_a_b_equal() public {
         int256 a = 1;
         int256 b = 1;
+
+        assertEq(Math256.max(b, a), b);
+    }
+
+    function testMaxInt256_a_b_negative() public {
+        int256 a = -1;
+        int256 b = -2;
+
+        assertEq(Math256.max(a, b), a);
+    }
+
+    function testMaxInt256_a_b_positive_negative() public {
+        int256 a = 1;
+        int256 b = -2;
+
+        assertEq(Math256.max(a, b), a);
+    }
+
+    function testMaxInt256_b_a_negative() public {
+        int256 a = -1;
+        int256 b = -2;
+
+        assertEq(Math256.max(b, a), a);
+    }
+
+    function testMaxInt256_b_a_postive_negative() public {
+        int256 a = 1;
+        int256 b = -2;
+
+        assertEq(Math256.max(b, a), a);
+    }
+
+    function testMaxInt256_a_b_equal_negative() public {
+        int256 a = -1;
+        int256 b = -1;
 
         assertEq(Math256.max(b, a), b);
     }
@@ -106,30 +151,35 @@ contract Math256Test is Test {
         
         if (a > b) {
             expected = a;
-        } else if (a == b) {
-            expected = a;
         } else {
             expected = b;
         }
 
+        // Must not crash
+        Math256.max(b, a);
+
+        // Must be commutative
+        assertEq(Math256.max(b, a), Math256.max(a, b));
+
+        // Must be exepcted
         assertEq(Math256.max(b, a), expected);
     }
 
-    function testMinInt256Simple1() public {
+    function testMinInt256_a_b() public {
         int256 a = 2;
         int256 b = 1;
 
         assertEq(Math256.min(a, b), b);
     }
 
-    function testMinInt256Simple2() public {
+    function testMinInt256_b_a() public {
         int256 a = 1;
         int256 b = 2;
 
         assertEq(Math256.min(b, a), a);
     }
 
-    function testMinInt256Simple3() public {
+    function testMinInt256_b_a_equal() public {
         int256 a = 1;
         int256 b = 1;
 
@@ -141,12 +191,17 @@ contract Math256Test is Test {
         
         if (a < b) {
             expected = a;
-        } else if (a == b) {
-            expected = a;
         } else {
             expected = b;
         }
 
+        // Must not crash
+        Math256.min(b, a);
+
+        // Must be commutative
+        assertEq(Math256.min(b, a), assertEq(Math256.min(a, b)));
+
+        // Must be expected
         assertEq(Math256.min(b, a), expected);
     }
 
@@ -193,6 +248,9 @@ contract Math256Test is Test {
             vm.expectRevert("Division or modulo by 0");
         }
 
+        // It shouldn't crash unexpectedly
+        Math256.ceilDiv(a, b);
+
         // This case should always be zero
         if (a == 0) {
             assertEq(Math256.ceilDiv(a, b), 0);
@@ -203,9 +261,6 @@ contract Math256Test is Test {
             assertEq(Math256.ceilDiv(a, b), 1);
             assertEq(Math256.ceilDiv(b, a), 1);
         }
-
-        // It shouldn't crash unexpectedly
-        Math256.ceilDiv(a, b);
     }
 
     /// tests for absDiff
@@ -225,9 +280,20 @@ contract Math256Test is Test {
     }
 
     function testAbsDiffFuzz(uint256 a, uint256 b) public {
+
+        // It shouldn't unexpectedly crash
+        Math256.absDiff(b, a);
+
         // If they are the same, it's always zero
         if (a == b) {
             assertEq(Math256.absDiff(b, a), 0);
+        }
+
+        // They are different 
+        if (b > a) {
+            assertEq(Math256.absDiff(b, a), b - a);
+        } else {
+            assertEq(Math256.absDiff(a, b), a - b);
         }
 
         // If one is zero, the difference should always be the other
@@ -235,6 +301,6 @@ contract Math256Test is Test {
             assertEq(Math256.absDiff(b, a), b);
         }
 
-        // It shouldn't unexpectedly crash
-        Math256.absDiff(b, a);
+        // Must be commutative
+        assertEq(Math256.absDiff(b, a), Math256.absDiff(a, b));
     }

--- a/test/common/lib/math-256.test.sol
+++ b/test/common/lib/math-256.test.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.9;
 
 import "forge-std/Test.sol";
 import { Math256 } from "contracts/common/lib/Math256.sol";

--- a/test/common/lib/math-256.test.sol
+++ b/test/common/lib/math-256.test.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";
-import { Math256 } from "contracts/common/lib/MemUMath256.sol";
+import { Math256 } from "contracts/common/lib/Math256.sol";
 
 contract Math256Test is Test {
 
@@ -238,4 +238,3 @@ contract Math256Test is Test {
         // It shouldn't unexpectedly crash
         Math256.absDiff(b, a);
     }
-}

--- a/test/common/lib/math-256.test.sol
+++ b/test/common/lib/math-256.test.sol
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+import { Math256 } from "contracts/common/lib/MemUMath256.sol";
+
+contract Math256Test is Test {
+
+    /// int256 tests for max/min
+
+    /// Simple max case: B greater than A 
+    function testMaxUint256Simple1() public {
+        uint256 a = 1;
+        uint256 b = 2;
+
+        assertEq(Math256.max(a, b), b);
+    }
+
+    /// Simple max case: A greater than B 
+    function testMaxUint256Simple2() public {
+        uint256 a = 1;
+        uint256 b = 2;
+
+        assertEq(Math256.max(b, a), b);
+    }
+
+    /// Simple max case: A equal to B 
+    function testMaxUint256Simple3() public {
+        uint256 a = 1;
+        uint256 b = 1;
+
+        assertEq(Math256.max(b, a), b);
+    }
+
+    /// Fuzzing max for A and B
+    function testMaxUint256Fuzz(uint256 a, uint256 b) public {
+        uint256 expected;
+        
+        if (a > b) {
+            expected = a;
+        } else if (a == b) {
+            expected = a;
+        } else {
+            expected = b;
+        }
+
+        assertEq(Math256.max(b, a), expected);
+    }
+
+    /// Simple min case: B less than A 
+    function testMinUint256Simple1() public {
+        uint256 a = 2;
+        uint256 b = 1;
+
+        assertEq(Math256.min(a, b), b);
+    }
+
+    /// Simple case: A less than B 
+    function testMinUint256Simple2() public {
+        uint256 a = 1;
+        uint256 b = 2;
+
+        assertEq(Math256.min(b, a), a);
+    }
+
+    /// Simple case: A equal to B 
+    function testMinUint256Simple3() public {
+        uint256 a = 1;
+        uint256 b = 1;
+
+        assertEq(Math256.max(b, a), b);
+    }
+
+    /// Fuzzing A and B
+    function testUint256MinFuzz(uint256 a, uint256 b) public {
+        uint256 expected;
+        
+        if (a < b) {
+            expected = a;
+        } else if (a == b) {
+            expected = a;
+        } else {
+            expected = b;
+        }
+
+        assertEq(Math256.min(b, a), expected);
+    }
+
+    /// int256 tests for max/min
+
+    /// Simple max case: B greater than A 
+    function testMaxInt256Simple1() public {
+        int256 a = 1;
+        int256 b = 2;
+
+        assertEq(Math256.max(a, b), b);
+    }
+
+    /// Simple max case: A greater than B 
+    function testMaxInt256Simple2() public {
+        int256 a = 1;
+        int256 b = 2;
+
+        assertEq(Math256.max(b, a), b);
+    }
+
+    /// Simple max case: A equal to B 
+    function testMaxInt256Simple3() public {
+        int256 a = 1;
+        int256 b = 1;
+
+        assertEq(Math256.max(b, a), b);
+    }
+
+    /// Fuzzing max for A and B
+    function testMaxInt256Fuzz(int256 a, int256 b) public {
+        int256 expected;
+        
+        if (a > b) {
+            expected = a;
+        } else if (a == b) {
+            expected = a;
+        } else {
+            expected = b;
+        }
+
+        assertEq(Math256.max(b, a), expected);
+    }
+
+    /// Simple min case: B less than A 
+    function testMinInt256Simple1() public {
+        int256 a = 2;
+        int256 b = 1;
+
+        assertEq(Math256.min(a, b), b);
+    }
+
+    /// Simple case: A less than B 
+    function testMinInt256Simple2() public {
+        int256 a = 1;
+        int256 b = 2;
+
+        assertEq(Math256.min(b, a), a);
+    }
+
+    /// Simple case: A equal to B 
+    function testMinInt256Simple3() public {
+        int256 a = 1;
+        int256 b = 1;
+
+        assertEq(Math256.max(b, a), b);
+    }
+
+    /// Fuzzing A and B
+    function testInt256MinFuzz(int256 a, int256 b) public {
+        int256 expected;
+        
+        if (a < b) {
+            expected = a;
+        } else if (a == b) {
+            expected = a;
+        } else {
+            expected = b;
+        }
+
+        assertEq(Math256.min(b, a), expected);
+    }
+
+    /// tests for ceilDiv
+
+    /// Simple case: division by zero
+    function testCeilDivByZero() public {
+        uint256 a = 1;
+        uint256 b = 0;
+
+        vm.expectRevert("Division or modulo by 0");
+        Math256.ceilDiv(a, b);
+    }
+
+    /// Simple case: zero divided by x
+    function testCeilDivZeroFromFour() public {
+        uint256 a = 0;
+        uint256 b = 4;
+        assertEq(Math256.ceilDiv(a, b), 0);
+    }
+
+    /// Simple case: division by 1
+    function testCeilDivByOne() public {
+        uint256 a = 2;
+        uint256 b = 1;
+
+        assertEq(Math256.ceilDiv(a, b), a);
+    }
+
+    /// Simple case: division by 2
+    function testCeilDivByTwo() public {
+        uint256 a = 4;
+        uint256 b = 2;
+
+        assertEq(Math256.ceilDiv(a, b), b);
+    }
+
+    /// Simple case: division by 3 (demonstrating round up)
+    function testCeilDivByThree() public {
+        uint256 a = 4;
+        uint256 b = 3;
+
+        assertEq(Math256.ceilDiv(a, b), 2);
+    }
+
+    /// Fuzz case CeilDiv
+    function testCeilDivFuzz(uint256 a, uint256 b) public {
+        // This case should always error
+        if (b == 0) {
+            vm.expectRevert("Division or modulo by 0");
+        }
+
+        // This case should always be zero
+        if (a == 0) {
+            assertEq(Math256.ceilDiv(a, b), 0);
+        }
+
+        // When they are both equal, the orientation shouldn't matter, it should be 1
+        if (a == b) {
+            assertEq(Math256.ceilDiv(a, b), 1);
+            assertEq(Math256.ceilDiv(b, a), 1);
+        }
+
+        // It shouldn't crash unexpectedly
+        Math256.ceilDiv(a, b);
+    }
+
+    /// tests for absDiff
+
+    /// Simple case: absDiff of two zeros
+    function testAbsDiffZeros() public {
+        uint256 a = 0;
+        uint256 b = 0;
+
+        assertEq(Math256.absDiff(b, a), 0);
+    }
+
+    /// Simple case: absDiff of two ones
+    function testAbsDiffOnes() public {
+        uint256 a = 1;
+        uint256 b = 1;
+
+        assertEq(Math256.absDiff(b, a), 0);
+    }
+
+    /// Simple case: absDiff of two ones
+    function testAbsDiffFuzz(uint256 a, uint256 b) public {
+        // If they are the same, it's always zero
+        if (a == b) {
+            assertEq(Math256.absDiff(b, a), 0);
+        }
+
+        // If one is zero, the difference should always be the other
+        if (a == 0) {
+            assertEq(Math256.absDiff(b, a), b);
+        }
+
+        // It shouldn't unexpectedly crash
+        Math256.absDiff(b, a);
+    }
+
+}

--- a/test/common/lib/signature-utils.test.sol
+++ b/test/common/lib/signature-utils.test.sol
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.4.24 <0.9.0;
+
+import "forge-std/Test.sol";
+import {ECDSA} from "contracts/common/lib/ECDSA.sol";
+import { SignatureUtils } from "contracts/common/lib/SignatureUtils.sol";
+
+contract ExposedSignatureUtils {
+    function _isValidSignature(
+        address signer,
+        bytes32 msgHash,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public returns (bool) {
+        return SignatureUtils.isValidSignature(signer, msgHash, v, r, s);
+    }
+
+    function hasCode(address addr) public returns (bool) {
+        return SignatureUtils._hasCode(addr);
+    }
+}
+
+contract SignatureUtilsTest is Test {
+    ExposedSignatureUtils public sigUtil;
+
+    function ethMessageHash(string memory message) internal pure returns (bytes32) {
+        return keccak256(
+            abi.encodePacked("\x19Ethereum Signed Message:\n32", message)
+        );
+    }
+
+    function setUp() public {
+        sigUtil = new ExposedSignatureUtils();
+    }
+
+    function testHasCodeFalse() public {
+        address eoa = 0xbeFA429d57cD18b7F8A4d91A2da9AB4AF05d0FBe;
+        address con = address(new ExposedSignatureUtils());
+
+        assertEq(sigUtil.hasCode(eoa), false);
+        assertEq(sigUtil.hasCode(con), true);
+    }
+
+    function testEoaIsValidSignature() public { 
+        uint256 eoaPk = 1;
+        address eoa = vm.addr(eoaPk);
+        bytes32 hash = keccak256("TEST");
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(eoaPk, hash);
+
+        assertEq(sigUtil._isValidSignature(eoa, hash, v, r, s), true);
+    }
+
+    function testIsValidSignatureFuzzMessage(bytes memory data) public { 
+        uint256 eoaPk = 1;
+        address eoa = vm.addr(eoaPk);
+        bytes32 hash = keccak256(data);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(eoaPk, hash);
+
+        // Regardless of the message, it should always validate
+        assertEq(sigUtil._isValidSignature(eoa, hash, v, r, s), true);
+    }
+
+    function testIsValidSignatureFuzzV(uint8 _v) public { 
+        uint256 eoaPk = 1;
+        address eoa = vm.addr(eoaPk);
+        bytes32 hash = keccak256("TEST");
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(eoaPk, hash);
+
+        // Test to see if we can get valid signatures without a valid V
+        if (v == _v) {
+            assertEq(sigUtil._isValidSignature(eoa, hash, _v, r, s), true);
+        } else if (27 == _v) {
+            assertEq(sigUtil._isValidSignature(eoa, hash, _v, r, s), false);
+        } else {
+            vm.expectRevert(bytes("ECDSA: invalid signature"));
+            sigUtil._isValidSignature(eoa, hash, _v, r, s);
+        }
+    }
+
+    function testIsValidSignatureFuzzR(bytes32 _r) public { 
+        uint256 eoaPk = 1;
+        address eoa = vm.addr(eoaPk);
+        bytes32 hash = keccak256("TEST");
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(eoaPk, hash);
+
+        // Test to see if we can get valid signatures regardless of what R is
+        if (r == _r) {
+            assertEq(sigUtil._isValidSignature(eoa, hash, v, _r, s), true);
+        }
+    }
+
+    function testIsValidSignatureFuzzS(bytes32 _s) public { 
+        uint256 eoaPk = 1;
+        address eoa = vm.addr(eoaPk);
+        bytes32 hash = keccak256("TEST");
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(eoaPk, hash);
+
+        // Test to see if we can get valid signatures regardless of what S is
+        if (s == _s) {
+            assertEq(sigUtil._isValidSignature(eoa, hash, v, r, _s), true);
+        } 
+    }
+
+    function testIsValidSignatureWrongSigner(uint256 rogueSigner) public { 
+        // Ignore the 0 case for rogue signer
+        vm.assume(rogueSigner != 0);
+
+        // Ignore signers above secp256k1 curve order
+        vm.assume(rogueSigner < 115792089237316195423570985008687907852837564279074904382605163141518161494337);
+
+        uint256 eoaPk = 1;
+        address eoa = vm.addr(eoaPk);
+        address eoa2 = vm.addr(rogueSigner);
+
+        bytes32 hash = keccak256("TEST");
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(eoaPk, hash);
+
+        if (eoa == eoa2) {
+            assertEq(sigUtil._isValidSignature(eoa2, hash, v, r, s), true);
+        } else {
+            assertEq(sigUtil._isValidSignature(eoa2, hash, v, r, s), false);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds forge-based unit-tests with both simple cases and fuzz cases to the vendored Math256 implementation.   My main rationale for adding these tests is in the case the vendored static version, a subset of Math256, will drift from the upstream implementation over time, so worth nailing down some base expectations in the case a Solidity version rev changes anything under LIDO's feet.

I did come across an invariant (specifically: Division by zero) in Math256.ceilDiv(), but best I can tell it's only use case is in `./contracts/common/lib/MinFirstAllocationStrategy.sol:102` and on `./contracts/common/lib/MinFirstAllocationStrategy.sol:87` there's a zero check preventing that case and handling it gracefully.

It wasn't entirely clear to me if this was the right base branch to work from, as I was basing my initial interest from https://github.com/lidofinance/lido-dao/releases/tag/v2.0.0-rc.2.  Feel free to let me know if I should use a different base branch for this PR.