### PR TITLE
Add check against underflow

### DIFF
--- a/contracts/0.8.9/test_helpers/AccountingOracleMock.sol
+++ b/contracts/0.8.9/test_helpers/AccountingOracleMock.sol
@@ -22,6 +22,7 @@ contract AccountingOracleMock {
         AccountingOracle.ReportData calldata data,
         uint256 /* contractVersion */
     ) external {
+        require(data.refSlot >= _lastRefSlot, "refSlot less than _lastRefSlot");
         uint256 slotsElapsed = data.refSlot - _lastRefSlot;
         _lastRefSlot = data.refSlot;
 


### PR DESCRIPTION
This adds a simple check on AccountingOracleMock.sol to avoid it underflowing.

This is just the mock, so not live implementation risk here.