### PR TITLE
fix: added permissions for deauthorize

### DIFF
--- a/contracts/0.8.25/vaults/Dashboard.sol
+++ b/contracts/0.8.25/vaults/Dashboard.sol
@@ -480,6 +480,13 @@ contract Dashboard is Permissions {
         _triggerValidatorWithdrawal(_pubkeys, _amounts, _refundRecipient);
     }
 
+    /**
+     * @notice Deauthorizes the Lido Vault Hub from managing the staking vault.
+     */
+    function deauthorizeLidoVaultHub() external {
+        _deauthorizeLidoVaultHub();
+    }
+
     // ==================== Internal Functions ====================
 
     /**

--- a/contracts/0.8.25/vaults/Permissions.sol
+++ b/contracts/0.8.25/vaults/Permissions.sol
@@ -88,6 +88,12 @@ abstract contract Permissions is AccessControlConfirmable {
     bytes32 public constant PDG_WITHDRAWAL_ROLE = keccak256("vaults.Permissions.PDGWithdrawal");
 
     /**
+     * @dev Permission for deauthorizing Lido VaultHub from the StakingVault.
+     */
+    bytes32 public constant LIDO_VAULTHUB_DEAUTHORIZATION_ROLE =
+        keccak256("vaults.Permissions.LidoVaultHubDeauthorization");
+
+    /**
      * @notice Permission for assets recovery
      */
     bytes32 public constant ASSET_RECOVERY_ROLE = keccak256("vaults.Permissions.AssetRecovery");
@@ -282,6 +288,13 @@ abstract contract Permissions is AccessControlConfirmable {
      */
     function _transferStakingVaultOwnership(address _newOwner) internal onlyConfirmed(_confirmingRoles()) {
         OwnableUpgradeable(address(stakingVault())).transferOwnership(_newOwner);
+    }
+
+    /**
+     * @dev Checks the LIDO_VAULTHUB_DEAUTHORIZATION_ROLE and deauthorizes Lido VaultHub from the StakingVault.
+     */
+    function _deauthorizeLidoVaultHub() internal onlyRole(LIDO_VAULTHUB_DEAUTHORIZATION_ROLE) {
+        stakingVault().deauthorizeLidoVaultHub();
     }
 
     /**

--- a/contracts/0.8.25/vaults/StakingVault.sol
+++ b/contracts/0.8.25/vaults/StakingVault.sol
@@ -40,11 +40,13 @@ import {IStakingVault, StakingVaultDeposit} from "./interfaces/IStakingVault.sol
  *   - `fund()`
  *   - `withdraw()`
  *   - `rebalance()`
+ *   - `lock()`
  *   - `pauseBeaconChainDeposits()`
  *   - `resumeBeaconChainDeposits()`
  *   - `requestValidatorExit()`
  *   - `triggerValidatorWithdrawal()`
  *   - `authorizeLidoVaultHub()`
+ *   - `deauthorizeLidoVaultHub()`
  *   - `ossifyStakingVault()`
  *   - `setDepositor()`
  *   - `resetLocked()`
@@ -53,11 +55,9 @@ import {IStakingVault, StakingVaultDeposit} from "./interfaces/IStakingVault.sol
  * - Depositor:
  *   - `depositToBeaconChain()`
  * - VaultHub:
- *   - `lock()`
  *   - `report()`
  *   - `rebalance()`
  *   - `triggerValidatorWithdrawal()`
- *   - `deauthorizeLidoVaultHub()`
  * - Anyone:
  *   - Can send ETH directly to the vault (treated as rewards)
  *
@@ -222,11 +222,15 @@ contract StakingVault is IStakingVault, OwnableUpgradeable {
 
     /**
      * @notice Deauthorizes the `VaultHub` from the vault
-     * @dev Can only be called by the VaultHub
+     * @dev Can only be called by the owner
      * @dev Reverts if vaultHub is already deauthorized
      */
-    function deauthorizeLidoVaultHub() external {
-        if (msg.sender != address(VAULT_HUB)) revert NotAuthorized("deauthorizeLidoVaultHub", msg.sender);
+    function deauthorizeLidoVaultHub() external onlyOwner {
+        VaultHub.VaultSocket memory socket = VaultHub(VAULT_HUB).vaultSocket(address(this));
+        if (socket.vault != address(0)) {
+            revert VaultConnected();
+        }
+
         ERC7201Storage storage $ = _getStorage();
         if (!$.vaultHubAuthorized) revert VaultHubNotAuthorized();
 
@@ -442,7 +446,7 @@ contract StakingVault is IStakingVault, OwnableUpgradeable {
         if (_ether > valuation_) revert RebalanceAmountExceedsValuation(valuation_, _ether);
 
         ERC7201Storage storage $ = _getStorage();
-        if (owner() == msg.sender || (valuation_ < $.locked && msg.sender == address(VAULT_HUB))) {
+        if (owner() == msg.sender || (valuation_ < $.locked && msg.sender == address(VAULT_HUB) && $.vaultHubAuthorized)) {
             $.inOutDelta -= int128(int256(_ether));
 
             emit Withdrawn(msg.sender, address(VAULT_HUB), _ether);
@@ -461,7 +465,7 @@ contract StakingVault is IStakingVault, OwnableUpgradeable {
      */
     function report(uint256 _valuation, int256 _inOutDelta, uint256 _locked) external {
         ERC7201Storage storage $ = _getStorage();
-        if (msg.sender != address(VAULT_HUB)) revert NotAuthorized("report", msg.sender);
+        if (msg.sender != address(VAULT_HUB) || !$.vaultHubAuthorized) revert NotAuthorized("report", msg.sender);
 
         $.report.valuation = uint128(_valuation);
         $.report.inOutDelta = int128(_inOutDelta);
@@ -614,7 +618,7 @@ contract StakingVault is IStakingVault, OwnableUpgradeable {
 
         bool isAuthorized = (msg.sender == $.nodeOperator ||
             msg.sender == owner() ||
-            (isValuationBelowLocked && msg.sender == address(VAULT_HUB))
+            (isValuationBelowLocked && msg.sender == address(VAULT_HUB) && $.vaultHubAuthorized)
         );
 
 
@@ -851,4 +855,9 @@ contract StakingVault is IStakingVault, OwnableUpgradeable {
      * @param depositor Address of the depositor
      */
     error InvalidDepositor(address depositor);
+
+    /**
+     * @notice Thrown when the vault is connected to VaultHub
+     */
+    error VaultConnected();
 }

--- a/contracts/0.8.25/vaults/StakingVault.sol
+++ b/contracts/0.8.25/vaults/StakingVault.sol
@@ -224,6 +224,7 @@ contract StakingVault is IStakingVault, OwnableUpgradeable {
      * @notice Deauthorizes the `VaultHub` from the vault
      * @dev Can only be called by the owner
      * @dev Reverts if vaultHub is already deauthorized
+     * @dev Reverts if vault is already connected to VaultHub
      */
     function deauthorizeLidoVaultHub() external onlyOwner {
         VaultHub.VaultSocket memory socket = VaultHub(VAULT_HUB).vaultSocket(address(this));

--- a/contracts/0.8.25/vaults/VaultFactory.sol
+++ b/contracts/0.8.25/vaults/VaultFactory.sol
@@ -29,6 +29,7 @@ struct DelegationConfig {
     address[] validatorExitRequesters;
     address[] validatorWithdrawalTriggerers;
     address[] disconnecters;
+    address[] lidoVaultHubDeauthorizers;
     address[] nodeOperatorFeeClaimers;
 }
 
@@ -124,6 +125,9 @@ contract VaultFactory {
         }
         for (uint256 i = 0; i < _delegationConfig.disconnecters.length; i++) {
             delegation.grantRole(delegation.VOLUNTARY_DISCONNECT_ROLE(), _delegationConfig.disconnecters[i]);
+        }
+        for (uint256 i = 0; i < _delegationConfig.lidoVaultHubDeauthorizers.length; i++) {
+            delegation.grantRole(delegation.LIDO_VAULTHUB_DEAUTHORIZATION_ROLE(), _delegationConfig.lidoVaultHubDeauthorizers[i]);
         }
         for (uint256 i = 0; i < _delegationConfig.nodeOperatorFeeClaimers.length; i++) {
             delegation.grantRole(

--- a/contracts/0.8.25/vaults/VaultHub.sol
+++ b/contracts/0.8.25/vaults/VaultHub.sol
@@ -599,9 +599,6 @@ contract VaultHub is PausableUntilWithRoles {
         for (uint256 i = 1; i < length; i++) {
             VaultSocket memory socket = $.sockets[i];
             if (socket.pendingDisconnect) {
-                // deauthorize vaultHub from the vault
-                IStakingVault(socket.vault).deauthorizeLidoVaultHub();
-
                 // remove disconnected vault from the list
                 VaultSocket memory lastSocket = $.sockets[length - 1];
                 $.sockets[i] = lastSocket;

--- a/lib/protocol/helpers/vaults.ts
+++ b/lib/protocol/helpers/vaults.ts
@@ -29,6 +29,7 @@ export type VaultRoles = {
   validatorExitRequester: HardhatEthersSigner;
   validatorWithdrawalTriggerer: HardhatEthersSigner;
   disconnecter: HardhatEthersSigner;
+  lidoVaultHubDeauthorizer: HardhatEthersSigner;
   nodeOperatorFeeClaimer: HardhatEthersSigner;
 };
 
@@ -62,7 +63,7 @@ export async function createVaultWithDelegation(
   fee = VAULT_NODE_OPERATOR_FEE,
   confirmExpiry = DEFAULT_CONFIRM_EXPIRY,
 ): Promise<VaultWithDelegation> {
-  const defaultRoles = await getRandomSigners(13);
+  const defaultRoles = await getRandomSigners(14);
 
   const [
     assetRecoverer,
@@ -77,6 +78,7 @@ export async function createVaultWithDelegation(
     validatorExitRequester,
     validatorWithdrawalTriggerer,
     disconnecter,
+    lidoVaultHubDeauthorizer,
     nodeOperatorFeeClaimer,
   ] = defaultRoles;
 
@@ -93,6 +95,7 @@ export async function createVaultWithDelegation(
     validatorExitRequester: rolesOverrides.validatorExitRequester ?? validatorExitRequester,
     validatorWithdrawalTriggerer: rolesOverrides.validatorWithdrawalTriggerer ?? validatorWithdrawalTriggerer,
     disconnecter: rolesOverrides.disconnecter ?? disconnecter,
+    lidoVaultHubDeauthorizer: rolesOverrides.lidoVaultHubDeauthorizer ?? lidoVaultHubDeauthorizer,
     nodeOperatorFeeClaimer: rolesOverrides.nodeOperatorFeeClaimer ?? nodeOperatorFeeClaimer,
   };
 
@@ -114,6 +117,7 @@ export async function createVaultWithDelegation(
       validatorExitRequesters: [roles.validatorExitRequester],
       validatorWithdrawalTriggerers: [roles.validatorWithdrawalTriggerer],
       disconnecters: [roles.disconnecter],
+      lidoVaultHubDeauthorizers: [roles.lidoVaultHubDeauthorizer],
       nodeOperatorFeeClaimers: [roles.nodeOperatorFeeClaimer],
     },
     "0x",

--- a/test/0.8.25/vaults/delegation/delegation.test.ts
+++ b/test/0.8.25/vaults/delegation/delegation.test.ts
@@ -37,6 +37,7 @@ describe("Delegation.sol", () => {
   let validatorExitRequester: HardhatEthersSigner;
   let validatorWithdrawalTriggerer: HardhatEthersSigner;
   let disconnecter: HardhatEthersSigner;
+  let lidoVaultHubDeauthorizer: HardhatEthersSigner;
   let nodeOperatorManager: HardhatEthersSigner;
   let nodeOperatorFeeClaimer: HardhatEthersSigner;
   let vaultDepositor: HardhatEthersSigner;
@@ -75,6 +76,7 @@ describe("Delegation.sol", () => {
       validatorExitRequester,
       validatorWithdrawalTriggerer,
       disconnecter,
+      lidoVaultHubDeauthorizer,
       nodeOperatorManager,
       nodeOperatorFeeClaimer,
       stranger,
@@ -124,6 +126,7 @@ describe("Delegation.sol", () => {
         validatorExitRequesters: [validatorExitRequester],
         validatorWithdrawalTriggerers: [validatorWithdrawalTriggerer],
         disconnecters: [disconnecter],
+        lidoVaultHubDeauthorizers: [lidoVaultHubDeauthorizer],
         nodeOperatorFeeClaimers: [nodeOperatorFeeClaimer],
       },
       "0x",

--- a/test/0.8.25/vaults/staking-vault/contracts/VaultHub__MockForStakingVault.sol
+++ b/test/0.8.25/vaults/staking-vault/contracts/VaultHub__MockForStakingVault.sol
@@ -3,8 +3,12 @@
 
 pragma solidity ^0.8.0;
 
+import {VaultHub} from "contracts/0.8.25/vaults/VaultHub.sol";
+
 contract VaultHub__MockForStakingVault {
     address public immutable LIDO_LOCATOR;
+
+    mapping(address => VaultHub.VaultSocket) public sockets;
 
     constructor(address _lidoLocator) {
         LIDO_LOCATOR = _lidoLocator;
@@ -14,5 +18,21 @@ contract VaultHub__MockForStakingVault {
 
     function rebalance() external payable {
         emit Mock__Rebalanced(msg.sender, msg.value);
+    }
+
+    function addVaultSocket(address vault) external {
+        sockets[vault] = VaultHub.VaultSocket({
+            vault: vault,
+            sharesMinted: 0,
+            shareLimit: 0,
+            reserveRatioBP: 0,
+            rebalanceThresholdBP: 0,
+            treasuryFeeBP: 0,
+            pendingDisconnect: false
+        });
+    }
+
+    function vaultSocket(address vault) external view returns (VaultHub.VaultSocket memory) {
+        return sockets[vault];
     }
 }

--- a/test/0.8.25/vaults/staking-vault/stakingVault.test.ts
+++ b/test/0.8.25/vaults/staking-vault/stakingVault.test.ts
@@ -34,6 +34,7 @@ const MAX_INT128 = 2n ** 127n - 1n;
 
 const PUBLIC_KEY_LENGTH = 48;
 const SAMPLE_PUBKEY = "0x" + "ab".repeat(48);
+const INVALID_PUBKEY = "0x" + "ab".repeat(47);
 
 const getPubkeys = (num: number): { pubkeys: string[]; stringified: string } => {
   const pubkeys = Array.from({ length: num }, (_, i) => {
@@ -201,7 +202,7 @@ describe("StakingVault.sol", () => {
     });
 
     it("works on deauthorized vault", async () => {
-      await stakingVault.connect(vaultHubSigner).deauthorizeLidoVaultHub();
+      await stakingVault.deauthorizeLidoVaultHub();
       await stakingVault.resetLocked();
       expect(await stakingVault.locked()).to.equal(0n);
     });
@@ -268,41 +269,47 @@ describe("StakingVault.sol", () => {
     });
 
     it("reverts on isOssified", async () => {
-      await stakingVault.connect(vaultHubSigner).deauthorizeLidoVaultHub();
+      await stakingVault.deauthorizeLidoVaultHub();
       await stakingVault.ossifyStakingVault();
       await expect(stakingVault.authorizeLidoVaultHub()).to.revertedWithCustomError(stakingVault, "VaultIsOssified");
     });
 
     it("reverts if depositor is not Lido Predeposit Guarantee", async () => {
-      await stakingVault.connect(vaultHubSigner).deauthorizeLidoVaultHub();
+      await stakingVault.deauthorizeLidoVaultHub();
       await stakingVault.setDepositor(stranger);
 
       await expect(stakingVault.authorizeLidoVaultHub()).to.revertedWithCustomError(stakingVault, "InvalidDepositor");
     });
 
     it("authorize works on deauthorized vault", async () => {
-      await stakingVault.connect(vaultHubSigner).deauthorizeLidoVaultHub();
+      await stakingVault.deauthorizeLidoVaultHub();
       await expect(stakingVault.authorizeLidoVaultHub()).to.emit(stakingVault, "VaultHubAuthorizedSet").withArgs(true);
     });
   });
 
   context("deauthorizeLidoVaultHub", () => {
     it("reverts on unauthorized", async () => {
-      await expect(stakingVault.connect(stranger).deauthorizeLidoVaultHub())
-        .to.revertedWithCustomError(stakingVault, "NotAuthorized")
-        .withArgs("deauthorizeLidoVaultHub", stranger);
+      await expect(stakingVault.connect(stranger).deauthorizeLidoVaultHub()).to.revertedWithCustomError(
+        stakingVault,
+        "OwnableUnauthorizedAccount",
+      );
     });
 
     it("reverts on VaultHubNotAuthorized", async () => {
-      await stakingVault.connect(vaultHubSigner).deauthorizeLidoVaultHub();
-      await expect(stakingVault.connect(vaultHubSigner).deauthorizeLidoVaultHub()).to.revertedWithCustomError(
+      await stakingVault.deauthorizeLidoVaultHub();
+      await expect(stakingVault.deauthorizeLidoVaultHub()).to.revertedWithCustomError(
         stakingVault,
         "VaultHubNotAuthorized",
       );
     });
 
+    it("reverts if vault connected to VaultHub", async () => {
+      await vaultHub.addVaultSocket(stakingVault);
+      await expect(stakingVault.deauthorizeLidoVaultHub()).to.revertedWithCustomError(stakingVault, "VaultConnected");
+    });
+
     it("deauthorize works", async () => {
-      await expect(stakingVault.connect(vaultHubSigner).deauthorizeLidoVaultHub())
+      await expect(stakingVault.deauthorizeLidoVaultHub())
         .to.emit(stakingVault, "VaultHubAuthorizedSet")
         .withArgs(false);
 
@@ -324,13 +331,13 @@ describe("StakingVault.sol", () => {
     });
 
     it("reverts on already ossified", async () => {
-      await stakingVault.connect(vaultHubSigner).deauthorizeLidoVaultHub();
+      await stakingVault.deauthorizeLidoVaultHub();
       await stakingVault.ossifyStakingVault();
       await expect(stakingVault.ossifyStakingVault()).to.revertedWithCustomError(stakingVault, "AlreadyOssified");
     });
 
     it("ossify works on deauthorized vault", async () => {
-      await stakingVault.connect(vaultHubSigner).deauthorizeLidoVaultHub();
+      await stakingVault.deauthorizeLidoVaultHub();
       await expect(stakingVault.ossifyStakingVault()).to.emit(stakingVault, "PinnedImplementationUpdated");
     });
   });
@@ -360,7 +367,7 @@ describe("StakingVault.sol", () => {
     });
 
     it("setDepositor works", async () => {
-      await stakingVault.connect(vaultHubSigner).deauthorizeLidoVaultHub();
+      await stakingVault.deauthorizeLidoVaultHub();
 
       await expect(stakingVault.connect(vaultOwner).setDepositor(stranger))
         .to.emit(stakingVault, "DepositorSet")
@@ -602,6 +609,29 @@ describe("StakingVault.sol", () => {
         .withArgs("rebalance", stranger);
     });
 
+    it("not reverts if the caller is vaultHub, but vaultHub is authorized", async () => {
+      await stakingVault.fund({ value: ether("2") });
+
+      expect(await stakingVault.vaultHubAuthorized()).to.equal(true);
+
+      await expect(stakingVault.rebalance(ether("1")))
+        .to.emit(stakingVault, "Withdrawn")
+        .withArgs(vaultOwnerAddress, vaultHubAddress, ether("1"))
+        .to.emit(vaultHub, "Mock__Rebalanced")
+        .withArgs(stakingVaultAddress, ether("1"));
+    });
+
+    it("reverts if the caller is vaultHub, but vaultHub is deauthorized", async () => {
+      await stakingVault.fund({ value: ether("2") });
+
+      await stakingVault.deauthorizeLidoVaultHub();
+      expect(await stakingVault.vaultHubAuthorized()).to.equal(false);
+
+      await expect(stakingVault.connect(vaultHubSigner).rebalance(ether("1")))
+        .to.be.revertedWithCustomError(stakingVault, "NotAuthorized")
+        .withArgs("rebalance", vaultHubSigner);
+    });
+
     it("can be called by the owner", async () => {
       await stakingVault.fund({ value: ether("2") });
       const inOutDeltaBefore = await stakingVault.inOutDelta();
@@ -635,6 +665,15 @@ describe("StakingVault.sol", () => {
       await expect(stakingVault.connect(stranger).report(ether("1"), ether("2"), ether("3")))
         .to.be.revertedWithCustomError(stakingVault, "NotAuthorized")
         .withArgs("report", stranger);
+    });
+
+    it("reverts if the caller is the vault hub, but vaultHub is deauthorized", async () => {
+      await stakingVault.deauthorizeLidoVaultHub();
+      expect(await stakingVault.vaultHubAuthorized()).to.equal(false);
+
+      await expect(stakingVault.connect(vaultHubSigner).report(ether("1"), ether("2"), ether("3")))
+        .to.be.revertedWithCustomError(stakingVault, "NotAuthorized")
+        .withArgs("report", vaultHubSigner);
     });
 
     it("updates the state and emits the Reported event", async () => {
@@ -837,9 +876,10 @@ describe("StakingVault.sol", () => {
     });
 
     it("reverts if the length of the pubkeys is not a multiple of 48", async () => {
-      await expect(
-        stakingVault.connect(vaultOwner).requestValidatorExit("0x" + "ab".repeat(47)),
-      ).to.be.revertedWithCustomError(stakingVault, "InvalidPubkeysLength");
+      await expect(stakingVault.connect(vaultOwner).requestValidatorExit(INVALID_PUBKEY)).to.be.revertedWithCustomError(
+        stakingVault,
+        "InvalidPubkeysLength",
+      );
     });
 
     it("emits the `ValidatorExitRequested` event for a single validator key", async () => {
@@ -893,6 +933,14 @@ describe("StakingVault.sol", () => {
       )
         .to.be.revertedWithCustomError(stakingVault, "ZeroArgument")
         .withArgs("_amounts");
+    });
+
+    it("reverts if the invalid pubkey is provided", async () => {
+      await expect(
+        stakingVault
+          .connect(vaultOwner)
+          .triggerValidatorWithdrawal(INVALID_PUBKEY, [ether("1")], vaultOwnerAddress, { value: 1n }),
+      ).to.be.revertedWithCustomError(stakingVault, "InvalidPubkeysLength");
     });
 
     it("reverts if called by a non-owner or the node operator", async () => {
@@ -1091,6 +1139,22 @@ describe("StakingVault.sol", () => {
       )
         .to.emit(withdrawalRequestContract, "RequestAdded__Mock")
         .withArgs(encodeEip7002Input(SAMPLE_PUBKEY, 0n), baseFee);
+    });
+
+    it("requests a validator withdrawal if called by the vault hub, when vaultHub is deauthorized", async () => {
+      await stakingVault.fund({ value: ether("1") });
+      await stakingVault.connect(vaultHubSigner).report(ether("0.9"), ether("1"), ether("1.1")); // slashing
+
+      await stakingVault.deauthorizeLidoVaultHub();
+      expect(await stakingVault.vaultHubAuthorized()).to.equal(false);
+
+      await expect(
+        stakingVault
+          .connect(vaultHubSigner)
+          .triggerValidatorWithdrawal(SAMPLE_PUBKEY, [0n], vaultOwnerAddress, { value: 1n }),
+      )
+        .to.be.revertedWithCustomError(stakingVault, "NotAuthorized")
+        .withArgs("triggerValidatorWithdrawal", vaultHubSigner);
     });
   });
 });

--- a/test/0.8.25/vaults/vaultFactory.test.ts
+++ b/test/0.8.25/vaults/vaultFactory.test.ts
@@ -137,6 +137,7 @@ describe("VaultFactory.sol", () => {
       validatorExitRequesters: [await vaultOwner1.getAddress()],
       validatorWithdrawalTriggerers: [await vaultOwner1.getAddress()],
       disconnecters: [await vaultOwner1.getAddress()],
+      lidoVaultHubDeauthorizers: [await vaultOwner1.getAddress()],
       assetRecoverer: await vaultOwner1.getAddress(),
     };
   });

--- a/test/0.8.25/vaults/vaulthub/vaulthub.detach.test.ts
+++ b/test/0.8.25/vaults/vaulthub/vaulthub.detach.test.ts
@@ -27,6 +27,11 @@ import { createVaultProxy, days, ether, impersonate } from "lib";
 import { deployLidoLocator } from "test/deploy";
 import { Snapshot, VAULTS_RELATIVE_SHARE_LIMIT_BP } from "test/suite";
 
+const SHARE_LIMIT = ether("1");
+const RESERVE_RATIO_BP = 10_00n;
+const RESERVE_RATIO_THRESHOLD_BP = 8_00n;
+const TREASURY_FEE_BP = 5_00n;
+
 describe("VaultHub.sol:deauthorize", () => {
   let deployer: HardhatEthersSigner;
   let admin: HardhatEthersSigner;
@@ -135,6 +140,7 @@ describe("VaultHub.sol:deauthorize", () => {
       validatorExitRequesters: [await vaultOwner1.getAddress()],
       validatorWithdrawalTriggerers: [await vaultOwner1.getAddress()],
       disconnecters: [await vaultOwner1.getAddress()],
+      lidoVaultHubDeauthorizers: [await vaultOwner1.getAddress()],
       nodeOperatorFeeClaimers: [await operator.getAddress()],
     };
   });
@@ -142,6 +148,64 @@ describe("VaultHub.sol:deauthorize", () => {
   beforeEach(async () => (originalState = await Snapshot.take()));
 
   afterEach(async () => await Snapshot.restore(originalState));
+
+  context("deauthorization flow", () => {
+    it("authorize=on, authorize=off", async () => {
+      const { vault, delegation: _delegation } = await createVaultProxy(vaultOwner1, vaultFactory, delegationParams);
+      const delegationSigner = await impersonate(await _delegation.getAddress(), ether("100"));
+
+      expect(await vault.vaultHubAuthorized()).to.equal(true);
+      await vault.connect(delegationSigner).deauthorizeLidoVaultHub();
+      expect(await vault.vaultHubAuthorized()).to.equal(false);
+    });
+
+    it("authorize=on, connect vault, authorize=exception", async () => {
+      const { vault, delegation: _delegation } = await createVaultProxy(vaultOwner1, vaultFactory, delegationParams);
+      const delegationSigner = await impersonate(await _delegation.getAddress(), ether("100"));
+
+      expect(await vault.vaultHubAuthorized()).to.equal(true);
+
+      await vaultHub
+        .connect(admin)
+        .connectVault(vault, SHARE_LIMIT, RESERVE_RATIO_BP, RESERVE_RATIO_THRESHOLD_BP, TREASURY_FEE_BP);
+      await expect(vault.connect(delegationSigner).deauthorizeLidoVaultHub()).to.revertedWithCustomError(
+        vault,
+        "VaultConnected",
+      );
+    });
+
+    it("authorize=on, connect vault, pendingDisonnect, authorize=exception", async () => {
+      const { vault, delegation: _delegation } = await createVaultProxy(vaultOwner1, vaultFactory, delegationParams);
+      const delegationSigner = await impersonate(await _delegation.getAddress(), ether("100"));
+
+      expect(await vault.vaultHubAuthorized()).to.equal(true);
+
+      await vaultHub
+        .connect(admin)
+        .connectVault(vault, SHARE_LIMIT, RESERVE_RATIO_BP, RESERVE_RATIO_THRESHOLD_BP, TREASURY_FEE_BP);
+      await vaultHub.connect(delegationSigner).voluntaryDisconnect(vault);
+      await expect(vault.connect(delegationSigner).deauthorizeLidoVaultHub()).to.revertedWithCustomError(
+        vault,
+        "VaultConnected",
+      );
+    });
+
+    it("authorize=on, connect vault, pendingDisonnect, report, authorize=off", async () => {
+      const { vault, delegation: _delegation } = await createVaultProxy(vaultOwner1, vaultFactory, delegationParams);
+      const delegationSigner = await impersonate(await _delegation.getAddress(), ether("100"));
+      const accountingSigner = await impersonate(await locator.accounting(), ether("100"));
+
+      expect(await vault.vaultHubAuthorized()).to.equal(true);
+
+      await vaultHub
+        .connect(admin)
+        .connectVault(vault, SHARE_LIMIT, RESERVE_RATIO_BP, RESERVE_RATIO_THRESHOLD_BP, TREASURY_FEE_BP);
+      await vaultHub.connect(delegationSigner).voluntaryDisconnect(vault);
+      await vaultHub.connect(accountingSigner).updateVaults([1n], [1n], [1n], [0n]);
+      await vault.connect(delegationSigner).deauthorizeLidoVaultHub();
+      expect(await vault.vaultHubAuthorized()).to.equal(false);
+    });
+  });
 
   context("ossification", () => {
     it("ossify works on deauthorized vault", async () => {
@@ -152,10 +216,9 @@ describe("VaultHub.sol:deauthorize", () => {
       } = await createVaultProxy(vaultOwner1, vaultFactory, delegationParams);
       const { proxy: proxy2 } = await createVaultProxy(vaultOwner2, vaultFactory, delegationParams);
 
-      const vaultHubSigner = await impersonate(await vaultHub.getAddress(), ether("100"));
       const delegationSigner = await impersonate(await _delegation.getAddress(), ether("100"));
 
-      await vault.connect(vaultHubSigner).deauthorizeLidoVaultHub();
+      await vault.connect(delegationSigner).deauthorizeLidoVaultHub();
       await expect(vault.connect(delegationSigner).ossifyStakingVault()).to.emit(vault, "PinnedImplementationUpdated");
 
       const vault1ImplementationAfterOssify = await proxy1.implementation();

--- a/test/integration/vaults/happy-path.integration.ts
+++ b/test/integration/vaults/happy-path.integration.ts
@@ -54,7 +54,6 @@ describe("Scenario: Staking Vaults Happy Path", () => {
   let owner: HardhatEthersSigner;
   let nodeOperator: HardhatEthersSigner;
   let curator: HardhatEthersSigner;
-
   let depositContract: string;
 
   const reserveRatio = 10_00n; // 10% of ETH allocation as reserve
@@ -182,6 +181,7 @@ describe("Scenario: Staking Vaults Happy Path", () => {
         validatorExitRequesters: [curator],
         validatorWithdrawalTriggerers: [curator],
         disconnecters: [curator],
+        lidoVaultHubDeauthorizers: [curator],
         nodeOperatorFeeClaimers: [nodeOperator],
       },
       "0x",

--- a/test/integration/vaults/roles.integration.ts
+++ b/test/integration/vaults/roles.integration.ts
@@ -43,6 +43,7 @@ describe("Integration: Staking Vaults Delegation Roles Initial Setup", () => {
     validatorExitRequesters: HardhatEthersSigner,
     validatorWithdrawalTriggerers: HardhatEthersSigner,
     disconnecters: HardhatEthersSigner,
+    lidoVaultHubDeauthorizers: HardhatEthersSigner,
     nodeOperatorFeeClaimers: HardhatEthersSigner,
     stranger: HardhatEthersSigner;
 
@@ -67,6 +68,7 @@ describe("Integration: Staking Vaults Delegation Roles Initial Setup", () => {
       validatorExitRequesters,
       validatorWithdrawalTriggerers,
       disconnecters,
+      lidoVaultHubDeauthorizers,
       nodeOperatorFeeClaimers,
       stranger,
     ] = allRoles;
@@ -104,6 +106,7 @@ describe("Integration: Staking Vaults Delegation Roles Initial Setup", () => {
           validatorExitRequesters: [validatorExitRequesters],
           validatorWithdrawalTriggerers: [validatorWithdrawalTriggerers],
           disconnecters: [disconnecters],
+          lidoVaultHubDeauthorizers: [lidoVaultHubDeauthorizers],
           nodeOperatorFeeClaimers: [nodeOperatorFeeClaimers],
         },
         "0x",
@@ -498,6 +501,7 @@ describe("Integration: Staking Vaults Delegation Roles Initial Setup", () => {
           validatorExitRequesters: [],
           validatorWithdrawalTriggerers: [],
           disconnecters: [],
+          lidoVaultHubDeauthorizers: [],
           nodeOperatorFeeClaimers: [],
         },
         "0x",


### PR DESCRIPTION
added new role `LIDO_VAULTHUB_DEAUTHORIZATION_ROLE` for deauthorizeLidoVaultHub()

`authorizeLidoVaultHub` and `deauthorizeLidoVaultHub` can onle be called by owner

cannot reauthorize vaulthub if there is connection to vaultHub exist