### PR TITLE
chore: add refslot cache unit tests

### DIFF
--- a/contracts/0.8.25/vaults/lib/RefSlotCache.sol
+++ b/contracts/0.8.25/vaults/lib/RefSlotCache.sol
@@ -75,7 +75,7 @@ library RefSlotCache {
         IHashConsensus _consensus
     ) internal view returns (uint112) {
         (uint256 refSlot, ) = _consensus.getCurrentFrame();
-        if (uint32(refSlot) > _storage.refSlot) {
+        if (uint32(refSlot) != _storage.refSlot) {
             return _storage.value;
         } else {
             return _storage.valueOnRefSlot;
@@ -91,7 +91,7 @@ library RefSlotCache {
         IHashConsensus _consensus
     ) internal view returns (int112) {
         (uint256 refSlot, ) = _consensus.getCurrentFrame();
-        if (uint32(refSlot) > _storage.refSlot) {
+        if (uint32(refSlot) != _storage.refSlot) {
             return _storage.value;
         } else {
             return _storage.valueOnRefSlot;

--- a/test/0.8.25/vaults/refSlotCache/contracts/HashConsensus__Mock.sol
+++ b/test/0.8.25/vaults/refSlotCache/contracts/HashConsensus__Mock.sol
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2025 Lido <info@lido.fi>
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity 0.8.25;
+
+contract HashConsensus__Mock {
+    uint256 private _refSlot;
+
+    constructor(uint256 initialRefSlot) {
+        _refSlot = initialRefSlot;
+    }
+
+    function getCurrentFrame() external view returns (uint256 refSlot, uint256 reportProcessingDeadlineSlot) {
+        return (_refSlot, _refSlot + 100);
+    }
+
+    // Test helper functions
+    function setRefSlot(uint256 refSlot) external {
+        _refSlot = refSlot;
+    }
+}

--- a/test/0.8.25/vaults/refSlotCache/contracts/RefSlotCacheTest.sol
+++ b/test/0.8.25/vaults/refSlotCache/contracts/RefSlotCacheTest.sol
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2025 Lido <info@lido.fi>
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity 0.8.25;
+
+import {RefSlotCache} from "contracts/0.8.25/vaults/lib/RefSlotCache.sol";
+import {IHashConsensus} from "contracts/common/interfaces/IHashConsensus.sol";
+
+contract RefSlotCacheTest {
+    using RefSlotCache for RefSlotCache.Uint112WithRefSlotCache;
+    using RefSlotCache for RefSlotCache.Int112WithRefSlotCache;
+
+    RefSlotCache.Uint112WithRefSlotCache public uintCacheStorage;
+    RefSlotCache.Int112WithRefSlotCache public intCacheStorage;
+
+    IHashConsensus public consensus;
+
+    constructor(IHashConsensus _consensus) {
+        consensus = _consensus;
+    }
+
+    function setConsensus(IHashConsensus _consensus) external {
+        consensus = _consensus;
+    }
+
+    // Uint112 functions
+    function increaseUintValue(uint112 increment) external returns (RefSlotCache.Uint112WithRefSlotCache memory) {
+        RefSlotCache.Uint112WithRefSlotCache memory newStorage = uintCacheStorage.withValueIncrease(
+            consensus,
+            increment
+        );
+        uintCacheStorage = newStorage;
+        return newStorage;
+    }
+
+    function getUintValueForLastRefSlot() external view returns (uint112) {
+        return uintCacheStorage.getValueForLastRefSlot(consensus);
+    }
+
+    function getUintCacheStorage() external view returns (RefSlotCache.Uint112WithRefSlotCache memory) {
+        return uintCacheStorage;
+    }
+
+    function setUintCacheStorage(uint112 value, uint112 valueOnRefSlot, uint32 refSlot) external {
+        uintCacheStorage.value = value;
+        uintCacheStorage.valueOnRefSlot = valueOnRefSlot;
+        uintCacheStorage.refSlot = refSlot;
+    }
+
+    // Int112 functions
+    function increaseIntValue(int112 increment) external returns (RefSlotCache.Int112WithRefSlotCache memory) {
+        RefSlotCache.Int112WithRefSlotCache memory newStorage = intCacheStorage.withValueIncrease(consensus, increment);
+        intCacheStorage = newStorage;
+        return newStorage;
+    }
+
+    function getIntValueForLastRefSlot() external view returns (int112) {
+        return intCacheStorage.getValueForLastRefSlot(consensus);
+    }
+
+    function getIntCacheStorage() external view returns (RefSlotCache.Int112WithRefSlotCache memory) {
+        return intCacheStorage;
+    }
+
+    function setIntCacheStorage(int112 value, int112 valueOnRefSlot, uint32 refSlot) external {
+        intCacheStorage.value = value;
+        intCacheStorage.valueOnRefSlot = valueOnRefSlot;
+        intCacheStorage.refSlot = refSlot;
+    }
+}

--- a/test/0.8.25/vaults/refSlotCache/refSlotCache.test.ts
+++ b/test/0.8.25/vaults/refSlotCache/refSlotCache.test.ts
@@ -148,18 +148,33 @@ describe("RefSlotCache.sol", () => {
       });
 
       it("should return cached value when current refSlot equals cached refSlot", async () => {
-        const firstIncrement = 50n;
+        const increment = 50n;
         const refSlot = 200n;
 
         // Set initial value
         await consensus.setRefSlot(refSlot);
-        await refSlotCacheTest.increaseUintValue(firstIncrement);
-
-        // Change refSlot to trigger caching
-        await consensus.setRefSlot(refSlot + 100n);
+        await refSlotCacheTest.increaseUintValue(increment);
 
         const result = await refSlotCacheTest.getUintValueForLastRefSlot();
-        expect(result).to.equal(firstIncrement);
+        expect(result).to.equal(0n);
+      });
+
+      it("should handle refSlot truncation to uint32", async () => {
+        const increment = 10n;
+        const maxUint32 = 2n ** 32n - 1n;
+        const largeRefSlot = maxUint32 + 100n; // Larger than uint32 max
+
+        await consensus.setRefSlot(maxUint32);
+        await refSlotCacheTest.increaseUintValue(increment);
+
+        let result = await refSlotCacheTest.getUintValueForLastRefSlot();
+        expect(result).to.equal(0n);
+
+        // next refSlot is larger than uint32 max and truncated version is smaller than previous refSlot
+        await consensus.setRefSlot(largeRefSlot);
+
+        result = await refSlotCacheTest.getUintValueForLastRefSlot();
+        expect(result).to.equal(increment);
       });
 
       it("should handle zero cached values correctly", async () => {
@@ -318,18 +333,33 @@ describe("RefSlotCache.sol", () => {
       });
 
       it("should return cached value when current refSlot equals cached refSlot", async () => {
-        const firstIncrement = 50;
+        const increment = 50;
         const refSlot = 200n;
 
         // Set initial value
         await consensus.setRefSlot(refSlot);
-        await refSlotCacheTest.increaseIntValue(firstIncrement);
-
-        // Change refSlot to trigger caching
-        await consensus.setRefSlot(refSlot + 100n);
+        await refSlotCacheTest.increaseIntValue(increment);
 
         const result = await refSlotCacheTest.getIntValueForLastRefSlot();
-        expect(result).to.equal(firstIncrement);
+        expect(result).to.equal(0n);
+      });
+
+      it("should handle refSlot truncation to uint32", async () => {
+        const increment = 10n;
+        const maxUint32 = 2n ** 32n - 1n;
+        const largeRefSlot = maxUint32 + 100n; // Larger than uint32 max
+
+        await consensus.setRefSlot(maxUint32);
+        await refSlotCacheTest.increaseIntValue(increment);
+
+        let result = await refSlotCacheTest.getIntValueForLastRefSlot();
+        expect(result).to.equal(0n);
+
+        // next refSlot is larger than uint32 max and truncated version is smaller than previous refSlot
+        await consensus.setRefSlot(largeRefSlot);
+
+        result = await refSlotCacheTest.getIntValueForLastRefSlot();
+        expect(result).to.equal(increment);
       });
     });
   });

--- a/test/0.8.25/vaults/refSlotCache/refSlotCache.test.ts
+++ b/test/0.8.25/vaults/refSlotCache/refSlotCache.test.ts
@@ -1,0 +1,395 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+import { HashConsensus__Mock, RefSlotCacheTest } from "typechain-types";
+
+import { Snapshot } from "test/suite";
+
+describe("RefSlotCache.sol", () => {
+  let consensus: HashConsensus__Mock;
+  let refSlotCacheTest: RefSlotCacheTest;
+
+  let originalState: string;
+
+  const DEFAULT_INITIAL_REF_SLOT = 100n;
+
+  before(async () => {
+    consensus = await ethers.deployContract("HashConsensus__Mock", [DEFAULT_INITIAL_REF_SLOT]);
+
+    refSlotCacheTest = await ethers.deployContract("RefSlotCacheTest", [consensus]);
+  });
+
+  beforeEach(async () => (originalState = await Snapshot.take()));
+
+  afterEach(async () => await Snapshot.restore(originalState));
+
+  context("Uint112WithRefSlotCache", () => {
+    describe("withValueIncrease", () => {
+      it("should initialize cache only on first call", async () => {
+        const increment = 100n;
+        const refSlot = 200n;
+
+        await consensus.setRefSlot(refSlot);
+
+        let storage = await refSlotCacheTest.getUintCacheStorage();
+        expect(storage.value).to.equal(0n);
+        expect(storage.valueOnRefSlot).to.equal(0n);
+        expect(storage.refSlot).to.equal(0n);
+
+        await refSlotCacheTest.increaseUintValue(increment);
+
+        storage = await refSlotCacheTest.getUintCacheStorage();
+        expect(storage.value).to.equal(increment);
+        expect(storage.valueOnRefSlot).to.equal(0n);
+        expect(storage.refSlot).to.equal(refSlot);
+
+        await refSlotCacheTest.increaseUintValue(increment);
+
+        storage = await refSlotCacheTest.getUintCacheStorage();
+        expect(storage.value).to.equal(2n * increment);
+        expect(storage.valueOnRefSlot).to.equal(0n);
+        expect(storage.refSlot).to.equal(refSlot);
+      });
+
+      it("should cache previous value when refSlot changes", async () => {
+        const initialIncrement = 50n;
+        const secondIncrement = 75n;
+        const firstRefSlot = 200n;
+        const secondRefSlot = 300n;
+
+        // First increment at refSlot 200
+        await consensus.setRefSlot(firstRefSlot);
+        await refSlotCacheTest.increaseUintValue(initialIncrement);
+
+        // Change to refSlot 300 and increment again
+        await consensus.setRefSlot(secondRefSlot);
+        await refSlotCacheTest.increaseUintValue(secondIncrement);
+
+        const storage = await refSlotCacheTest.getUintCacheStorage();
+        expect(storage.value).to.equal(initialIncrement + secondIncrement);
+        expect(storage.valueOnRefSlot).to.equal(initialIncrement);
+        expect(storage.refSlot).to.equal(secondRefSlot);
+      });
+
+      it("should not update cached value when refSlot stays the same", async () => {
+        const firstIncrement = 30n;
+        const secondIncrement = 20n;
+        const refSlot = 200n;
+
+        await consensus.setRefSlot(refSlot);
+
+        // First increment
+        await refSlotCacheTest.increaseUintValue(firstIncrement);
+
+        // Second increment at same refSlot
+        await refSlotCacheTest.increaseUintValue(secondIncrement);
+
+        const storage = await refSlotCacheTest.getUintCacheStorage();
+        expect(storage.value).to.equal(firstIncrement + secondIncrement);
+        expect(storage.valueOnRefSlot).to.equal(0n); // Should remain 0 as it was set initially
+        expect(storage.refSlot).to.equal(refSlot);
+      });
+
+      it("should handle multiple refSlot changes correctly", async () => {
+        const increments = [10n, 20n, 30n];
+        const refSlots = [100n, 200n, 300n];
+
+        for (let i = 0; i < increments.length; i++) {
+          await consensus.setRefSlot(refSlots[i]);
+          await refSlotCacheTest.increaseUintValue(increments[i]);
+        }
+
+        const finalStorage = await refSlotCacheTest.getUintCacheStorage();
+        expect(finalStorage.value).to.equal(increments[0] + increments[1] + increments[2]);
+        expect(finalStorage.valueOnRefSlot).to.equal(increments[0] + increments[1]);
+        expect(finalStorage.refSlot).to.equal(refSlots[2]);
+      });
+
+      it("should handle refSlot truncation to uint32", async () => {
+        const increment = 100n;
+        const maxUint32 = 2n ** 32n - 1n;
+        const largeRefSlot = maxUint32 + 100n; // Larger than uint32 max
+        const expectedTruncatedRefSlot = largeRefSlot & (2n ** 32n - 1n); // Truncate to uint32
+
+        await consensus.setRefSlot(maxUint32);
+        await refSlotCacheTest.increaseUintValue(increment);
+
+        let storage = await refSlotCacheTest.getUintCacheStorage();
+        expect(storage.refSlot).to.equal(maxUint32);
+        expect(storage.value).to.equal(increment);
+        expect(storage.valueOnRefSlot).to.equal(0n);
+
+        // next refSlot is larger than uint32 max and truncated version is smaller than previous refSlot
+        await consensus.setRefSlot(largeRefSlot);
+        await refSlotCacheTest.increaseUintValue(increment);
+
+        storage = await refSlotCacheTest.getUintCacheStorage();
+        expect(storage.refSlot).to.equal(expectedTruncatedRefSlot);
+        expect(storage.value).to.equal(increment * 2n);
+        expect(storage.valueOnRefSlot).to.equal(increment);
+      });
+    });
+
+    describe("getValueForLastRefSlot", () => {
+      it("should return current value when current refSlot is greater than cached refSlot", async () => {
+        const increment = 100n;
+        const oldRefSlot = 200n;
+        const newRefSlot = 300n;
+
+        // Set up cache at oldRefSlot
+        await consensus.setRefSlot(oldRefSlot);
+        await refSlotCacheTest.increaseUintValue(increment);
+
+        // Move to newRefSlot
+        await consensus.setRefSlot(newRefSlot);
+
+        const result = await refSlotCacheTest.getUintValueForLastRefSlot();
+        expect(result).to.equal(increment);
+      });
+
+      it("should return cached value when current refSlot equals cached refSlot", async () => {
+        const firstIncrement = 50n;
+        const refSlot = 200n;
+
+        // Set initial value
+        await consensus.setRefSlot(refSlot);
+        await refSlotCacheTest.increaseUintValue(firstIncrement);
+
+        // Change refSlot to trigger caching
+        await consensus.setRefSlot(refSlot + 100n);
+
+        const result = await refSlotCacheTest.getUintValueForLastRefSlot();
+        expect(result).to.equal(firstIncrement);
+      });
+
+      it("should handle zero cached values correctly", async () => {
+        const refSlot = 200n;
+
+        await consensus.setRefSlot(refSlot);
+
+        const result = await refSlotCacheTest.getUintValueForLastRefSlot();
+        expect(result).to.equal(0n);
+      });
+    });
+  });
+
+  context("Int112WithRefSlotCache", () => {
+    describe("withValueIncrease", () => {
+      it("should handle positive increments", async () => {
+        const increment = 100;
+        const refSlot = 200n;
+
+        await consensus.setRefSlot(refSlot);
+
+        await refSlotCacheTest.increaseIntValue(increment);
+
+        const storage = await refSlotCacheTest.getIntCacheStorage();
+        expect(storage.value).to.equal(increment);
+        expect(storage.valueOnRefSlot).to.equal(0);
+        expect(storage.refSlot).to.equal(refSlot);
+      });
+
+      it("should handle negative increments", async () => {
+        const positiveIncrement = 100;
+        const negativeIncrement = -50;
+        const refSlot = 200n;
+
+        await consensus.setRefSlot(refSlot);
+
+        // First add positive value
+        await refSlotCacheTest.increaseIntValue(positiveIncrement);
+
+        // Then subtract
+        await refSlotCacheTest.increaseIntValue(negativeIncrement);
+
+        const storage = await refSlotCacheTest.getIntCacheStorage();
+        expect(storage.value).to.equal(positiveIncrement + negativeIncrement);
+        expect(storage.valueOnRefSlot).to.equal(0);
+        expect(storage.refSlot).to.equal(refSlot);
+      });
+
+      it("should cache previous value when refSlot changes", async () => {
+        const initialIncrement = 50;
+        const secondIncrement = -25;
+        const firstRefSlot = 200n;
+        const secondRefSlot = 300n;
+
+        // First increment at refSlot 200
+        await consensus.setRefSlot(firstRefSlot);
+        await refSlotCacheTest.increaseIntValue(initialIncrement);
+
+        // Change to refSlot 300 and increment again
+        await consensus.setRefSlot(secondRefSlot);
+        await refSlotCacheTest.increaseIntValue(secondIncrement);
+
+        const storage = await refSlotCacheTest.getIntCacheStorage();
+        expect(storage.value).to.equal(initialIncrement + secondIncrement);
+        expect(storage.valueOnRefSlot).to.equal(initialIncrement);
+        expect(storage.refSlot).to.equal(secondRefSlot);
+      });
+
+      it("should not update cached value when refSlot stays the same", async () => {
+        const increment = 10n;
+        const refSlot = 200n;
+
+        await consensus.setRefSlot(refSlot);
+
+        // First increment
+        await refSlotCacheTest.increaseIntValue(increment);
+
+        // Second increment at same refSlot
+        await refSlotCacheTest.increaseIntValue(increment);
+
+        const storage = await refSlotCacheTest.getIntCacheStorage();
+        expect(storage.value).to.equal(increment * 2n);
+        expect(storage.valueOnRefSlot).to.equal(0n); // Should remain 0 as it was set initially
+        expect(storage.refSlot).to.equal(refSlot);
+      });
+
+      it("should handle multiple refSlot changes correctly", async () => {
+        const increments = [10n, -20n, 30n];
+        const refSlots = [100n, 200n, 300n];
+
+        for (let i = 0; i < increments.length; i++) {
+          await consensus.setRefSlot(refSlots[i]);
+          await refSlotCacheTest.increaseIntValue(increments[i]);
+        }
+
+        const finalStorage = await refSlotCacheTest.getIntCacheStorage();
+        expect(finalStorage.value).to.equal(increments[0] + increments[1] + increments[2]);
+        expect(finalStorage.valueOnRefSlot).to.equal(increments[0] + increments[1]);
+        expect(finalStorage.refSlot).to.equal(refSlots[2]);
+      });
+
+      it("should handle refSlot truncation to uint32", async () => {
+        const increment = -100n;
+        const maxUint32 = 2n ** 32n - 1n;
+        const largeRefSlot = maxUint32 + 100n; // Larger than uint32 max
+        const expectedTruncatedRefSlot = largeRefSlot & (2n ** 32n - 1n); // Truncate to uint32
+
+        await consensus.setRefSlot(maxUint32);
+        await refSlotCacheTest.increaseIntValue(increment);
+
+        let storage = await refSlotCacheTest.getIntCacheStorage();
+        expect(storage.refSlot).to.equal(maxUint32);
+        expect(storage.value).to.equal(increment);
+        expect(storage.valueOnRefSlot).to.equal(0n);
+
+        // next refSlot is larger than uint32 max and truncated version is smaller than previous refSlot
+        await consensus.setRefSlot(largeRefSlot);
+        await refSlotCacheTest.increaseIntValue(increment);
+
+        storage = await refSlotCacheTest.getIntCacheStorage();
+        expect(storage.refSlot).to.equal(expectedTruncatedRefSlot);
+        expect(storage.value).to.equal(increment * 2n);
+        expect(storage.valueOnRefSlot).to.equal(increment);
+      });
+
+      it("should handle zero increments", async () => {
+        const increment = 0;
+        const refSlot = 200n;
+
+        await consensus.setRefSlot(refSlot);
+
+        await refSlotCacheTest.increaseIntValue(increment);
+
+        const storage = await refSlotCacheTest.getIntCacheStorage();
+        expect(storage.value).to.equal(0);
+        expect(storage.valueOnRefSlot).to.equal(0);
+        expect(storage.refSlot).to.equal(refSlot);
+      });
+    });
+
+    describe("getValueForLastRefSlot", () => {
+      it("should return current value when current refSlot is greater than cached refSlot", async () => {
+        const increment = -100;
+        const oldRefSlot = 200n;
+        const newRefSlot = 300n;
+
+        // Set up cache at oldRefSlot
+        await consensus.setRefSlot(oldRefSlot);
+        await refSlotCacheTest.increaseIntValue(increment);
+
+        // Move to newRefSlot
+        await consensus.setRefSlot(newRefSlot);
+
+        const result = await refSlotCacheTest.getIntValueForLastRefSlot();
+        expect(result).to.equal(increment);
+      });
+
+      it("should return cached value when current refSlot equals cached refSlot", async () => {
+        const firstIncrement = 50;
+        const refSlot = 200n;
+
+        // Set initial value
+        await consensus.setRefSlot(refSlot);
+        await refSlotCacheTest.increaseIntValue(firstIncrement);
+
+        // Change refSlot to trigger caching
+        await consensus.setRefSlot(refSlot + 100n);
+
+        const result = await refSlotCacheTest.getIntValueForLastRefSlot();
+        expect(result).to.equal(firstIncrement);
+      });
+    });
+  });
+
+  context("Edge cases", () => {
+    it("should handle maximum uint112 values", async () => {
+      const maxUint112 = 2n ** 112n - 1n;
+      const refSlot = 200n;
+
+      await consensus.setRefSlot(refSlot);
+      await refSlotCacheTest.increaseUintValue(maxUint112);
+
+      const storage = await refSlotCacheTest.getUintCacheStorage();
+      expect(storage.value).to.equal(maxUint112);
+    });
+
+    it("should handle maximum int112 values", async () => {
+      const maxInt112 = 2n ** 111n - 1n;
+      const refSlot = 200n;
+
+      await consensus.setRefSlot(refSlot);
+      await refSlotCacheTest.increaseIntValue(maxInt112);
+
+      const storage = await refSlotCacheTest.getIntCacheStorage();
+      expect(storage.value).to.equal(maxInt112);
+    });
+
+    it("should handle minimum int112 values", async () => {
+      const minInt112 = -(2n ** 111n);
+      const refSlot = 200n;
+
+      await consensus.setRefSlot(refSlot);
+      await refSlotCacheTest.increaseIntValue(minInt112);
+
+      const storage = await refSlotCacheTest.getIntCacheStorage();
+      expect(storage.value).to.equal(minInt112);
+    });
+
+    it("should handle consensus contract change", async () => {
+      const increment = 100n;
+      const refSlot1 = 200n;
+      const refSlot2 = 300n;
+
+      // Setup with first consensus
+      await consensus.setRefSlot(refSlot1);
+      await refSlotCacheTest.increaseUintValue(increment);
+
+      // Deploy new consensus contract
+      const newConsensus = await ethers.deployContract("HashConsensus__Mock", [DEFAULT_INITIAL_REF_SLOT]);
+
+      await newConsensus.setRefSlot(refSlot2);
+      await refSlotCacheTest.setConsensus(newConsensus);
+
+      await refSlotCacheTest.increaseUintValue(increment);
+
+      // Should treat as new refSlot due to different consensus contract
+      const storage = await refSlotCacheTest.getUintCacheStorage();
+      expect(storage.value).to.equal(increment * 2n);
+      expect(storage.valueOnRefSlot).to.equal(increment);
+      expect(storage.refSlot).to.equal(refSlot2);
+    });
+  });
+});


### PR DESCRIPTION
Unit tests for refSlotCache library

Fix #1198 