### PR TITLE
Update GitHub Actions in CI Workflows

### DIFF
--- a/.github/workflows/analyse.yml
+++ b/.github/workflows/analyse.yml
@@ -15,7 +15,7 @@ jobs:
       security-events: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Common setup
         uses: ./.github/workflows/setup

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Common setup
         uses: ./.github/workflows/setup

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Common setup
         uses: ./.github/workflows/setup
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Common setup
         uses: ./.github/workflows/setup
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Common setup
         uses: ./.github/workflows/setup

--- a/.github/workflows/release-abis.yml
+++ b/.github/workflows/release-abis.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Common setup
         uses: ./.github/workflows/setup

--- a/.github/workflows/tests-integration-mainnet.yml
+++ b/.github/workflows/tests-integration-mainnet.yml
@@ -20,7 +20,7 @@ jobs:
           ETH_RPC_URL: "${{ secrets.ETH_RPC_URL }}"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Common setup
         uses: ./.github/workflows/setup

--- a/.github/workflows/tests-integration-scratch.yml
+++ b/.github/workflows/tests-integration-scratch.yml
@@ -15,7 +15,7 @@ jobs:
           - 8555:8545
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Common setup
         uses: ./.github/workflows/setup

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Common setup
         uses: ./.github/workflows/setup
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Common setup
         uses: ./.github/workflows/setup


### PR DESCRIPTION
Updates actions/checkout@v4 to actions/checkout@v5 across CI workflows.

Upgrade to actions/checkout@v5 for improved performance and stability.

Reference:
Latest version: https://github.com/actions/checkout/releases/tag/v5.0.0
