### PR TITLE
[VAULTS] Patch: `PinnedBeaconProxy` can hide malicious implementation via constructor

### DIFF
--- a/contracts/0.8.25/vaults/PinnedBeaconProxy.sol
+++ b/contracts/0.8.25/vaults/PinnedBeaconProxy.sol
@@ -4,7 +4,6 @@
 // See contracts/COMPILERS.md
 pragma solidity 0.8.25;
 
-import {IBeacon} from "@openzeppelin/contracts-v5.2/proxy/beacon/IBeacon.sol";
 import {BeaconProxy} from "@openzeppelin/contracts-v5.2/proxy/beacon/BeaconProxy.sol";
 import {PinnedBeaconUtils} from "./lib/PinnedBeaconUtils.sol";
 
@@ -25,19 +24,20 @@ import {PinnedBeaconUtils} from "./lib/PinnedBeaconUtils.sol";
 contract PinnedBeaconProxy is BeaconProxy {
     constructor(address beacon, bytes memory data) BeaconProxy(beacon, data) payable {}
 
+    function isOssified() external view returns (bool) {
+        return PinnedBeaconUtils.getPinnedImplementation() != address(0);
+    }
+
     function _implementation() internal view virtual override returns (address) {
         address pinnedImpl = PinnedBeaconUtils.getPinnedImplementation();
         if (pinnedImpl != address(0)) {
             return pinnedImpl;
         }
-        return IBeacon(_getBeacon()).implementation();
+        
+        return super._implementation();
     }
 
     function implementation() external view returns (address) {
         return _implementation();
-    }
-
-    function isOssified() external view returns (bool) {
-        return PinnedBeaconUtils.ossified();
     }
 }

--- a/contracts/0.8.25/vaults/StakingVault.sol
+++ b/contracts/0.8.25/vaults/StakingVault.sol
@@ -174,14 +174,6 @@ contract StakingVault is IStakingVault, Ownable2StepUpgradeable {
     }
 
     /**
-     * @notice Returns whether the vault is ossified
-     * @return True if the vault is ossified, false otherwise
-     */
-    function isOssified() public view returns (bool) {
-        return PinnedBeaconUtils.ossified();
-    }
-
-    /**
      * @notice Returns the 0x02-type withdrawal credentials for the validators deposited from this `StakingVault`
      *         All consensus layer rewards are sent to this contract. Only 0x02-type withdrawal credentials are supported
      * @return Bytes32 value of the withdrawal credentials
@@ -460,8 +452,6 @@ contract StakingVault is IStakingVault, Ownable2StepUpgradeable {
      * @dev vault can't be connected to the hub after ossification
      */
     function ossify() external onlyOwner {
-        if (isOssified()) revert VaultOssified();
-
         PinnedBeaconUtils.ossify();
     }
 

--- a/contracts/0.8.25/vaults/VaultHub.sol
+++ b/contracts/0.8.25/vaults/VaultHub.sol
@@ -11,6 +11,7 @@ import {IHashConsensus} from "contracts/common/interfaces/IHashConsensus.sol";
 
 import {IStakingVault} from "./interfaces/IStakingVault.sol";
 import {IPredepositGuarantee} from "./interfaces/IPredepositGuarantee.sol";
+import {IPinnedBeaconProxy} from "./interfaces/IPinnedBeaconProxy.sol";
 
 import {OperatorGrid} from "./OperatorGrid.sol";
 import {LazyOracle} from "./LazyOracle.sol";
@@ -356,7 +357,7 @@ contract VaultHub is PausableUntilWithRoles {
 
         IStakingVault vault_ = IStakingVault(_vault);
         if (vault_.pendingOwner() != address(this)) revert VaultHubNotPendingOwner(_vault);
-        if (vault_.isOssified()) revert VaultOssified(_vault);
+        if (IPinnedBeaconProxy(address(vault_)).isOssified()) revert VaultOssified(_vault);
         if (vault_.depositor() != address(_predepositGuarantee())) revert PDGNotDepositor(_vault);
 
         (

--- a/contracts/0.8.25/vaults/interfaces/IPinnedBeaconProxy.sol
+++ b/contracts/0.8.25/vaults/interfaces/IPinnedBeaconProxy.sol
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2025 Lido <info@lido.fi>
+// SPDX-License-Identifier: GPL-3.0
+
+// See contracts/COMPILERS.md
+// solhint-disable-next-line lido/fixed-compiler-version
+pragma solidity >=0.8.0;
+
+/**
+ * @title IPinnedBeaconProxy
+ * @author Lido
+ * @notice Interface for the `PinnedBeaconProxy` contract
+ */
+interface IPinnedBeaconProxy {
+    function isOssified() external view returns (bool);
+}

--- a/contracts/0.8.25/vaults/interfaces/IStakingVault.sol
+++ b/contracts/0.8.25/vaults/interfaces/IStakingVault.sol
@@ -41,7 +41,6 @@ interface IStakingVault {
 
     function nodeOperator() external view returns (address);
     function depositor() external view returns (address);
-    function isOssified() external view returns (bool);
     function calculateValidatorWithdrawalFee(uint256 _keysCount) external view returns (uint256);
     function fund() external payable;
     function withdraw(address _recipient, uint256 _ether) external;

--- a/contracts/0.8.25/vaults/lib/PinnedBeaconUtils.sol
+++ b/contracts/0.8.25/vaults/lib/PinnedBeaconUtils.sol
@@ -23,18 +23,11 @@ library PinnedBeaconUtils {
      * @notice Ossifies the beacon by pinning the current implementation
      */
     function ossify() internal {
-        if (ossified()) revert AlreadyOssified();
+        if (getPinnedImplementation() != address(0)) revert AlreadyOssified();
+        
         address currentImplementation = IBeacon(ERC1967Utils.getBeacon()).implementation();
         StorageSlot.getAddressSlot(PINNED_BEACON_STORAGE_SLOT).value = currentImplementation;
         emit PinnedImplementationUpdated(currentImplementation);
-    }
-
-    /**
-     * @notice Returns true if the proxy is ossified
-     * @return True if the proxy is ossified, false otherwise
-     */
-    function ossified() internal view returns(bool) {
-        return getPinnedImplementation() != address(0);
     }
 
     /**

--- a/test/0.8.25/vaults/contracts/StakingVault__HarnessForTestUpgrade.sol
+++ b/test/0.8.25/vaults/contracts/StakingVault__HarnessForTestUpgrade.sol
@@ -123,8 +123,6 @@ contract StakingVault__HarnessForTestUpgrade is IStakingVault, Ownable2StepUpgra
     error ZeroArgument(string name);
     error VaultAlreadyInitialized();
 
-    function isOssified() external view override returns (bool) {}
-
     function triggerValidatorWithdrawals(
         bytes calldata _pubkeys,
         uint64[] calldata _amounts,

--- a/test/0.8.25/vaults/pinnedBeaconProxy.test.ts
+++ b/test/0.8.25/vaults/pinnedBeaconProxy.test.ts
@@ -147,4 +147,15 @@ describe("PinnedBeaconProxy.sol", () => {
       expect(await proxy2.implementation()).to.equal(await beacon.implementation());
     });
   });
+
+  describe("isOssified()", () => {
+    it("should return false when not ossified", async () => {
+      expect(await pinnedBeaconProxy.isOssified()).to.be.false;
+    });
+
+    it("should return true when ossified", async () => {
+      await ossify(pinnedBeaconProxy, randomAddress());
+      expect(await pinnedBeaconProxy.isOssified()).to.be.true;
+    });
+  });
 });

--- a/test/0.8.25/vaults/staking-vault/stakingVault.test.ts
+++ b/test/0.8.25/vaults/staking-vault/stakingVault.test.ts
@@ -80,7 +80,6 @@ describe("StakingVault.sol", () => {
     expect(await stakingVault.version()).to.equal(1);
     expect(await stakingVault.getInitializedVersion()).to.equal(1);
     expect(await stakingVault.pendingOwner()).to.equal(ZeroAddress);
-    expect(await stakingVault.isOssified()).to.equal(false);
     expect(toChecksumAddress(await stakingVault.withdrawalCredentials())).to.equal(
       toChecksumAddress("0x02" + "00".repeat(11) + de0x(await stakingVault.getAddress())),
     );
@@ -157,7 +156,7 @@ describe("StakingVault.sol", () => {
     it("reverts on already ossified", async () => {
       await stakingVault.ossify();
 
-      await expect(stakingVault.ossify()).to.revertedWithCustomError(stakingVault, "VaultOssified");
+      await expect(stakingVault.ossify()).to.revertedWithCustomError(stakingVault, "AlreadyOssified");
     });
 
     it("ossifies the vault", async () => {

--- a/test/0.8.25/vaults/vaulthub/contracts/PinnedBeaconProxy__BeaconOverride.sol
+++ b/test/0.8.25/vaults/vaulthub/contracts/PinnedBeaconProxy__BeaconOverride.sol
@@ -1,15 +1,14 @@
-// SPDX-FileCopyrightText: 2025 Lido <info@lido.fi>
-// SPDX-License-Identifier: GPL-3.0
+// SPDX-License-Identifier: UNLICENSED
+// for testing purposes only
 
-// See contracts/COMPILERS.md
 pragma solidity 0.8.25;
 
 import {IBeacon} from "@openzeppelin/contracts-v5.2/proxy/beacon/IBeacon.sol";
 import {BeaconProxy} from "@openzeppelin/contracts-v5.2/proxy/beacon/BeaconProxy.sol";
-import {PinnedBeaconUtils} from "./lib/PinnedBeaconUtils.sol";
+import {PinnedBeaconUtils} from "contracts/0.8.25/vaults/lib/PinnedBeaconUtils.sol";
 
 /**
- * @title PinnedBeaconProxy
+ * @title PinnedBeaconProxy__BeaconOverride
  * @author Lido
  * @notice
  *
@@ -22,8 +21,15 @@ import {PinnedBeaconUtils} from "./lib/PinnedBeaconUtils.sol";
  * - When ossified, the proxy will always use the pinned implementation instead of the beacon's implementation
  *
  */
-contract PinnedBeaconProxy is BeaconProxy {
-    constructor(address beacon, bytes memory data) BeaconProxy(beacon, data) payable {}
+contract PinnedBeaconProxy__BeaconOverride is BeaconProxy {
+    constructor(address _spoofImpl, address beacon, bytes memory data) payable BeaconProxy(beacon, data) {
+        assembly {
+            sstore(
+                0x8d75cfa6c9a3cd2fb8b6d445eafb32adc5497a45b333009f9000379f7024f9f5, // PINNED_BEACON_STORAGE_SLOT
+                _spoofImpl
+            )
+        }
+    }
 
     function _implementation() internal view virtual override returns (address) {
         address pinnedImpl = PinnedBeaconUtils.getPinnedImplementation();

--- a/test/0.8.25/vaults/vaulthub/contracts/PinnedBeaconProxy__BeaconOverride.sol
+++ b/test/0.8.25/vaults/vaulthub/contracts/PinnedBeaconProxy__BeaconOverride.sol
@@ -31,19 +31,20 @@ contract PinnedBeaconProxy__BeaconOverride is BeaconProxy {
         }
     }
 
+    function isOssified() external view returns (bool) {
+        return PinnedBeaconUtils.getPinnedImplementation() != address(0);
+    }
+
     function _implementation() internal view virtual override returns (address) {
         address pinnedImpl = PinnedBeaconUtils.getPinnedImplementation();
         if (pinnedImpl != address(0)) {
             return pinnedImpl;
         }
-        return IBeacon(_getBeacon()).implementation();
+
+        return super._implementation();
     }
 
     function implementation() external view returns (address) {
         return _implementation();
-    }
-
-    function isOssified() external view returns (bool) {
-        return PinnedBeaconUtils.ossified();
     }
 }

--- a/test/0.8.25/vaults/vaulthub/contracts/StakingVault__OssifiedSpoof.sol
+++ b/test/0.8.25/vaults/vaulthub/contracts/StakingVault__OssifiedSpoof.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: UNLICENSED
+// for testing purposes only
+
+pragma solidity 0.8.25;
+
+contract StakingVault__OssifiedSpoof {
+    address public pendingOwner;
+
+    function setPendingOwner(address _pendingOwner) external {
+        pendingOwner = _pendingOwner;
+    }
+
+    function isOssified() external view returns (bool) {
+        return false;
+    }
+}

--- a/test/integration/vaults/disconnected.integration.ts
+++ b/test/integration/vaults/disconnected.integration.ts
@@ -203,47 +203,6 @@ describe("Integration: Actions with vault disconnected from hub", () => {
       });
     });
 
-    describe("Ossification", () => {
-      it("Can ossify vault", async () => {
-        await expect(stakingVault.connect(owner).ossify()).to.emit(stakingVault, "PinnedImplementationUpdated");
-
-        expect(await stakingVault.isOssified()).to.equal(true);
-      });
-
-      describe("Ossified", () => {
-        beforeEach(async () => {
-          await stakingVault.connect(owner).ossify();
-        });
-
-        it("Can't ossify vault again", async () => {
-          await expect(stakingVault.connect(owner).ossify()).to.be.revertedWithCustomError(
-            stakingVault,
-            "VaultOssified",
-          );
-        });
-
-        it("Can withdraw the funds", async () => {
-          const balance = await ethers.provider.getBalance(stranger);
-          const amount = await ethers.provider.getBalance(stakingVault);
-
-          await expect(stakingVault.connect(owner).withdraw(stranger, amount))
-            .to.emit(stakingVault, "EtherWithdrawn")
-            .withArgs(stranger, amount);
-
-          expect(await ethers.provider.getBalance(stranger)).to.equal(balance + amount);
-        });
-
-        it("Can't reconnect the vault to the hub", async () => {
-          const { vaultHub } = ctx.contracts;
-          await stakingVault.connect(owner).transferOwnership(vaultHub);
-
-          await expect(vaultHub.connectVault(stakingVault))
-            .to.be.revertedWithCustomError(vaultHub, "VaultOssified")
-            .withArgs(stakingVault);
-        });
-      });
-    });
-
     describe("Validator exiting", () => {
       it("Can request validator exit", async () => {
         const keys = getPubkeys(2);

--- a/test/integration/vaults/impl-switch.integration.ts
+++ b/test/integration/vaults/impl-switch.integration.ts
@@ -34,6 +34,9 @@ describe("Switching vault implementation by spoofing ossification", () => {
   it("connectVault reverts if the vault is ossified by checking the ossification on the proxy", async () => {
     const spoofImpl = await ethers.deployContract("StakingVault__OssifiedSpoof");
 
+    // isOssified() returns false on the implementation
+    expect(await spoofImpl.isOssified()).to.be.false;
+
     const badProxy = await ethers.deployContract("PinnedBeaconProxy__BeaconOverride", [
       spoofImpl,
       ctx.contracts.stakingVaultBeacon,

--- a/test/integration/vaults/impl-switch.integration.ts
+++ b/test/integration/vaults/impl-switch.integration.ts
@@ -1,0 +1,61 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
+
+import { PinnedBeaconProxy, VaultHub } from "typechain-types";
+
+import { createVaultWithDashboard, getProtocolContext, ProtocolContext, setupLidoForVaults } from "lib/protocol";
+
+describe("Switching vault implementation by spoofing ossification", () => {
+  let owner: HardhatEthersSigner;
+
+  let ctx: ProtocolContext;
+  let vaultHub: VaultHub;
+  let goodProxy: PinnedBeaconProxy;
+
+  before(async () => {
+    ctx = await getProtocolContext();
+
+    await setupLidoForVaults(ctx);
+
+    [owner] = await ethers.getSigners();
+    vaultHub = ctx.contracts.vaultHub.connect(owner);
+
+    ({ proxy: goodProxy } = await createVaultWithDashboard(
+      ctx,
+      ctx.contracts.stakingVaultFactory,
+      owner,
+      owner,
+      owner,
+    ));
+  });
+
+  it("connectVault reverts if the vault is ossified by checking the ossification on the proxy", async () => {
+    const spoofImpl = await ethers.deployContract("StakingVault__OssifiedSpoof");
+
+    const badProxy = await ethers.deployContract("PinnedBeaconProxy__BeaconOverride", [
+      spoofImpl,
+      ctx.contracts.stakingVaultBeacon,
+      "0x",
+    ]);
+
+    // proof that the constructor does not affect the runtime code (excepting the metadata, contract name, source mappings, etc.)
+    const goodProxyCode = stripMetadata(await ethers.provider.getCode(goodProxy));
+    const badProxyCode = stripMetadata(await ethers.provider.getCode(badProxy));
+    expect(goodProxyCode).to.equal(badProxyCode);
+
+    const vault = await ethers.getContractAt("StakingVault__OssifiedSpoof", badProxy);
+    await vault.setPendingOwner(vaultHub);
+
+    await expect(vaultHub.connectVault(vault)).to.be.revertedWithCustomError(vaultHub, "VaultOssified");
+  });
+});
+
+function stripMetadata(bytecode: string) {
+  const hex = bytecode.startsWith("0x") ? bytecode.slice(2) : bytecode;
+  // Last 2 bytes (4 hex chars) encode the CBOR length (big-endian) per solc.
+  const cborLen = parseInt(hex.slice(-4), 16);
+  const totalMetaHexLen = cborLen * 2 + 4; // CBOR + the 2 length bytes
+  return "0x" + hex.slice(0, hex.length - totalMetaHexLen);
+}

--- a/test/integration/vaults/impl-switch.integration.ts
+++ b/test/integration/vaults/impl-switch.integration.ts
@@ -7,7 +7,10 @@ import { PinnedBeaconProxy, VaultHub } from "typechain-types";
 
 import { createVaultWithDashboard, getProtocolContext, ProtocolContext, setupLidoForVaults } from "lib/protocol";
 
+import { Snapshot } from "test/suite";
+
 describe("Switching vault implementation by spoofing ossification", () => {
+  let snapshot: string;
   let owner: HardhatEthersSigner;
 
   let ctx: ProtocolContext;
@@ -15,6 +18,7 @@ describe("Switching vault implementation by spoofing ossification", () => {
   let goodProxy: PinnedBeaconProxy;
 
   before(async () => {
+    snapshot = await Snapshot.take();
     ctx = await getProtocolContext();
 
     await setupLidoForVaults(ctx);
@@ -30,6 +34,8 @@ describe("Switching vault implementation by spoofing ossification", () => {
       owner,
     ));
   });
+
+  afterEach(async () => await Snapshot.restore(snapshot));
 
   it("connectVault reverts if the vault is ossified by checking the ossification on the proxy", async () => {
     const spoofImpl = await ethers.deployContract("StakingVault__OssifiedSpoof");


### PR DESCRIPTION
Context: https://github.com/lidofinance/core/issues/1390