### PR TITLE
fix(tw-deploy): Fix CAPELLA_SLOT for mainnet

### DIFF
--- a/scripts/triggerable-withdrawals/tw-deploy.ts
+++ b/scripts/triggerable-withdrawals/tw-deploy.ts
@@ -112,6 +112,9 @@ async function main(): Promise<void> {
   const BLOCK_ROOT_IN_SUMMARY_PREV_GINDEX = "0x000000000000000000000000000000000000000000000000000000000040000d";
   const BLOCK_ROOT_IN_SUMMARY_CURR_GINDEX = BLOCK_ROOT_IN_SUMMARY_PREV_GINDEX;
 
+  const FIRST_SUPPORTED_SLOT = 1;
+  const PIVOT_SLOT = 1;
+  const CAPELLA_SLOT = 194048 * 32; // capellaSlot @see https://github.com/ethereum/consensus-specs/blob/365320e778965631cbef11fd93328e82a746b1f6/specs/capella/fork.md?plain=1#L22
   const SLOTS_PER_HISTORICAL_ROOT = 8192;
 
   // TriggerableWithdrawalsGateway params
@@ -205,9 +208,9 @@ async function main(): Promise<void> {
     [
       locator.address,
       gIndexes,
-      1, // firstSupportedSlot
-      1, // pivotSlot
-      0, // capellaSlot @see https://github.com/eth-clients/hoodi/blob/main/metadata/config.yaml#L33
+      FIRST_SUPPORTED_SLOT,
+      PIVOT_SLOT,
+      CAPELLA_SLOT,
       SLOTS_PER_HISTORICAL_ROOT, // slotsPerHistoricalRoot
       SLOTS_PER_EPOCH,
       SECONDS_PER_SLOT,


### PR DESCRIPTION
Fix CAPELLA_SLOT argument for mainnet TW deploy.

## Context

Fix CAPELLA_SLOT argument for mainnet TW deploy, it used to be 0 since Hoodi was activated after the capella.

## Problem

Propagation of correct parameters in the deploy script.
