### PR TITLE
fix: script syntax and quote network variable

### DIFF
--- a/scripts/dao-upgrade.sh
+++ b/scripts/dao-upgrade.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e +u
+set -e
 set -o pipefail
 
 # Check for required environment variables
@@ -21,4 +21,4 @@ yarn compile
 # Generic migration steps file
 export STEPS_FILE=upgrade/steps.json
 
-yarn hardhat --network $NETWORK run --no-compile scripts/utils/migrate.ts
+yarn hardhat --network "$NETWORK" run --no-compile scripts/utils/migrate.ts


### PR DESCRIPTION
## Context

the deployment script is used to run Hardhat tasks with a specified network.

## Problem

the script had `set -e +u`, which is invalid, and `$NETWORK` wasn’t quoted, causing potential issues if it contains spaces or special characters.

## Solution

changed `set -e +u` → `set -e` and wrapped `$NETWORK` in quotes in the Hardhat command. Everything else stays the same.
