### PR TITLE
fix: pause acceptor vault's deposits / require fresh report on rebalance

### DIFF
--- a/contracts/0.8.25/vaults/VaultHub.sol
+++ b/contracts/0.8.25/vaults/VaultHub.sol
@@ -386,12 +386,9 @@ contract VaultHub is PausableUntilWithRoles {
     /// @param _liabilitySharesTarget maximum amount of liabilityShares that will be preserved, the rest will be
     ///         marked as redemptionShares. If value is greater than liabilityShares, redemptionShares are set to 0
     /// @dev NB: Mechanism to be triggered when Lido Core TVL <= stVaults TVL
-    /// @dev requires the fresh report
     function setLiabilitySharesTarget(address _vault, uint256 _liabilitySharesTarget) external onlyRole(REDEMPTION_MASTER_ROLE) {
         VaultConnection storage connection = _checkConnection(_vault);
         VaultRecord storage record = _vaultRecord(_vault);
-
-        _requireFreshReport(_vault, record);
 
         uint256 liabilityShares_ = record.liabilityShares;
         uint256 redemptionShares = liabilityShares_ > _liabilitySharesTarget ? liabilityShares_ - _liabilitySharesTarget : 0;
@@ -765,13 +762,11 @@ contract VaultHub is PausableUntilWithRoles {
     /// @param _amountOfShares amount of shares to burn
     /// @dev msg.sender should be vault's owner
     /// @dev this function is designed to be used by the smart contract, for EOA see `transferAndBurnShares`
-    /// @dev requires the fresh report
     function burnShares(address _vault, uint256 _amountOfShares) public whenResumed {
         _requireNotZero(_amountOfShares);
         _checkConnectionAndOwner(_vault);
 
         VaultRecord storage record = _vaultRecord(_vault);
-        _requireFreshReport(_vault, record);
 
         _decreaseLiability(_vault, record, _amountOfShares);
 
@@ -786,7 +781,6 @@ contract VaultHub is PausableUntilWithRoles {
     /// @param _vault vault address
     /// @param _amountOfShares amount of shares to transfer and burn
     /// @dev msg.sender should be vault's owner
-    /// @dev requires the fresh report
     function transferAndBurnShares(address _vault, uint256 _amountOfShares) external {
         LIDO.transferSharesFrom(msg.sender, address(this), _amountOfShares);
 

--- a/contracts/0.8.25/vaults/VaultHub.sol
+++ b/contracts/0.8.25/vaults/VaultHub.sol
@@ -589,6 +589,8 @@ contract VaultHub is PausableUntilWithRoles {
                 _overrideOperatorLimits: true
             });
 
+            _updateBeaconChainDepositsPause(_vaultAcceptor, acceptorRecord, acceptorConnection);
+
             emit BadDebtSocialized(_badDebtVault, _vaultAcceptor, badDebtSharesToAccept);
         }
 

--- a/contracts/0.8.25/vaults/VaultHub.sol
+++ b/contracts/0.8.25/vaults/VaultHub.sol
@@ -713,7 +713,10 @@ contract VaultHub is PausableUntilWithRoles {
         _requireNotZero(_shares);
         _checkConnectionAndOwner(_vault);
 
-        _rebalance(_vault, _vaultRecord(_vault), _shares);
+        VaultRecord storage record = _vaultRecord(_vault);
+        _requireFreshReport(_vault, record);
+
+        _rebalance(_vault, record, _shares);
     }
 
     /// @notice mint StETH shares backed by vault external balance to the receiver address

--- a/contracts/0.8.25/vaults/VaultHub.sol
+++ b/contracts/0.8.25/vaults/VaultHub.sol
@@ -385,10 +385,13 @@ contract VaultHub is PausableUntilWithRoles {
     /// @param _vault The address of the vault
     /// @param _liabilitySharesTarget maximum amount of liabilityShares that will be preserved, the rest will be
     ///         marked as redemptionShares. If value is greater than liabilityShares, redemptionShares are set to 0
-    /// @dev NB: Mechanism to be triggered when Lido Core TVL <= stVaults TVL.
+    /// @dev NB: Mechanism to be triggered when Lido Core TVL <= stVaults TVL
+    /// @dev requires the fresh report
     function setLiabilitySharesTarget(address _vault, uint256 _liabilitySharesTarget) external onlyRole(REDEMPTION_MASTER_ROLE) {
         VaultConnection storage connection = _checkConnection(_vault);
         VaultRecord storage record = _vaultRecord(_vault);
+
+        _requireFreshReport(_vault, record);
 
         uint256 liabilityShares_ = record.liabilityShares;
         uint256 redemptionShares = liabilityShares_ > _liabilitySharesTarget ? liabilityShares_ - _liabilitySharesTarget : 0;
@@ -408,6 +411,7 @@ contract VaultHub is PausableUntilWithRoles {
     /// @param _infraFeeBP new infra fee
     /// @param _liquidityFeeBP new liquidity fee
     /// @param _reservationFeeBP new reservation fee
+    /// @dev requires the fresh report
     function updateConnection(
         address _vault,
         uint256 _shareLimit,
@@ -463,6 +467,7 @@ contract VaultHub is PausableUntilWithRoles {
     /// @param _vault vault address
     /// @dev msg.sender must have VAULT_MASTER_ROLE
     /// @dev vault's `liabilityShares` should be zero
+    /// @dev requires the fresh report (see _initiateDisconnection)
     function disconnect(address _vault) external onlyRole(VAULT_MASTER_ROLE) {
         _initiateDisconnection(_vault, _checkConnection(_vault), _vaultRecord(_vault), false);
 
@@ -493,6 +498,7 @@ contract VaultHub is PausableUntilWithRoles {
 
         VaultConnection storage connection = _vaultConnection(_vault);
         _requireConnected(connection, _vault);
+
         VaultRecord storage record = _vaultRecord(_vault);
 
         if (connection.disconnectInitiatedTs <= _reportTimestamp) {
@@ -542,6 +548,7 @@ contract VaultHub is PausableUntilWithRoles {
     /// @return number of shares that was socialized
     ///         (it's limited by acceptor vault capacity and bad debt actual size)
     /// @dev msg.sender must have BAD_DEBT_MASTER_ROLE
+    /// @dev requires the fresh report for both bad debt and acceptor vaults
     function socializeBadDebt(
         address _badDebtVault,
         address _vaultAcceptor,
@@ -602,6 +609,7 @@ contract VaultHub is PausableUntilWithRoles {
     /// @param _maxSharesToInternalize maximum amount of shares to internalize
     /// @return number of shares that was internalized (limited by actual size of the bad debt)
     /// @dev msg.sender must have BAD_DEBT_MASTER_ROLE
+    /// @dev requires the fresh report
     function internalizeBadDebt(
         address _badDebtVault,
         uint256 _maxSharesToInternalize
@@ -666,6 +674,7 @@ contract VaultHub is PausableUntilWithRoles {
     /// @param _vault vault address
     /// @dev msg.sender should be vault's owner
     /// @dev vault's `liabilityShares` should be zero
+    /// @dev requires the fresh report (see _initiateDisconnection)
     function voluntaryDisconnect(address _vault) external whenResumed {
         VaultConnection storage connection = _checkConnectionAndOwner(_vault);
 
@@ -693,9 +702,9 @@ contract VaultHub is PausableUntilWithRoles {
     /// @param _recipient recipient address
     /// @param _ether amount of ether to withdraw
     /// @dev msg.sender should be vault's owner
+    /// @dev requires the fresh report
     function withdraw(address _vault, address _recipient, uint256 _ether) external whenResumed {
         VaultConnection storage connection = _checkConnectionAndOwner(_vault);
-
         VaultRecord storage record = _vaultRecord(_vault);
         _requireFreshReport(_vault, record);
 
@@ -711,6 +720,7 @@ contract VaultHub is PausableUntilWithRoles {
     /// @param _vault vault address
     /// @param _shares amount of shares to rebalance
     /// @dev msg.sender should be vault's owner
+    /// @dev requires the fresh report
     function rebalance(address _vault, uint256 _shares) external whenResumed {
         _requireNotZero(_shares);
         _checkConnectionAndOwner(_vault);
@@ -725,6 +735,7 @@ contract VaultHub is PausableUntilWithRoles {
     /// @param _vault vault address
     /// @param _recipient address of the receiver
     /// @param _amountOfShares amount of stETH shares to mint
+    /// @dev requires the fresh report
     function mintShares(address _vault, address _recipient, uint256 _amountOfShares) external whenResumed {
         _requireNotZero(_recipient);
         _requireNotZero(_amountOfShares);
@@ -754,11 +765,13 @@ contract VaultHub is PausableUntilWithRoles {
     /// @param _amountOfShares amount of shares to burn
     /// @dev msg.sender should be vault's owner
     /// @dev this function is designed to be used by the smart contract, for EOA see `transferAndBurnShares`
+    /// @dev requires the fresh report
     function burnShares(address _vault, uint256 _amountOfShares) public whenResumed {
         _requireNotZero(_amountOfShares);
         _checkConnectionAndOwner(_vault);
 
         VaultRecord storage record = _vaultRecord(_vault);
+        _requireFreshReport(_vault, record);
 
         _decreaseLiability(_vault, record, _amountOfShares);
 
@@ -773,6 +786,7 @@ contract VaultHub is PausableUntilWithRoles {
     /// @param _vault vault address
     /// @param _amountOfShares amount of shares to transfer and burn
     /// @dev msg.sender should be vault's owner
+    /// @dev requires the fresh report
     function transferAndBurnShares(address _vault, uint256 _amountOfShares) external {
         LIDO.transferSharesFrom(msg.sender, address(this), _amountOfShares);
 
@@ -795,11 +809,14 @@ contract VaultHub is PausableUntilWithRoles {
     /// @notice resumes beacon chain deposits for the vault
     /// @param _vault vault address
     /// @dev msg.sender should be vault's owner
+    /// @dev requires the fresh report
     function resumeBeaconChainDeposits(address _vault) external {
         VaultConnection storage connection = _checkConnectionAndOwner(_vault);
         if (!connection.isBeaconDepositsManuallyPaused) revert PausedExpected();
 
         VaultRecord storage record = _vaultRecord(_vault);
+        _requireFreshReport(_vault, record);
+
         if (record.redemptionShares > 0) revert HasRedemptionsCannotDeposit(_vault);
         if (_unsettledLidoFeesValue(record) >= MIN_BEACON_DEPOSIT) revert FeesTooHighCannotDeposit(_vault);
         if (!_isVaultHealthy(connection, record)) revert UnhealthyVaultCannotDeposit(_vault);
@@ -826,7 +843,7 @@ contract VaultHub is PausableUntilWithRoles {
     /// @param _amountsInGwei array of amounts to withdraw from each validator (0 for full withdrawal)
     /// @param _refundRecipient address that will receive the refund for transaction costs
     /// @dev msg.sender should be vault's owner
-    /// @dev in case of partial withdrawals, the report should be fresh
+    /// @dev requires the fresh report (in case of partial withdrawals)
     function triggerValidatorWithdrawals(
         address _vault,
         bytes calldata _pubkeys,
@@ -859,14 +876,14 @@ contract VaultHub is PausableUntilWithRoles {
         _triggerVaultValidatorWithdrawals(_vault, msg.value, _pubkeys, _amountsInGwei, _refundRecipient);
     }
 
-    /// @notice Triggers validator full withdrawals for the vault using EIP-7002 permissionlessly if the vault has
-    ///         obligations shortfall
+    /// @notice Triggers validator full withdrawals for the vault using EIP-7002 if the vault has obligations shortfall
     /// @param _vault address of the vault to exit validators from
     /// @param _pubkeys array of public keys of the validators to exit
     /// @param _refundRecipient address that will receive the refund for transaction costs
     /// @dev    In case the vault has obligations shortfall, trusted actor with the role can force its validators to
     ///         exit the beacon chain. This returns the vault's deposited ETH back to vault's balance and allows to
-    ///         rebalance the vault.
+    ///         rebalance the vault
+    /// @dev requires the fresh report
     function forceValidatorExit(
         address _vault,
         bytes calldata _pubkeys,
@@ -888,7 +905,8 @@ contract VaultHub is PausableUntilWithRoles {
     /// @notice Permissionless rebalance for vaults with obligations shortfall
     /// @param _vault vault address
     /// @dev rebalance all available amount of ether on the vault to fulfill the vault's obligations: restore vault
-    ///      to healthy state and settle outstanding redemptions. Fees are not settled in this case.
+    ///      to healthy state and settle outstanding redemptions. Fees are not settled in this case
+    /// @dev requires the fresh report
     function forceRebalance(address _vault) external {
         VaultConnection storage connection = _checkConnection(_vault);
         VaultRecord storage record = _vaultRecord(_vault);
@@ -909,6 +927,7 @@ contract VaultHub is PausableUntilWithRoles {
 
     /// @notice Permissionless payout of unsettled Lido fees to treasury
     /// @param _vault vault address
+    /// @dev requires the fresh report
     function settleLidoFees(address _vault) external {
         VaultConnection storage connection = _checkConnection(_vault);
         VaultRecord storage record = _vaultRecord(_vault);

--- a/test/0.8.25/vaults/vaulthub/vaulthub.redemptions.test.ts
+++ b/test/0.8.25/vaults/vaulthub/vaulthub.redemptions.test.ts
@@ -49,12 +49,6 @@ describe("VaultHub.sol:redemptions", () => {
       ).to.be.revertedWithCustomError(vaultHub, "AccessControlUnauthorizedAccount");
     });
 
-    it("reverts if report is stale", async () => {
-      await expect(vaultHub.connect(redemptionMaster).setLiabilitySharesTarget(connectedVault, 1000n))
-        .to.be.revertedWithCustomError(vaultHub, "VaultReportStale")
-        .withArgs(connectedVault);
-    });
-
     it("reverts if vault is not connected to the hub", async () => {
       await expect(vaultHub.connect(redemptionMaster).setLiabilitySharesTarget(disconnectedVault, 1000n))
         .to.be.revertedWithCustomError(vaultHub, "NotConnectedToHub")

--- a/test/0.8.25/vaults/vaulthub/vaulthub.redemptions.test.ts
+++ b/test/0.8.25/vaults/vaulthub/vaulthub.redemptions.test.ts
@@ -49,6 +49,12 @@ describe("VaultHub.sol:redemptions", () => {
       ).to.be.revertedWithCustomError(vaultHub, "AccessControlUnauthorizedAccount");
     });
 
+    it("reverts if report is stale", async () => {
+      await expect(vaultHub.connect(redemptionMaster).setLiabilitySharesTarget(connectedVault, 1000n))
+        .to.be.revertedWithCustomError(vaultHub, "VaultReportStale")
+        .withArgs(connectedVault);
+    });
+
     it("reverts if vault is not connected to the hub", async () => {
       await expect(vaultHub.connect(redemptionMaster).setLiabilitySharesTarget(disconnectedVault, 1000n))
         .to.be.revertedWithCustomError(vaultHub, "NotConnectedToHub")
@@ -71,7 +77,7 @@ describe("VaultHub.sol:redemptions", () => {
     it("allows to set redemption shares fully up to liability shares", async () => {
       const liabilityShares = ether("2");
 
-      await vaultsContext.reportVault({ vault: connectedVault, totalValue: ether("3") }); //
+      await vaultsContext.reportVault({ vault: connectedVault, totalValue: ether("3") });
       await vaultHub.connect(user).mintShares(connectedVault, user, liabilityShares);
 
       await expect(vaultHub.connect(redemptionMaster).setLiabilitySharesTarget(connectedVault, 0n))
@@ -139,6 +145,12 @@ describe("VaultHub.sol:redemptions", () => {
       await expect(vaultHub.forceRebalance(disconnectedVault))
         .to.be.revertedWithCustomError(vaultHub, "NotConnectedToHub")
         .withArgs(disconnectedVault);
+    });
+
+    it("reverts if report is stale", async () => {
+      await expect(vaultHub.forceRebalance(connectedVault))
+        .to.be.revertedWithCustomError(vaultHub, "VaultReportStale")
+        .withArgs(connectedVault);
     });
 
     it("settles obligations and unpauses deposits if they are paused", async () => {

--- a/test/0.8.25/vaults/vaulthub/vaulthub.vault.test.ts
+++ b/test/0.8.25/vaults/vaulthub/vaulthub.vault.test.ts
@@ -17,7 +17,7 @@ import {
   VaultHub,
 } from "typechain-types";
 
-import { ether, getCurrentBlockTimestamp, impersonate } from "lib";
+import { advanceChainTime, days, ether, getCurrentBlockTimestamp, impersonate } from "lib";
 import { ONE_GWEI, TOTAL_BASIS_POINTS } from "lib/constants";
 import { findEvents } from "lib/event";
 
@@ -279,8 +279,7 @@ describe("VaultHub.sol:owner-functions", () => {
     });
 
     it("reverts when report is stale", async () => {
-      // Make report stale
-      await lazyOracle.setLatestReportTimestamp((await getCurrentBlockTimestamp()) - 3n * 24n * 60n * 60n);
+      await advanceChainTime(days(3n));
 
       await expect(vaultHub.connect(vaultOwner).withdraw(vaultAddress, recipient, ether("1")))
         .to.be.revertedWithCustomError(vaultHub, "VaultReportStale")
@@ -369,7 +368,7 @@ describe("VaultHub.sol:owner-functions", () => {
     });
 
     it("reverts when report is stale", async () => {
-      await lazyOracle.setLatestReportTimestamp((await getCurrentBlockTimestamp()) - 3n * 24n * 60n * 60n);
+      await advanceChainTime(days(3n));
 
       await expect(vaultHub.connect(vaultOwner).mintShares(vaultAddress, recipient, ether("1")))
         .to.be.revertedWithCustomError(vaultHub, "VaultReportStale")
@@ -457,6 +456,15 @@ describe("VaultHub.sol:owner-functions", () => {
       );
     });
 
+    it("reverts when report is stale", async () => {
+      await advanceChainTime(days(3n));
+
+      await expect(vaultHub.connect(vaultOwner).burnShares(vaultAddress, ether("1"))).to.be.revertedWithCustomError(
+        vaultHub,
+        "VaultReportStale",
+      );
+    });
+
     it("reverts when burning more shares than minted", async () => {
       const liabilityShares = await vaultHub.liabilityShares(vaultAddress);
 
@@ -481,20 +489,30 @@ describe("VaultHub.sol:owner-functions", () => {
   });
 
   describe("transferAndBurnShares", () => {
+    let burnAmount: bigint;
+
     beforeEach(async () => {
       // Setup: fund vault and mint shares
       await vaultHub.connect(vaultOwner).fund(vaultAddress, { value: ether("10") });
       await reportVault({ totalValue: ether("11") });
       await vaultHub.connect(vaultOwner).mintShares(vaultAddress, vaultOwner, ether("5"));
       await reportVault({});
-    });
 
-    it("transfers and burns shares successfully", async () => {
-      const burnAmount = ether("2");
+      burnAmount = ether("2");
 
       // Approve VaultHub to transfer shares
       await lido.connect(vaultOwner).approve(vaultHub, burnAmount);
+    });
 
+    it("reverts when report is stale", async () => {
+      await advanceChainTime(days(3n));
+
+      await expect(
+        vaultHub.connect(vaultOwner).transferAndBurnShares(vaultAddress, burnAmount),
+      ).to.be.revertedWithCustomError(vaultHub, "VaultReportStale");
+    });
+
+    it("transfers and burns shares successfully", async () => {
       const liabilitySharesBefore = await vaultHub.liabilityShares(vaultAddress);
       const ownerBalanceBefore = await lido.balanceOf(vaultOwner);
 
@@ -522,7 +540,7 @@ describe("VaultHub.sol:owner-functions", () => {
     });
 
     it("reverts when report is stale", async () => {
-      await lazyOracle.setLatestReportTimestamp((await getCurrentBlockTimestamp()) - 3n * 24n * 60n * 60n);
+      await advanceChainTime(days(3n));
 
       await expect(vaultHub.connect(vaultOwner).rebalance(vaultAddress, ether("1"))).to.be.revertedWithCustomError(
         vaultHub,
@@ -640,6 +658,15 @@ describe("VaultHub.sol:owner-functions", () => {
         .and.to.emit(vault, "Mock__BeaconChainDepositsResumed");
 
       expect(await vault.beaconChainDepositsPaused()).to.be.false;
+    });
+
+    it("reverts when report is stale", async () => {
+      await advanceChainTime(days(3n));
+
+      await expect(vaultHub.connect(vaultOwner).resumeBeaconChainDeposits(vaultAddress)).to.be.revertedWithCustomError(
+        vaultHub,
+        "VaultReportStale",
+      );
     });
 
     it("reverts when vault is unhealthy", async () => {

--- a/test/0.8.25/vaults/vaulthub/vaulthub.vault.test.ts
+++ b/test/0.8.25/vaults/vaulthub/vaulthub.vault.test.ts
@@ -521,6 +521,15 @@ describe("VaultHub.sol:owner-functions", () => {
       await reportVault({ totalValue: ether("10.5"), liabilityShares: ether("8.5") });
     });
 
+    it("reverts when report is stale", async () => {
+      await lazyOracle.setLatestReportTimestamp((await getCurrentBlockTimestamp()) - 3n * 24n * 60n * 60n);
+
+      await expect(vaultHub.connect(vaultOwner).rebalance(vaultAddress, ether("1"))).to.be.revertedWithCustomError(
+        vaultHub,
+        "VaultReportStale",
+      );
+    });
+
     it("reverts when paused", async () => {
       await vaultHub.connect(deployer).grantRole(await vaultHub.PAUSE_ROLE(), vaultOwner);
       await vaultHub.connect(vaultOwner).pauseFor(1000n);

--- a/test/0.8.25/vaults/vaulthub/vaulthub.vault.test.ts
+++ b/test/0.8.25/vaults/vaulthub/vaulthub.vault.test.ts
@@ -456,15 +456,6 @@ describe("VaultHub.sol:owner-functions", () => {
       );
     });
 
-    it("reverts when report is stale", async () => {
-      await advanceChainTime(days(3n));
-
-      await expect(vaultHub.connect(vaultOwner).burnShares(vaultAddress, ether("1"))).to.be.revertedWithCustomError(
-        vaultHub,
-        "VaultReportStale",
-      );
-    });
-
     it("reverts when burning more shares than minted", async () => {
       const liabilityShares = await vaultHub.liabilityShares(vaultAddress);
 
@@ -502,14 +493,6 @@ describe("VaultHub.sol:owner-functions", () => {
 
       // Approve VaultHub to transfer shares
       await lido.connect(vaultOwner).approve(vaultHub, burnAmount);
-    });
-
-    it("reverts when report is stale", async () => {
-      await advanceChainTime(days(3n));
-
-      await expect(
-        vaultHub.connect(vaultOwner).transferAndBurnShares(vaultAddress, burnAmount),
-      ).to.be.revertedWithCustomError(vaultHub, "VaultReportStale");
     });
 
     it("transfers and burns shares successfully", async () => {


### PR DESCRIPTION
- Pause the vault acceptor in case of obligations.
- Added comments to functions that need a fresh report, and included a request for a fresh report in:
   - rebalance
   - resumeBeaconChainDeposits
- Fixed comment for permissionless forceValidatorExit.