### PR TITLE
Feat: revoke the ability to revoke funds from the NOR contract

### DIFF
--- a/contracts/0.4.24/nos/NodeOperatorsRegistry.sol
+++ b/contracts/0.4.24/nos/NodeOperatorsRegistry.sol
@@ -275,6 +275,11 @@ contract NodeOperatorsRegistry is AragonApp, Versioned {
         _initialize_v4(_exitDeadlineThresholdInSeconds);
     }
 
+    /// @notice Overrides default AragonApp behaviour to disallow recovery
+    function transferToVault(address /* _token */) external {
+        revert("NOT_SUPPORTED");
+    }
+
     /// @notice Add node operator named `name` with reward address `rewardAddress` and staking limit = 0 validators
     /// @param _name Human-readable name
     /// @param _rewardAddress Ethereum 1 address which receives stETH rewards for this operator

--- a/test/0.4.24/nor/nor.aux.test.ts
+++ b/test/0.4.24/nor/nor.aux.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { encodeBytes32String } from "ethers";
+import { encodeBytes32String, ZeroAddress } from "ethers";
 import { ethers } from "hardhat";
 
 import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
@@ -302,6 +302,12 @@ describe("NodeOperatorsRegistry.sol:auxiliary", () => {
         .withArgs(nonce + 1n)
         .to.emit(nor, "NonceChanged")
         .withArgs(nonce + 1n);
+    });
+  });
+
+  context("transferToVault", () => {
+    it("Reverts always", async () => {
+      await expect(nor.transferToVault(ZeroAddress)).to.be.revertedWith("NOT_SUPPORTED");
     });
   });
 });


### PR DESCRIPTION
Close `transferToVault` function with a revert to properly address the security issue.

## Context

Anyone could transfer funds to the trusted wallet from the NOR contract before rewards were distributed to NOs.
Returning those funds to the NOs required additional operational work.

## Problem

This change closes a previously mitigated security issue:
https://research.lido.fi/t/post-mortem-nor-curated-module-sdvt-recovery-lever-weakness/10282