### PR TITLE
[VAULTS] Audit fixes 7

### DIFF
--- a/contracts/0.4.24/Lido.sol
+++ b/contracts/0.4.24/Lido.sol
@@ -254,7 +254,6 @@ contract Lido is Versioned, StETHPermit, AragonApp {
         _migrateBurner_v2_to_v3(_oldBurner, _contractsWithBurnerAllowances);
 
         _setMaxExternalRatioBP(_initialMaxExternalRatioBP);
-        emit MaxExternalRatioBPSet(_initialMaxExternalRatioBP);
     }
 
     function _migrateStorage_v2_to_v3() internal {
@@ -458,11 +457,8 @@ contract Lido is Versioned, StETHPermit, AragonApp {
      */
     function setMaxExternalRatioBP(uint256 _maxExternalRatioBP) external {
         _auth(STAKING_CONTROL_ROLE);
-        require(_maxExternalRatioBP <= TOTAL_BASIS_POINTS, "INVALID_MAX_EXTERNAL_RATIO");
 
         _setMaxExternalRatioBP(_maxExternalRatioBP);
-
-        emit MaxExternalRatioBPSet(_maxExternalRatioBP);
     }
 
     /**
@@ -1303,7 +1299,11 @@ contract Lido is Versioned, StETHPermit, AragonApp {
     }
 
     function _setMaxExternalRatioBP(uint256 _newMaxExternalRatioBP) internal {
+        require(_newMaxExternalRatioBP <= TOTAL_BASIS_POINTS, "INVALID_MAX_EXTERNAL_RATIO");
+
         LOCATOR_AND_MAX_EXTERNAL_RATIO_POSITION.setHighUint96(_newMaxExternalRatioBP);
+
+        emit MaxExternalRatioBPSet(_newMaxExternalRatioBP);
     }
 
     function _getMaxExternalRatioBP() internal view returns (uint256) {

--- a/contracts/0.4.24/Lido.sol
+++ b/contracts/0.4.24/Lido.sol
@@ -741,9 +741,17 @@ contract Lido is Versioned, StETHPermit, AragonApp {
         _setExternalShares(externalShares - _amountOfShares);
         _burnShares(msg.sender, _amountOfShares);
 
-        // Increase staking limit
         uint256 stethAmount = getPooledEthByShares(_amountOfShares);
-        _increaseStakingLimit(stethAmount);
+        StakeLimitState.Data memory stakeLimitData = STAKING_STATE_POSITION.getStorageStakeLimitStruct();
+
+        /// NB: burning external shares must be allowed even when staking is paused to allow external ether withdrawals
+        if (stakeLimitData.isStakingLimitSet() && !stakeLimitData.isStakingPaused()) {
+            uint256 newStakeLimit = stakeLimitData.calculateCurrentStakeLimit() + stethAmount;
+
+            STAKING_STATE_POSITION.setStorageStakeLimitStruct(
+                stakeLimitData.updatePrevStakeLimit(newStakeLimit)
+            );
+        }
 
         // Historically, Lido contract does not emit Transfer to zero address events
         // for burning but emits SharesBurnt instead, so it's kept here for compatibility
@@ -1131,6 +1139,7 @@ contract Lido is Versioned, StETHPermit, AragonApp {
         return _stakeLimitData.calculateCurrentStakeLimit();
     }
 
+    /// @dev note that staking limit may be increased by burnExternalShares function
     function _decreaseStakingLimit(uint256 _amount) internal {
         StakeLimitState.Data memory stakeLimitData = STAKING_STATE_POSITION.getStorageStakeLimitStruct();
         // There is an invariant that protocol pause also implies staking pause.
@@ -1143,17 +1152,6 @@ contract Lido is Versioned, StETHPermit, AragonApp {
 
             STAKING_STATE_POSITION.setStorageStakeLimitStruct(
                 stakeLimitData.updatePrevStakeLimit(currentStakeLimit - _amount)
-            );
-        }
-    }
-
-    function _increaseStakingLimit(uint256 _amount) internal {
-        StakeLimitState.Data memory stakeLimitData = STAKING_STATE_POSITION.getStorageStakeLimitStruct();
-        if (stakeLimitData.isStakingLimitSet()) {
-            uint256 newStakeLimit = stakeLimitData.calculateCurrentStakeLimit() + _amount;
-
-            STAKING_STATE_POSITION.setStorageStakeLimitStruct(
-                stakeLimitData.updatePrevStakeLimit(newStakeLimit)
             );
         }
     }

--- a/contracts/0.8.25/vaults/LazyOracle.sol
+++ b/contracts/0.8.25/vaults/LazyOracle.sol
@@ -442,7 +442,9 @@ contract LazyOracle is ILazyOracle, AccessControlEnumerableUpgradeable {
             revert CumulativeLidoFeesTooLarge(_cumulativeLidoFees - previousCumulativeLidoFees, maxLidoFees);
         }
 
-        // 5. _maxLiabilityShares is greater or equal than _liabilityShares and current `maxLiabilityShares`
+        // 5. _maxLiabilityShares must be greater or equal than _liabilityShares
+        // _maxLiabilityShares must be less or equal than the currently tracked on-chain record.maxLiabilityShares
+        // (the latter can increase after the ref slot reported)
         if (_maxLiabilityShares < _liabilityShares || _maxLiabilityShares > record.maxLiabilityShares) {
             revert InvalidMaxLiabilityShares();
         }

--- a/contracts/0.8.25/vaults/LazyOracle.sol
+++ b/contracts/0.8.25/vaults/LazyOracle.sol
@@ -443,7 +443,7 @@ contract LazyOracle is ILazyOracle, AccessControlEnumerableUpgradeable {
         }
 
         // 5. _maxLiabilityShares is greater or equal than _liabilityShares and current `maxLiabilityShares`
-        if (_maxLiabilityShares < _liabilityShares || _maxLiabilityShares < record.maxLiabilityShares) {
+        if (_maxLiabilityShares < _liabilityShares || _maxLiabilityShares > record.maxLiabilityShares) {
             revert InvalidMaxLiabilityShares();
         }
     }

--- a/contracts/0.8.25/vaults/VaultHub.sol
+++ b/contracts/0.8.25/vaults/VaultHub.sol
@@ -1468,6 +1468,7 @@ contract VaultHub is PausableUntilWithRoles {
 
     /// @notice Calculates the max lockable value of the vault
     /// @param _record The record of the vault
+    /// @param _deltaValue The delta value to apply to the total value of the vault (may be negative)
     /// @return the max lockable value of the vault
     function _maxLockableValue(VaultRecord storage _record, int256 _deltaValue) internal view returns (uint256) {
         uint256 totalValue_ = _totalValue(_record);

--- a/contracts/0.8.25/vaults/dashboard/NodeOperatorFee.sol
+++ b/contracts/0.8.25/vaults/dashboard/NodeOperatorFee.sol
@@ -460,9 +460,4 @@ contract NodeOperatorFee is Permissions {
      * @dev Error emitted when the vault is quarantined.
      */
     error VaultQuarantined();
-
-    /**
-     * @dev Error emitted when you try to disburse fees but there is no unsettled growth
-     */
-    error NoUnsettledGrowth();
 }

--- a/contracts/0.8.25/vaults/dashboard/NodeOperatorFee.sol
+++ b/contracts/0.8.25/vaults/dashboard/NodeOperatorFee.sol
@@ -293,8 +293,12 @@ contract NodeOperatorFee is Permissions {
     }
 
     function _disburseFee(uint256 fee, int256 growth, address _recipient) internal {
-        // it's important not to revert here so as not to block disconnect
-        if (fee == 0) return;
+        if (fee == 0) {
+            // we still need to update the settledGrowth event if the fee is zero
+            // to avoid the retroactive fees
+            if (growth > settledGrowth) _setSettledGrowth(growth);
+            return;
+        }
 
         _setSettledGrowth(growth);
         _doWithdraw(_recipient, fee);
@@ -303,13 +307,12 @@ contract NodeOperatorFee is Permissions {
     }
 
     function _setSettledGrowth(int256 _newSettledGrowth) internal {
-        int128 oldSettledGrowth = settledGrowth;
+        int256 oldSettledGrowth = settledGrowth;
         if (oldSettledGrowth == _newSettledGrowth) revert SameSettledGrowth();
 
-        int128 newSettledGrowth = _newSettledGrowth.toInt128();
-        settledGrowth = newSettledGrowth;
+        settledGrowth = _newSettledGrowth.toInt128();
 
-        emit SettledGrowthSet(oldSettledGrowth, newSettledGrowth);
+        emit SettledGrowthSet(oldSettledGrowth, _newSettledGrowth);
     }
 
     /**
@@ -398,7 +401,7 @@ contract NodeOperatorFee is Permissions {
      * @param oldSettledGrowth the old settled growth
      * @param newSettledGrowth the new settled growth
      */
-    event SettledGrowthSet(int128 oldSettledGrowth, int128 newSettledGrowth);
+    event SettledGrowthSet(int256 oldSettledGrowth, int256 newSettledGrowth);
 
     /**
      * @dev Emitted when the settled growth is corrected.
@@ -457,4 +460,9 @@ contract NodeOperatorFee is Permissions {
      * @dev Error emitted when the vault is quarantined.
      */
     error VaultQuarantined();
+
+    /**
+     * @dev Error emitted when you try to disburse fees but there is no unsettled growth
+     */
+    error NoUnsettledGrowth();
 }

--- a/test/0.4.24/lido/lido.externalShares.test.ts
+++ b/test/0.4.24/lido/lido.externalShares.test.ts
@@ -420,6 +420,20 @@ describe("Lido.sol:externalShares", () => {
 
       expect(await lido.getCurrentStakeLimit()).to.equal(limit + amountToBurn);
     });
+
+    it("Burns shares correctly when staking is paused", async () => {
+      await lido.setMaxExternalRatioBP(maxExternalRatioBP);
+      await lido.setStakingLimit(ether("1500000"), ether("1000000"));
+
+      const amountToMint = await lido.getMaxMintableExternalShares();
+      await lido.connect(vaultHubSigner).mintExternalShares(vaultHubSigner, amountToMint);
+
+      await lido.pauseStaking();
+
+      await expect(lido.connect(vaultHubSigner).burnExternalShares(amountToMint))
+        .to.emit(lido, "ExternalSharesBurnt")
+        .withArgs(amountToMint);
+    });
   });
 
   context("rebalanceExternalEtherToInternal", () => {

--- a/test/integration/vaults/lazyOracle.integration.ts
+++ b/test/integration/vaults/lazyOracle.integration.ts
@@ -78,83 +78,104 @@ describe("Integration: LazyOracle", () => {
       expect(await vaultHub.isReportFresh(stakingVault)).to.equal(false);
     });
 
-    it("updates report data and check for all the parameters and events", async () => {
-      const { locator, hashConsensus, lido } = ctx.contracts;
+    context("average vault report", () => {
+      let vaultReport: VaultReportItem;
 
-      await dashboard.fund({ value: ether("1") });
-      await dashboard.mintShares(owner, 13001n);
-      await lido.approve(dashboard, 2n);
-      await dashboard.burnShares(1n);
+      beforeEach(async () => {
+        const { lido } = ctx.contracts;
 
-      await advanceChainTime(days(2n));
-      expect(await vaultHub.isReportFresh(stakingVault)).to.equal(false);
+        await dashboard.fund({ value: ether("1") });
+        await dashboard.mintShares(owner, 13001n);
+        await lido.approve(dashboard, 2n);
+        await dashboard.burnShares(1n);
 
-      const totalValueArg = ether("2");
-      const cumulativeLidoFeesArg = ether("0.1");
-      const liabilitySharesArg = 13000n;
-      const maxLiabilitySharesArg = 13001n;
-      const slashingReserveArg = ether("1.5");
-      const reportTimestampArg = await getCurrentBlockTimestamp();
-      const reportRefSlotArg = (await hashConsensus.getCurrentFrame()).refSlot;
+        const totalValueArg = ether("2");
+        const cumulativeLidoFeesArg = ether("0.1");
+        const liabilitySharesArg = 13000n;
+        const maxLiabilitySharesArg = 13001n;
+        const slashingReserveArg = ether("1.5");
 
-      const vaultReport: VaultReportItem = {
-        vault: await stakingVault.getAddress(),
-        totalValue: totalValueArg,
-        cumulativeLidoFees: cumulativeLidoFeesArg,
-        liabilityShares: liabilitySharesArg,
-        maxLiabilityShares: maxLiabilitySharesArg,
-        slashingReserve: slashingReserveArg,
-      };
-      const reportTree = createVaultsReportTree([vaultReport]);
+        vaultReport = {
+          vault: await stakingVault.getAddress(),
+          totalValue: totalValueArg,
+          cumulativeLidoFees: cumulativeLidoFeesArg,
+          liabilityShares: liabilitySharesArg,
+          maxLiabilityShares: maxLiabilitySharesArg,
+          slashingReserve: slashingReserveArg,
+        };
+      });
 
-      const accountingSigner = await impersonate(await locator.accountingOracle(), ether("100"));
-      await expect(
-        lazyOracle
-          .connect(accountingSigner)
-          .updateReportData(reportTimestampArg, reportRefSlotArg, reportTree.root, ""),
-      )
-        .to.emit(lazyOracle, "VaultsReportDataUpdated")
-        .withArgs(reportTimestampArg, reportRefSlotArg, reportTree.root, "");
+      it("reverts if maxLiabilityShares is less than liabilityShares", async () => {
+        await expect(
+          reportVaultDataWithProof(ctx, stakingVault, { maxLiabilityShares: 12999n }),
+        ).to.be.revertedWithCustomError(lazyOracle, "InvalidMaxLiabilityShares");
+      });
 
-      await expect(
-        lazyOracle.updateVaultData(
-          stakingVault,
-          totalValueArg,
-          cumulativeLidoFeesArg,
-          liabilitySharesArg,
-          maxLiabilitySharesArg,
-          slashingReserveArg,
-          reportTree.getProof(0),
-        ),
-      )
-        .to.emit(vaultHub, "VaultReportApplied")
-        .withArgs(
-          stakingVault,
-          reportTimestampArg,
-          totalValueArg,
-          ether("2"),
-          cumulativeLidoFeesArg,
-          liabilitySharesArg,
-          maxLiabilitySharesArg,
-          slashingReserveArg,
+      it("reverts if maxLiabilityShares is greater than the currently tracked on-chain record.maxLiabilityShares", async () => {
+        await expect(
+          reportVaultDataWithProof(ctx, stakingVault, { maxLiabilityShares: 13002n }),
+        ).to.be.revertedWithCustomError(lazyOracle, "InvalidMaxLiabilityShares");
+      });
+
+      it("updates report data and check for all the parameters and events", async () => {
+        const { locator, hashConsensus } = ctx.contracts;
+
+        await advanceChainTime(days(2n));
+        expect(await vaultHub.isReportFresh(stakingVault)).to.equal(false);
+
+        const reportTimestampArg = await getCurrentBlockTimestamp();
+        const reportRefSlotArg = (await hashConsensus.getCurrentFrame()).refSlot;
+
+        const reportTree = createVaultsReportTree([vaultReport]);
+        const accountingSigner = await impersonate(await locator.accountingOracle(), ether("100"));
+        await expect(
+          lazyOracle
+            .connect(accountingSigner)
+            .updateReportData(reportTimestampArg, reportRefSlotArg, reportTree.root, ""),
+        )
+          .to.emit(lazyOracle, "VaultsReportDataUpdated")
+          .withArgs(reportTimestampArg, reportRefSlotArg, reportTree.root, "");
+
+        await expect(
+          lazyOracle.updateVaultData(
+            stakingVault,
+            vaultReport.totalValue,
+            vaultReport.cumulativeLidoFees,
+            vaultReport.liabilityShares,
+            vaultReport.maxLiabilityShares,
+            vaultReport.slashingReserve,
+            reportTree.getProof(0),
+          ),
+        )
+          .to.emit(vaultHub, "VaultReportApplied")
+          .withArgs(
+            stakingVault,
+            reportTimestampArg,
+            vaultReport.totalValue,
+            vaultReport.totalValue, // inOutDelta
+            vaultReport.cumulativeLidoFees,
+            vaultReport.liabilityShares,
+            vaultReport.maxLiabilityShares,
+            vaultReport.slashingReserve,
+          );
+
+        expect(await vaultHub.isReportFresh(stakingVault)).to.equal(true);
+
+        const record = await vaultHub.vaultRecord(stakingVault);
+        expect(record.report.totalValue).to.equal(ether("2"));
+        expect(record.report.inOutDelta).to.equal(ether("2"));
+        expect(await vaultHub.totalValue(stakingVault)).to.equal(ether("2"));
+        expect(record.report.timestamp).to.equal(reportTimestampArg);
+        expect(record.minimalReserve).to.equal(vaultReport.slashingReserve);
+        expect(record.maxLiabilityShares).to.equal(13000n);
+        expect(await vaultHub.locked(stakingVault)).to.equal(
+          await calculateLockedValue(ctx, stakingVault, {
+            liabilityShares: 13000n,
+            minimalReserve: vaultReport.slashingReserve,
+            reserveRatioBP: (await vaultHub.vaultConnection(stakingVault)).reserveRatioBP,
+          }),
         );
-
-      expect(await vaultHub.isReportFresh(stakingVault)).to.equal(true);
-
-      const record = await vaultHub.vaultRecord(stakingVault);
-      expect(record.report.totalValue).to.equal(ether("2"));
-      expect(record.report.inOutDelta).to.equal(ether("2"));
-      expect(await vaultHub.totalValue(stakingVault)).to.equal(ether("2"));
-      expect(record.report.timestamp).to.equal(reportTimestampArg);
-      expect(record.minimalReserve).to.equal(slashingReserveArg);
-      expect(record.maxLiabilityShares).to.equal(13000n);
-      expect(await vaultHub.locked(stakingVault)).to.equal(
-        await calculateLockedValue(ctx, stakingVault, {
-          liabilityShares: 13000n,
-          minimalReserve: slashingReserveArg,
-          reserveRatioBP: (await vaultHub.vaultConnection(stakingVault)).reserveRatioBP,
-        }),
-      );
+      });
     });
   });
 

--- a/test/integration/vaults/vaulthub.minting.integration.ts
+++ b/test/integration/vaults/vaulthub.minting.integration.ts
@@ -3,9 +3,9 @@ import { ethers } from "hardhat";
 
 import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
 
-import { Dashboard, StakingVault, VaultHub } from "typechain-types";
+import { Dashboard, Lido, StakingVault, VaultHub } from "typechain-types";
 
-import { impersonate } from "lib";
+import { BigIntMath, certainAddress, impersonate, TOTAL_BASIS_POINTS } from "lib";
 import {
   calculateLockedValue,
   createVaultWithDashboard,
@@ -13,7 +13,7 @@ import {
   ProtocolContext,
   setupLidoForVaults,
 } from "lib/protocol";
-import { setStakingLimit } from "lib/protocol/helpers";
+import { ceilDiv, reportVaultDataWithProof, setStakingLimit } from "lib/protocol/helpers";
 import { ether } from "lib/units";
 
 import { Snapshot } from "test/suite";
@@ -29,6 +29,7 @@ describe("Integration: VaultHub ", () => {
 
   let vaultHub: VaultHub;
   let dashboard: Dashboard;
+  let lido: Lido;
 
   before(async () => {
     ctx = await getProtocolContext();
@@ -48,6 +49,7 @@ describe("Integration: VaultHub ", () => {
     const dashboardSigner = await impersonate(dashboard, ether("10000"));
 
     vaultHub = ctx.contracts.vaultHub.connect(dashboardSigner);
+    lido = ctx.contracts.lido;
   });
 
   beforeEach(async () => (snapshot = await Snapshot.take()));
@@ -98,8 +100,6 @@ describe("Integration: VaultHub ", () => {
     let maxStakeLimit: bigint;
 
     beforeEach(async () => {
-      const { lido } = ctx.contracts;
-
       ({ maxStakeLimit } = await lido.getStakeLimitFullInfo());
 
       await setStakingLimit(ctx, maxStakeLimit, 0n); // to avoid increasing staking limit
@@ -108,8 +108,6 @@ describe("Integration: VaultHub ", () => {
     });
 
     it("Minting should decrease staking limit", async () => {
-      const { lido } = ctx.contracts;
-
       const shares = ether("1");
 
       const stakingLimitBefore = await lido.getCurrentStakeLimit();
@@ -124,8 +122,6 @@ describe("Integration: VaultHub ", () => {
     });
 
     it("Burning should increase staking limit", async () => {
-      const { lido } = ctx.contracts;
-
       const shares = ether("1");
       await vaultHub.mintShares(stakingVault, vaultHub, shares);
 
@@ -141,8 +137,6 @@ describe("Integration: VaultHub ", () => {
     });
 
     it("Minting and burning should not change staking limit", async () => {
-      const { lido } = ctx.contracts;
-
       const shares = ether("1");
       const stakingLimitBeforeAll = await lido.getCurrentStakeLimit();
 
@@ -160,6 +154,154 @@ describe("Integration: VaultHub ", () => {
 
       const stakingLimitAfterAll = await lido.getCurrentStakeLimit();
       expect(stakingLimitAfterAll).to.equal(stakingLimitBeforeAll);
+    });
+  });
+
+  describe("Total Minting Capacity Shares", () => {
+    beforeEach(async () => {
+      const fundedAmount = ether("10");
+      await dashboard.connect(owner).fund({ value: fundedAmount });
+    });
+
+    it("returns correct total minting capacity shares", async () => {
+      const totalValue = await vaultHub.totalValue(stakingVault);
+      const record = await vaultHub.vaultRecord(stakingVault);
+      const connection = await vaultHub.vaultConnection(stakingVault);
+      const reserve = ceilDiv(totalValue * connection.reserveRatioBP, TOTAL_BASIS_POINTS);
+      const capacity = totalValue - BigIntMath.max(reserve, record.minimalReserve);
+
+      const expectedMintingCapacityShares = await lido.getSharesByPooledEth(capacity);
+
+      expect(await vaultHub.totalMintingCapacityShares(stakingVault, 0)).to.equal(expectedMintingCapacityShares);
+    });
+
+    it("takes unsettled lido fees into account", async () => {
+      const fees = ether("1");
+      await reportVaultDataWithProof(ctx, stakingVault, { cumulativeLidoFees: fees, waitForNextRefSlot: true });
+
+      const record = await vaultHub.vaultRecord(stakingVault);
+      const connection = await vaultHub.vaultConnection(stakingVault);
+
+      const totalValue = await vaultHub.totalValue(stakingVault);
+      const totalValueMinusFees = totalValue - record.cumulativeLidoFees;
+      const reserve = ceilDiv(totalValueMinusFees * connection.reserveRatioBP, TOTAL_BASIS_POINTS);
+      const capacity = totalValueMinusFees - BigIntMath.max(reserve, record.minimalReserve);
+
+      const expectedMintingCapacityShares = await lido.getSharesByPooledEth(capacity);
+
+      expect(await vaultHub.totalMintingCapacityShares(stakingVault, 0)).to.equal(expectedMintingCapacityShares);
+    });
+
+    it("takes positive delta value into account", async () => {
+      const record = await vaultHub.vaultRecord(stakingVault);
+      const connection = await vaultHub.vaultConnection(stakingVault);
+
+      const totalValue = await vaultHub.totalValue(stakingVault);
+      const deltaValue = ether("1");
+
+      const totalValuePlusDelta = totalValue + deltaValue;
+      const reservePlusDelta = ceilDiv(totalValuePlusDelta * connection.reserveRatioBP, TOTAL_BASIS_POINTS);
+      const capacityPlusDelta = totalValuePlusDelta - BigIntMath.max(reservePlusDelta, record.minimalReserve);
+      const expectedMintingCapacitySharesPlusDelta = await lido.getSharesByPooledEth(capacityPlusDelta);
+
+      expect(await vaultHub.totalMintingCapacityShares(stakingVault, deltaValue)).to.equal(
+        expectedMintingCapacitySharesPlusDelta,
+      );
+    });
+
+    it("takes negative delta value into account", async () => {
+      const record = await vaultHub.vaultRecord(stakingVault);
+      const connection = await vaultHub.vaultConnection(stakingVault);
+
+      const totalValue = await vaultHub.totalValue(stakingVault);
+      const deltaValue = -ether("1");
+
+      const totalValueMinusDelta = totalValue - ether("1");
+      const reserveMinusDelta = ceilDiv(totalValueMinusDelta * connection.reserveRatioBP, TOTAL_BASIS_POINTS);
+      const capacityMinusDelta = totalValueMinusDelta - BigIntMath.max(reserveMinusDelta, record.minimalReserve);
+      const expectedMintingCapacitySharesMinusDelta = await lido.getSharesByPooledEth(capacityMinusDelta);
+
+      expect(await vaultHub.totalMintingCapacityShares(stakingVault, deltaValue)).to.equal(
+        expectedMintingCapacitySharesMinusDelta,
+      );
+    });
+
+    it("handles zero delta value", async () => {
+      const withoutDelta = await vaultHub.totalMintingCapacityShares(stakingVault, 0);
+      const withZeroDelta = await vaultHub.totalMintingCapacityShares(stakingVault, 0);
+
+      expect(withZeroDelta).to.equal(withoutDelta);
+    });
+
+    it("returns 0 when negative delta exceeds total value", async () => {
+      const totalValue = await vaultHub.totalValue(stakingVault);
+      const deltaValue = -(totalValue + ether("1"));
+
+      expect(await vaultHub.totalMintingCapacityShares(stakingVault, deltaValue)).to.equal(0n);
+    });
+
+    for (const deltaValue of [1n, 2n, 3n, 5n, 10n, 100n, 1000n, ether("1"), ether("10")]) {
+      it(`handles ${ethers.formatEther(deltaValue)} deltas`, async () => {
+        const totalValue = await vaultHub.totalValue(stakingVault);
+        const record = await vaultHub.vaultRecord(stakingVault);
+        const connection = await vaultHub.vaultConnection(stakingVault);
+
+        // Plus delta
+        const plus = totalValue + deltaValue;
+        const reservePlus = ceilDiv(plus * connection.reserveRatioBP, TOTAL_BASIS_POINTS);
+        const capPlus = plus - BigIntMath.max(reservePlus, record.minimalReserve);
+        const expSharesPlus = await lido.getSharesByPooledEth(capPlus);
+
+        expect(await vaultHub.totalMintingCapacityShares(stakingVault, deltaValue)).to.equal(expSharesPlus);
+
+        // Minus delta
+        const minus = totalValue - deltaValue;
+        const reserveMinus = ceilDiv(minus * connection.reserveRatioBP, TOTAL_BASIS_POINTS);
+        const capMinus = minus - BigIntMath.max(reserveMinus, record.minimalReserve);
+        const expSharesMinus = await lido.getSharesByPooledEth(capMinus);
+
+        expect(await vaultHub.totalMintingCapacityShares(stakingVault, -deltaValue)).to.equal(expSharesMinus);
+      });
+    }
+
+    it("handles fees > totalValue with positive delta recovery", async () => {
+      // Report fees higher than current total value 11 ETH
+      const highFees = ether("12");
+      await reportVaultDataWithProof(ctx, stakingVault, { cumulativeLidoFees: highFees, waitForNextRefSlot: true });
+
+      const totalValue = await vaultHub.totalValue(stakingVault);
+
+      // Without delta, capacity should be 0
+      expect(await vaultHub.totalMintingCapacityShares(stakingVault, 0)).to.equal(0n);
+
+      // With large enough delta, should recover
+      const recoveryDelta = ether("5");
+      const record = await vaultHub.vaultRecord(stakingVault);
+      const connection = await vaultHub.vaultConnection(stakingVault);
+
+      const maxLockableValue = totalValue + recoveryDelta - record.cumulativeLidoFees;
+
+      const reserve = ceilDiv(maxLockableValue * connection.reserveRatioBP, TOTAL_BASIS_POINTS);
+      const capacity = maxLockableValue - BigIntMath.max(reserve, record.minimalReserve);
+      const expectedShares = await lido.getSharesByPooledEth(capacity);
+
+      expect(await vaultHub.totalMintingCapacityShares(stakingVault, recoveryDelta)).to.equal(expectedShares);
+    });
+
+    it("handles negative delta causing underflow in reserve calculation", async () => {
+      const totalValue = await vaultHub.totalValue(stakingVault);
+      const deltaValue = -(totalValue - 1n);
+
+      const result = await vaultHub.totalMintingCapacityShares(stakingVault, deltaValue);
+      expect(result).to.equal(0n);
+    });
+
+    it("returns 0 for disconnected vault regardless of delta", async () => {
+      const disconnectedVault = await certainAddress("disconnected-vault");
+
+      expect(await vaultHub.totalMintingCapacityShares(disconnectedVault, 0)).to.equal(0n);
+      expect(await vaultHub.totalMintingCapacityShares(disconnectedVault, ether("10"))).to.equal(0n);
+      expect(await vaultHub.totalMintingCapacityShares(disconnectedVault, -ether("5"))).to.equal(0n);
     });
   });
 });


### PR DESCRIPTION
- better parameter check in Lido.finalizeUpgrade_v3()
- prevent paying node operator fees retroactively when changing fee rate from 0 
- fix revert when burning shares on vaults when staking is paused
- now totalMintingCapacityShares() view returns proper results when unpaid fees greater than total value
- fix for maxLiabilityShares sanity check in LazyOracle 