### PR TITLE
feat: remove transfer to vault

### DIFF
--- a/contracts/0.4.24/nos/NodeOperatorsRegistry.sol
+++ b/contracts/0.4.24/nos/NodeOperatorsRegistry.sol
@@ -276,11 +276,6 @@ contract NodeOperatorsRegistry is AragonApp, Versioned {
         _initialize_v4(_exitDeadlineThresholdInSeconds);
     }
 
-    /// @notice Overrides default AragonApp behaviour to disallow recovery
-    function transferToVault(address /* _token */) external {
-        revert("NOT_SUPPORTED");
-    }
-
     /// @notice Add node operator named `name` with reward address `rewardAddress` and staking limit = 0 validators
     /// @param _name Human-readable name
     /// @param _rewardAddress Ethereum 1 address which receives stETH rewards for this operator

--- a/test/0.4.24/nor/nor.aux.test.ts
+++ b/test/0.4.24/nor/nor.aux.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { encodeBytes32String, ZeroAddress } from "ethers";
+import { encodeBytes32String } from "ethers";
 import { ethers } from "hardhat";
 
 import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
@@ -302,12 +302,6 @@ describe("NodeOperatorsRegistry.sol:auxiliary", () => {
         .withArgs(nonce + 1n)
         .to.emit(nor, "NonceChanged")
         .withArgs(nonce + 1n);
-    });
-  });
-
-  context("transferToVault", () => {
-    it("Reverts always", async () => {
-      await expect(nor.transferToVault(ZeroAddress)).to.be.revertedWith("NOT_SUPPORTED");
     });
   });
 });


### PR DESCRIPTION
An addition that is not intended to be included in the scope of V3. 
Details https://research.lido.fi/t/post-mortem-nor-curated-module-sdvt-recovery-lever-weakness/10282