### PR TITLE
[VAULTS] Audit fixes - 9

### DIFF
--- a/contracts/0.8.25/vaults/LazyOracle.sol
+++ b/contracts/0.8.25/vaults/LazyOracle.sol
@@ -266,16 +266,17 @@ contract LazyOracle is ILazyOracle, AccessControlEnumerableUpgradeable {
     }
 
     /**
-     * @notice batch method to mass check the validator stages in PredepositGuarantee contract
+     * @notice batch method to mass check the validator statuses in PredepositGuarantee contract
      * @param _pubkeys the array of validator's pubkeys to check
+     * @return batch array of IPredepositGuarantee.ValidatorStatus structs
      */
-    function batchValidatorStages(
+    function batchValidatorStatuses(
         bytes[] calldata _pubkeys
-    ) external view returns (IPredepositGuarantee.ValidatorStage[] memory batch) {
-        batch = new IPredepositGuarantee.ValidatorStage[](_pubkeys.length);
+    ) external view returns (IPredepositGuarantee.ValidatorStatus[] memory batch) {
+        batch = new IPredepositGuarantee.ValidatorStatus[](_pubkeys.length);
 
         for (uint256 i = 0; i < _pubkeys.length; i++) {
-            batch[i] = predepositGuarantee().validatorStatus(_pubkeys[i]).stage;
+            batch[i] = predepositGuarantee().validatorStatus(_pubkeys[i]);
         }
     }
 

--- a/contracts/0.8.25/vaults/OperatorGrid.sol
+++ b/contracts/0.8.25/vaults/OperatorGrid.sol
@@ -787,8 +787,9 @@ contract OperatorGrid is AccessControlEnumerableUpgradeable, Confirmable2Address
             revert ReserveRatioTooHigh(_tierId, _reserveRatioBP, MAX_RESERVE_RATIO_BP);
 
         if (_forcedRebalanceThresholdBP == 0) revert ZeroArgument("_forcedRebalanceThresholdBP");
-        if (_forcedRebalanceThresholdBP >= _reserveRatioBP)
+        if (_forcedRebalanceThresholdBP + 10 >= _reserveRatioBP) {
             revert ForcedRebalanceThresholdTooHigh(_tierId, _forcedRebalanceThresholdBP, _reserveRatioBP);
+        }
 
         if (_infraFeeBP > MAX_FEE_BP)
             revert InfraFeeTooHigh(_tierId, _infraFeeBP, MAX_FEE_BP);

--- a/contracts/0.8.25/vaults/VaultHub.sol
+++ b/contracts/0.8.25/vaults/VaultHub.sol
@@ -1218,9 +1218,6 @@ contract VaultHub is PausableUntilWithRoles {
             return 0;
         }
 
-        // if not healthy and low in debt, please rebalance the whole amount
-        if (liabilityShares_ <= 100) return liabilityShares_;
-
         uint256 reserveRatioBP = _connection.reserveRatioBP;
         uint256 maxMintableRatio = (TOTAL_BASIS_POINTS - reserveRatioBP);
         uint256 liability = _getPooledEthBySharesRoundUp(liabilityShares_);
@@ -1229,6 +1226,9 @@ contract VaultHub is PausableUntilWithRoles {
         if (liability > totalValue_) {
             return type(uint256).max;
         }
+
+        // if not healthy and low in debt, please rebalance the whole amount
+        if (liabilityShares_ <= 100) return liabilityShares_;
 
         // Solve the equation for X:
         // L - liability, TV - totalValue

--- a/contracts/0.8.25/vaults/VaultHub.sol
+++ b/contracts/0.8.25/vaults/VaultHub.sol
@@ -1218,6 +1218,9 @@ contract VaultHub is PausableUntilWithRoles {
             return 0;
         }
 
+        // if not healthy and low in debt, please rebalance the whole amount
+        if (liabilityShares_ <= 100) return liabilityShares_;
+
         uint256 reserveRatioBP = _connection.reserveRatioBP;
         uint256 maxMintableRatio = (TOTAL_BASIS_POINTS - reserveRatioBP);
         uint256 liability = _getPooledEthBySharesRoundUp(liabilityShares_);

--- a/contracts/0.8.25/vaults/VaultHub.sol
+++ b/contracts/0.8.25/vaults/VaultHub.sol
@@ -1242,10 +1242,11 @@ contract VaultHub is PausableUntilWithRoles {
         // X = (L * 100 - TV * MR) / (100 - MR)
         // RR = 100 - MR
         // X = (L * 100 - TV * MR) / RR
-        uint256 shortfallEth = (liability * TOTAL_BASIS_POINTS - totalValue_ * maxMintableRatio) / reserveRatioBP;
+        uint256 shortfallEth = Math256.ceilDiv(liability * TOTAL_BASIS_POINTS - totalValue_ * maxMintableRatio,
+            reserveRatioBP);
 
         // Add 10 extra shares to avoid dealing with rounding/precision issues
-        uint256 shortfallShares = _getSharesByPooledEth(shortfallEth) + 10;
+        uint256 shortfallShares = _getSharesByPooledEth(shortfallEth) + 100;
 
         return Math256.min(shortfallShares, liabilityShares_);
     }

--- a/contracts/0.8.25/vaults/VaultHub.sol
+++ b/contracts/0.8.25/vaults/VaultHub.sol
@@ -432,7 +432,6 @@ contract VaultHub is PausableUntilWithRoles {
     }
 
     /// @notice updates the vault's connection parameters
-    /// @dev Reverts if the vault is not healthy as of latest report
     /// @param _vault vault address
     /// @param _shareLimit new share limit
     /// @param _reserveRatioBP new reserve ratio
@@ -440,6 +439,7 @@ contract VaultHub is PausableUntilWithRoles {
     /// @param _infraFeeBP new infra fee
     /// @param _liquidityFeeBP new liquidity fee
     /// @param _reservationFeeBP new reservation fee
+    /// @dev reverts if the vault's minting capacity will be exceeded with new parameters
     /// @dev requires the fresh report
     function updateConnection(
         address _vault,

--- a/contracts/0.8.25/vaults/VaultHub.sol
+++ b/contracts/0.8.25/vaults/VaultHub.sol
@@ -1245,7 +1245,7 @@ contract VaultHub is PausableUntilWithRoles {
         uint256 shortfallEth = Math256.ceilDiv(liability * TOTAL_BASIS_POINTS - totalValue_ * maxMintableRatio,
             reserveRatioBP);
 
-        // Add 10 extra shares to avoid dealing with rounding/precision issues
+        // Add 100 extra shares to avoid dealing with rounding/precision issues
         uint256 shortfallShares = _getSharesByPooledEth(shortfallEth) + 100;
 
         return Math256.min(shortfallShares, liabilityShares_);

--- a/contracts/0.8.25/vaults/VaultHub.sol
+++ b/contracts/0.8.25/vaults/VaultHub.sol
@@ -439,7 +439,7 @@ contract VaultHub is PausableUntilWithRoles {
     /// @param _infraFeeBP new infra fee
     /// @param _liquidityFeeBP new liquidity fee
     /// @param _reservationFeeBP new reservation fee
-    /// @dev reverts if the vault's minting capacity will be exceeded with new parameters
+    /// @dev reverts if the vault's minting capacity will be exceeded with new reserve parameters
     /// @dev requires the fresh report
     function updateConnection(
         address _vault,

--- a/test/0.8.25/vaults/operatorGrid/operatorGrid.test.ts
+++ b/test/0.8.25/vaults/operatorGrid/operatorGrid.test.ts
@@ -230,7 +230,7 @@ describe("OperatorGrid.sol", () => {
       const operatorGridLocal = await ethers.getContractAt("OperatorGrid", operatorGridProxy, deployer);
       const defaultTierParams = {
         shareLimit: DEFAULT_TIER_SHARE_LIMIT,
-        reserveRatioBP: RESERVE_RATIO,
+        reserveRatioBP: RESERVE_RATIO + 10,
         forcedRebalanceThresholdBP: RESERVE_RATIO,
         infraFeeBP: INFRA_FEE,
         liquidityFeeBP: LIQUIDITY_FEE,
@@ -238,7 +238,7 @@ describe("OperatorGrid.sol", () => {
       };
       await expect(operatorGridLocal.initialize(stranger, defaultTierParams))
         .to.be.revertedWithCustomError(operatorGridLocal, "ForcedRebalanceThresholdTooHigh")
-        .withArgs("0", RESERVE_RATIO, RESERVE_RATIO);
+        .withArgs("0", RESERVE_RATIO, RESERVE_RATIO + 10);
     });
   });
 

--- a/test/0.8.25/vaults/vaulthub/vaulthub.hub.test.ts
+++ b/test/0.8.25/vaults/vaulthub/vaulthub.hub.test.ts
@@ -597,7 +597,7 @@ describe("VaultHub.sol:hub", () => {
       const totalValue_ = await vaultHub.totalValue(vault);
 
       const shortfallEth = ceilDiv(liability * TOTAL_BASIS_POINTS - totalValue_ * maxMintableRatio, 50_00n);
-      const shortfallShares = (await lido.getSharesByPooledEth(shortfallEth)) + 10n;
+      const shortfallShares = (await lido.getSharesByPooledEth(shortfallEth)) + 100n;
 
       expect(await vaultHub.healthShortfallShares(vault)).to.equal(shortfallShares);
     });
@@ -652,7 +652,7 @@ describe("VaultHub.sol:hub", () => {
     it("returns correct value for rebalance vault", async () => {
       const { vault } = await createAndConnectVault(vaultFactory, {
         shareLimit: ether("100"), // just to bypass the share limit check
-        reserveRatioBP: 50_00n, // 50%
+        reserveRatioBP: 50_00n, // 50%s
         forcedRebalanceThresholdBP: 50_00n, // 50%
       });
 
@@ -678,7 +678,7 @@ describe("VaultHub.sol:hub", () => {
       const totalValue_ = await vaultHub.totalValue(vault);
 
       const shortfallEth = ceilDiv(liability * TOTAL_BASIS_POINTS - totalValue_ * maxMintableRatio, 50_00n);
-      const shortfallShares = (await lido.getSharesByPooledEth(shortfallEth)) + 10n;
+      const shortfallShares = (await lido.getSharesByPooledEth(shortfallEth)) + 100n;
 
       expect(await vaultHub.healthShortfallShares(vault)).to.equal(shortfallShares);
     });

--- a/test/integration/vaults/vaulthub.shortfall.integration.ts
+++ b/test/integration/vaults/vaulthub.shortfall.integration.ts
@@ -139,7 +139,30 @@ describe("Integration: VaultHub Shortfall", () => {
       expect(await vaultHub.isVaultHealthy(stakingVault)).to.be.true;
     });
 
-    it("Works on small numbers", async () => {
+    it("Works on (TV=1000, LS=689, rr=2000 frt=1999) and shareRate 1.162518454795922", async () => {
+      await ensureExactShareRate(ctx, (1162518454795922n * SHARE_RATE_PRECISION) / 1000000000000000n);
+      ({ stakingVault, dashboard, vaultHub } = await setup({ rr: 2000n, frt: 1999n }));
+
+      await vaultHub.fund(stakingVault, { value: ether("1") });
+      expect(await vaultHub.totalValue(stakingVault)).to.equal(ether("2"));
+
+      await dashboard.mintShares(owner, 689n);
+
+      await reportVaultDataWithProof(ctx, stakingVault, {
+        totalValue: 1000n,
+        waitForNextRefSlot: true,
+      });
+
+      expect(await vaultHub.isVaultHealthy(stakingVault)).to.be.false;
+      const shortfall = await vaultHub.healthShortfallShares(stakingVault);
+      await dashboard.connect(owner).rebalanceVaultWithShares(shortfall);
+      const shortfall2 = await vaultHub.healthShortfallShares(stakingVault);
+      expect(shortfall2).to.equal(0n);
+      expect(await vaultHub.isVaultHealthy(stakingVault)).to.be.true;
+    });
+
+    it("Works on (TV=1000, LS=235, rr=2000 frt=1999) and shareRate 1.162518454795922", async () => {
+      await ensureExactShareRate(ctx, (1162518454795922n * SHARE_RATE_PRECISION) / 1000000000000000n);
       ({ stakingVault, dashboard, vaultHub } = await setup({ rr: 2000n, frt: 1999n }));
 
       await vaultHub.fund(stakingVault, { value: ether("1") });
@@ -235,6 +258,28 @@ describe("Integration: VaultHub Shortfall", () => {
 
       await reportVaultDataWithProof(ctx, stakingVault, {
         totalValue: 22n,
+        waitForNextRefSlot: true,
+      });
+
+      expect(await vaultHub.isVaultHealthy(stakingVault)).to.be.false;
+      const shortfall = await vaultHub.healthShortfallShares(stakingVault);
+      await dashboard.connect(owner).rebalanceVaultWithShares(shortfall);
+      const shortfall2 = await vaultHub.healthShortfallShares(stakingVault);
+      expect(await vaultHub.isVaultHealthy(stakingVault)).to.be.true;
+      expect(shortfall2).to.equal(0n);
+    });
+
+    it("Works on (TV=15, LS=12, rr=772 frt=769) and shareRate 1.125", async () => {
+      await ensureExactShareRate(ctx, (112500n * SHARE_RATE_PRECISION) / 100000n);
+      ({ stakingVault, dashboard, vaultHub } = await setup({ rr: 772n, frt: 769n }));
+
+      await vaultHub.fund(stakingVault, { value: ether("1") });
+      expect(await vaultHub.totalValue(stakingVault)).to.equal(ether("2"));
+
+      await dashboard.mintShares(owner, 12n);
+
+      await reportVaultDataWithProof(ctx, stakingVault, {
+        totalValue: 15n,
         waitForNextRefSlot: true,
       });
 

--- a/test/integration/vaults/vaulthub.shortfall.integration.ts
+++ b/test/integration/vaults/vaulthub.shortfall.integration.ts
@@ -95,7 +95,7 @@ describe("Integration: VaultHub Shortfall", () => {
 
   describe("Shortfall", () => {
     it("Works on larger numbers", async () => {
-      ({ stakingVault, dashboard, vaultHub } = await setup({ rr: 2000n, frt: 1999n }));
+      ({ stakingVault, dashboard, vaultHub } = await setup({ rr: 2000n, frt: 1989n }));
 
       await vaultHub.fund(stakingVault, { value: ether("1") });
       expect(await vaultHub.totalValue(stakingVault)).to.equal(ether("2"));
@@ -141,12 +141,12 @@ describe("Integration: VaultHub Shortfall", () => {
 
     it("Works on (TV=1000, LS=689, rr=2000 frt=1999) and shareRate 1.162518454795922", async () => {
       await ensureExactShareRate(ctx, (1162518454795922n * SHARE_RATE_PRECISION) / 1000000000000000n);
-      ({ stakingVault, dashboard, vaultHub } = await setup({ rr: 2000n, frt: 1999n }));
+      ({ stakingVault, dashboard, vaultHub } = await setup({ rr: 2000n, frt: 1989n }));
 
       await vaultHub.fund(stakingVault, { value: ether("1") });
       expect(await vaultHub.totalValue(stakingVault)).to.equal(ether("2"));
 
-      await dashboard.mintShares(owner, 689n);
+      await dashboard.mintShares(owner, 699n);
 
       await reportVaultDataWithProof(ctx, stakingVault, {
         totalValue: 1000n,
@@ -161,14 +161,14 @@ describe("Integration: VaultHub Shortfall", () => {
       expect(await vaultHub.isVaultHealthy(stakingVault)).to.be.true;
     });
 
-    it("Works on (TV=1000, LS=235, rr=2000 frt=1999) and shareRate 1.162518454795922", async () => {
+    it("Works on (TV=1000, LS=235, rr=2000 frt=1989) and shareRate 1.162518454795922", async () => {
       await ensureExactShareRate(ctx, (1162518454795922n * SHARE_RATE_PRECISION) / 1000000000000000n);
-      ({ stakingVault, dashboard, vaultHub } = await setup({ rr: 2000n, frt: 1999n }));
+      ({ stakingVault, dashboard, vaultHub } = await setup({ rr: 2000n, frt: 1989n }));
 
       await vaultHub.fund(stakingVault, { value: ether("1") });
       expect(await vaultHub.totalValue(stakingVault)).to.equal(ether("2"));
 
-      await dashboard.mintShares(owner, 689n);
+      await dashboard.mintShares(owner, 699n);
 
       await reportVaultDataWithProof(ctx, stakingVault, {
         totalValue: 1000n,
@@ -184,7 +184,7 @@ describe("Integration: VaultHub Shortfall", () => {
     });
 
     it("Works on really small numbers", async () => {
-      ({ stakingVault, dashboard, vaultHub } = await setup({ rr: 2000n, frt: 1999n }));
+      ({ stakingVault, dashboard, vaultHub } = await setup({ rr: 2000n, frt: 1989n }));
 
       await vaultHub.fund(stakingVault, { value: ether("1") });
       expect(await vaultHub.totalValue(stakingVault)).to.equal(ether("2"));
@@ -206,7 +206,7 @@ describe("Integration: VaultHub Shortfall", () => {
     });
 
     it("Works on numbers less than 10", async () => {
-      ({ stakingVault, dashboard, vaultHub } = await setup({ rr: 2000n, frt: 1999n }));
+      ({ stakingVault, dashboard, vaultHub } = await setup({ rr: 2000n, frt: 1989n }));
 
       await vaultHub.fund(stakingVault, { value: ether("1") });
       expect(await vaultHub.totalValue(stakingVault)).to.equal(ether("2"));
@@ -227,7 +227,7 @@ describe("Integration: VaultHub Shortfall", () => {
     });
 
     it("Works on hundreds", async () => {
-      ({ stakingVault, dashboard, vaultHub } = await setup({ rr: 2000n, frt: 1999n }));
+      ({ stakingVault, dashboard, vaultHub } = await setup({ rr: 2000n, frt: 1989n }));
 
       await vaultHub.fund(stakingVault, { value: ether("1") });
       expect(await vaultHub.totalValue(stakingVault)).to.equal(ether("2"));
@@ -249,7 +249,7 @@ describe("Integration: VaultHub Shortfall", () => {
 
     it("Works on (TV=22, LS=11, rr=frt=499) and shareRate 1.90909", async () => {
       await ensureExactShareRate(ctx, (190909n * SHARE_RATE_PRECISION) / 100000n);
-      ({ stakingVault, dashboard, vaultHub } = await setup({ rr: 500n, frt: 499n }));
+      ({ stakingVault, dashboard, vaultHub } = await setup({ rr: 500n, frt: 489n }));
 
       await vaultHub.fund(stakingVault, { value: ether("1") });
       expect(await vaultHub.totalValue(stakingVault)).to.equal(ether("2"));
@@ -271,7 +271,7 @@ describe("Integration: VaultHub Shortfall", () => {
 
     it("Works on (TV=15, LS=12, rr=772 frt=769) and shareRate 1.125", async () => {
       await ensureExactShareRate(ctx, (112500n * SHARE_RATE_PRECISION) / 100000n);
-      ({ stakingVault, dashboard, vaultHub } = await setup({ rr: 772n, frt: 769n }));
+      ({ stakingVault, dashboard, vaultHub } = await setup({ rr: 772n, frt: 761n }));
 
       await vaultHub.fund(stakingVault, { value: ether("1") });
       expect(await vaultHub.totalValue(stakingVault)).to.equal(ether("2"));


### PR DESCRIPTION
Final final batch of small but important changes:

- replace `LazyOracle.batchValidatorStages()` to `LazyOracle.batchValidatorStatuses()` to retrieve more info on validators' predeposits in oracle 
- allow updating fee rates and sharelimit even if the vault is unhealthy
- healthShortfall tweaks to counter rounding issues
- force forceRabalanceThreshold being more than 10 bp less than reserveRatio
