### PR TITLE
[VAULTS] Audit fixes 10

### DIFF
--- a/contracts/0.4.24/Lido.sol
+++ b/contracts/0.4.24/Lido.sol
@@ -357,7 +357,7 @@ contract Lido is Versioned, StETHPermit, AragonApp {
      *
      * @dev Reverts if:
      * - `_maxStakeLimit` == 0
-     * - `_maxStakeLimit` >= 2^96
+     * - `_maxStakeLimit` >= 2^95 (1/2 of uint96)
      * - `_maxStakeLimit` < `_stakeLimitIncreasePerBlock`
      * - `_maxStakeLimit` / `_stakeLimitIncreasePerBlock` >= 2^32 (only if `_stakeLimitIncreasePerBlock` != 0)
      *
@@ -366,6 +366,8 @@ contract Lido is Versioned, StETHPermit, AragonApp {
      */
     function setStakingLimit(uint256 _maxStakeLimit, uint256 _stakeLimitIncreasePerBlock) external {
         _auth(STAKING_CONTROL_ROLE);
+
+        require(_maxStakeLimit <= uint96(-1) / 2, "TOO_LARGE_MAX_STAKE_LIMIT");
 
         STAKING_STATE_POSITION.setStorageStakeLimitStruct(
             STAKING_STATE_POSITION.getStorageStakeLimitStruct().setStakingLimit(

--- a/contracts/0.8.25/vaults/VaultHub.sol
+++ b/contracts/0.8.25/vaults/VaultHub.sol
@@ -357,9 +357,12 @@ contract VaultHub is PausableUntilWithRoles {
     }
 
     /// @notice amount of bad debt to be internalized to become the protocol loss
-    /// @return the number of shares to internalize as bad debt during the oracle report
-    /// @dev the value is lagging increases that was done after the current refSlot to the next one
     function badDebtToInternalize() external view returns (uint256) {
+        return _storage().badDebtToInternalize.value;
+    }
+
+    /// @notice amount of bad debt to be internalized to become the protocol loss (that was actual on the last refSlot)
+    function badDebtToInternalizeForLastRefSlot() external view returns (uint256) {
         return _storage().badDebtToInternalize.getValueForLastRefSlot(CONSENSUS_CONTRACT);
     }
 
@@ -460,7 +463,7 @@ contract VaultHub is PausableUntilWithRoles {
         _requireFreshReport(_vault, record);
 
         if (
-            _reserveRatioBP != connection.reserveRatioBP || 
+            _reserveRatioBP != connection.reserveRatioBP ||
             _forcedRebalanceThresholdBP != connection.forcedRebalanceThresholdBP
         ) {
             uint256 totalValue_ = _totalValue(record);

--- a/contracts/common/interfaces/IVaultHub.sol
+++ b/contracts/common/interfaces/IVaultHub.sol
@@ -8,6 +8,7 @@ pragma solidity >=0.5.0;
 
 interface IVaultHub {
     function badDebtToInternalize() external view returns (uint256);
+    function badDebtToInternalizeForLastRefSlot() external view returns (uint256);
 
     function decreaseInternalizedBadDebt(uint256 _amountOfShares) external;
 }

--- a/lib/protocol/helpers/accounting.ts
+++ b/lib/protocol/helpers/accounting.ts
@@ -344,7 +344,7 @@ type SimulateReportResult = {
 /**
  * Simulate oracle report to get the expected result.
  */
-const simulateReport = async (
+export const simulateReport = async (
   ctx: ProtocolContext,
   { refSlot, beaconValidators, clBalance, withdrawalVaultBalance, elRewardsVaultBalance }: SimulateReportParams,
 ): Promise<SimulateReportResult> => {
@@ -363,7 +363,7 @@ const simulateReport = async (
 
   const reportValues: ReportValuesStruct = {
     timestamp: reportTimestamp,
-    timeElapsed: (await getReportTimeElapsed(ctx)).timeElapsed,
+    timeElapsed: /* 1 day */ 86_400n,
     clValidators: beaconValidators,
     clBalance,
     withdrawalVaultBalance,

--- a/test/0.4.24/lido/lido.staking-limit.test.ts
+++ b/test/0.4.24/lido/lido.staking-limit.test.ts
@@ -84,6 +84,21 @@ describe("Lido.sol:staking-limit", () => {
       expect(await lido.getCurrentStakeLimit()).to.equal(maxStakeLimit);
     });
 
+    it("Works with the maximum possible max stake limit", async () => {
+      const maxAllowed = (2n ** 96n - 1n) / 2n;
+      const bigStakeLimitIncreasePerBlock = maxAllowed / 7200n;
+      await expect(lido.setStakingLimit(maxAllowed, bigStakeLimitIncreasePerBlock))
+        .to.emit(lido, "StakingLimitSet")
+        .withArgs(maxAllowed, bigStakeLimitIncreasePerBlock);
+    });
+
+    it("Reverts if the max stake limit is too large", async () => {
+      const nonAllowed = (2n ** 96n - 1n) / 2n + 1n;
+      await expect(lido.setStakingLimit(nonAllowed, stakeLimitIncreasePerBlock)).to.be.revertedWith(
+        "TOO_LARGE_MAX_STAKE_LIMIT",
+      );
+    });
+
     it("Reverts if the caller is unauthorized", async () => {
       await expect(
         lido.connect(stranger).setStakingLimit(maxStakeLimit, stakeLimitIncreasePerBlock),

--- a/test/0.8.9/oracle/VaultHub__MockForAccReport.sol
+++ b/test/0.8.9/oracle/VaultHub__MockForAccReport.sol
@@ -2,18 +2,28 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.8.9;
 
-contract VaultHub__MockForAccountingReport {
-    uint256 public badDebtToInternalize;
+import {IVaultHub} from "contracts/common/interfaces/IVaultHub.sol";
+
+contract VaultHub__MockForAccountingReport is IVaultHub {
+    uint256 private badDebtToInternalize_;
 
     function mock__badDebtToInternalize() external view returns (uint256) {
-        return badDebtToInternalize;
+        return badDebtToInternalize_;
     }
 
     function setBadDebtToInternalize(uint256 _badDebt) external {
-        badDebtToInternalize = _badDebt;
+        badDebtToInternalize_ = _badDebt;
     }
 
     function decreaseInternalizedBadDebt(uint256 _badDebt) external {
-        badDebtToInternalize -= _badDebt;
+        badDebtToInternalize_ -= _badDebt;
+    }
+
+    function badDebtToInternalize() external view override returns (uint256) {
+        return badDebtToInternalize_;
+    }
+
+    function badDebtToInternalizeForLastRefSlot() external view override returns (uint256) {
+        return badDebtToInternalize_;
     }
 }


### PR DESCRIPTION
Accounting
- make sure that simulate accounts for the current refSlot values when invoked by the oracle
Lido
- limit max staking limit to be uint96.max/2 to avoid overflow on burn
