### PR TITLE
[VAULTS]: Audit fixes 11

### DIFF
--- a/contracts/0.8.25/vaults/dashboard/Permissions.sol
+++ b/contracts/0.8.25/vaults/dashboard/Permissions.sol
@@ -5,6 +5,8 @@
 pragma solidity 0.8.25;
 
 import {Clones} from "@openzeppelin/contracts-v5.2/proxy/Clones.sol";
+import {AccessControl} from "@openzeppelin/contracts-v5.2/access/AccessControl.sol";
+import {IAccessControl} from "@openzeppelin/contracts-v5.2/access/IAccessControl.sol";
 import {AccessControlConfirmable} from "contracts/0.8.25/utils/AccessControlConfirmable.sol";
 import {ILidoLocator} from "contracts/common/interfaces/ILidoLocator.sol";
 
@@ -174,6 +176,13 @@ abstract contract Permissions is AccessControlConfirmable {
         for (uint256 i = 0; i < _assignments.length; i++) {
             revokeRole(_assignments[i].role, _assignments[i].account);
         }
+    }
+
+    /**
+     * @notice Role renouncement is disabled to avoid accidental access loss.
+     */
+    function renounceRole(bytes32, address) public pure override(AccessControl, IAccessControl) {
+        revert RoleRenouncementDisabled();
     }
 
     /**
@@ -370,4 +379,9 @@ abstract contract Permissions is AccessControlConfirmable {
      * @notice Error thrown for when a given address cannot be zero
      */
     error ZeroAddress();
+
+    /**
+     * @notice Error thrown when attempting to renounce a role.
+     */
+    error RoleRenouncementDisabled();
 }

--- a/test/0.8.25/vaults/permissions/permissions.test.ts
+++ b/test/0.8.25/vaults/permissions/permissions.test.ts
@@ -386,6 +386,20 @@ describe("Permissions", () => {
     });
   });
 
+  context("renounceRole()", () => {
+    it("reverts if called by a stranger", async () => {
+      await expect(
+        permissions.connect(stranger).renounceRole(await permissions.DEFAULT_ADMIN_ROLE(), stranger),
+      ).to.be.revertedWithCustomError(permissions, "RoleRenouncementDisabled");
+    });
+
+    it("reverts if called by the role holder", async () => {
+      await expect(
+        permissions.connect(defaultAdmin).renounceRole(await permissions.DEFAULT_ADMIN_ROLE(), defaultAdmin),
+      ).to.be.revertedWithCustomError(permissions, "RoleRenouncementDisabled");
+    });
+  });
+
   context("revokeRoles()", () => {
     it("mass-revokes roles", async () => {
       const [

--- a/test/integration/vaults/roles.integration.ts
+++ b/test/integration/vaults/roles.integration.ts
@@ -388,6 +388,20 @@ describe("Integration: Staking Vaults Dashboard Roles Initial Setup", () => {
             await dashboard.VAULT_CONFIGURATION_ROLE(),
           );
         });
+
+        describe("renounceRole()", () => {
+          for (const role of vaultRoleKeys) {
+            it(`reverts if called for role ${role}`, async () => {
+              const roleMethods = getRoleMethods(dashboard);
+              const roleId = await roleMethods[role];
+              const caller = roles[role];
+              await expect(dashboard.connect(caller).renounceRole(roleId, caller)).to.be.revertedWithCustomError(
+                dashboard,
+                "RoleRenouncementDisabled",
+              );
+            });
+          }
+        });
       });
     });
 


### PR DESCRIPTION
Users (especially critical roles like default admin or node operator manager) can accidentally renounce their role.

## Solution

Override the method and always revert