### PR TITLE
feat: additional setup for scripts CI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -341,7 +341,7 @@ This is the most common method for running integration tests. It uses an instanc
 mainnet environment, allowing you to run integration tests with trace logging.
 
 > [!NOTE]
-> Ensure that `FORK_RPC_URL` is set to Ethereum Mainnet RPC and `MAINNET_*` environment variables are set in the
+> Ensure that `RPC_URL` is set to Ethereum Mainnet RPC and `MAINNET_*` environment variables are set in the
 > `.env` file (refer to `.env.example` for guidance). Otherwise, the tests will run against the Scratch deployment.
 
 ```bash

--- a/deployed-mainnet-v3.json
+++ b/deployed-mainnet-v3.json
@@ -1,0 +1,866 @@
+{
+  "accounting": {
+    "proxy": {
+      "contract": "contracts/0.8.9/proxy/OssifiableProxy.sol",
+      "address": "0xc9158c756D2a510eaC85792C847798a30dE20D46",
+      "constructorArgs": [
+        "0x1bE2Ee7D32e3F9C4ecd5b6BfF69306ACb8Ab239e",
+        "0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c",
+        "0x"
+      ]
+    },
+    "implementation": {
+      "contract": "contracts/0.8.9/Accounting.sol",
+      "address": "0x1bE2Ee7D32e3F9C4ecd5b6BfF69306ACb8Ab239e",
+      "constructorArgs": ["0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb", "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84"]
+    }
+  },
+  "accountingOracle": {
+    "deployParameters": {
+      "consensusVersion": 1
+    },
+    "proxy": {
+      "address": "0x852deD011285fe67063a08005c71a85690503Cee",
+      "contract": "contracts/0.8.9/proxy/OssifiableProxy.sol",
+      "deployTx": "0x3def88f27741216b131de2861cf89af2ca2ac4242b384ee33dca8cc70c51c8dd",
+      "constructorArgs": [
+        "0x6F6541C2203196fEeDd14CD2C09550dA1CbEDa31",
+        "0x8Ea83AD72396f1E0cD2f8E72b1461db8Eb6aF7B5",
+        "0x"
+      ]
+    },
+    "implementation": {
+      "contract": "contracts/0.8.9/oracle/AccountingOracle.sol",
+      "address": "0xb2295820F5286BE40c2da8102eB2cDB24aD608Be",
+      "constructorArgs": ["0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb", 12, 1606824023]
+    }
+  },
+  "apmRegistryFactoryAddress": "0xa0BC4B67F5FacDE4E50EAFF48691Cfc43F4E280A",
+  "app:aragon-agent": {
+    "implementation": {
+      "contract": "@aragon/apps-agent/contracts/Agent.sol",
+      "address": "0x3A93C17FC82CC33420d1809dDA9Fb715cc89dd37",
+      "constructorArgs": []
+    },
+    "aragonApp": {
+      "name": "aragon-agent",
+      "fullName": "aragon-agent.lidopm.eth",
+      "id": "0x701a4fd1f5174d12a0f1d9ad2c88d0ad11ab6aad0ac72b7d9ce621815f8016a9"
+    },
+    "proxy": {
+      "address": "0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c",
+      "contract": "@aragon/os/contracts/apps/AppProxyUpgradeable.sol"
+    }
+  },
+  "app:aragon-finance": {
+    "implementation": {
+      "contract": "@aragon/apps-finance/contracts/Finance.sol",
+      "address": "0x836835289A2E81B66AE5d95b7c8dBC0480dCf9da",
+      "constructorArgs": []
+    },
+    "aragonApp": {
+      "name": "aragon-finance",
+      "fullName": "aragon-finance.lidopm.eth",
+      "id": "0x5c9918c99c4081ca9459c178381be71d9da40e49e151687da55099c49a4237f1"
+    },
+    "proxy": {
+      "address": "0xB9E5CBB9CA5b0d659238807E84D0176930753d86",
+      "contract": "@aragon/os/contracts/apps/AppProxyUpgradeable.sol"
+    }
+  },
+  "app:aragon-token-manager": {
+    "implementation": {
+      "contract": "@aragon/apps-lido/apps/token-manager/contracts/TokenManager.sol",
+      "address": "0xde3A93028F2283cc28756B3674BD657eaFB992f4",
+      "constructorArgs": []
+    },
+    "aragonApp": {
+      "name": "aragon-token-manager",
+      "fullName": "aragon-token-manager.lidopm.eth",
+      "id": "0xcd567bdf93dd0f6acc3bc7f2155f83244d56a65abbfbefb763e015420102c67b"
+    },
+    "proxy": {
+      "address": "0xf73a1260d222f447210581DDf212D915c09a3249",
+      "contract": "@aragon/os/contracts/apps/AppProxyUpgradeable.sol"
+    }
+  },
+  "app:aragon-voting": {
+    "implementation": {
+      "contract": "@aragon/apps-lido/apps/voting/contracts/Voting.sol",
+      "address": "0x72fb5253AD16307B9E773d2A78CaC58E309d5Ba4",
+      "constructorArgs": []
+    },
+    "aragonApp": {
+      "name": "aragon-voting",
+      "fullName": "aragon-voting.lidopm.eth",
+      "id": "0x0abcd104777321a82b010357f20887d61247493d89d2e987ff57bcecbde00e1e"
+    },
+    "proxy": {
+      "address": "0x2e59A20f205bB85a89C53f1936454680651E618e",
+      "contract": "@aragon/os/contracts/apps/AppProxyUpgradeable.sol"
+    }
+  },
+  "app:lido": {
+    "proxy": {
+      "address": "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84"
+    },
+    "implementation": {
+      "contract": "contracts/0.4.24/Lido.sol",
+      "address": "0xD0b9826e0EAf6dE91CE7A6783Cd6fd137ae422Ec",
+      "constructorArgs": []
+    },
+    "aragonApp": {
+      "fullName": "lido.lidopm.eth",
+      "name": "lido",
+      "id": "0x3ca7c3e38968823ccb4c78ea688df41356f182ae1d159e4ee608d30d68cef320",
+      "ipfsCid": "QmQkJMtvu4tyJvWrPXJfjLfyTWn959iayyNjp7YqNzX7pS",
+      "contentURI": "0x697066733a516d516b4a4d7476753474794a76577250584a666a4c667954576e393539696179794e6a703759714e7a58377053"
+    }
+  },
+  "app:node-operators-registry": {
+    "proxy": {
+      "address": "0x55032650b14df07b85bF18A3a3eC8E0Af2e028d5"
+    },
+    "implementation": {
+      "contract": "contracts/0.4.24/nos/NodeOperatorsRegistry.sol",
+      "address": "0x6828b023e737f96B168aCd0b5c6351971a4F81aE",
+      "constructorArgs": []
+    },
+    "aragonApp": {
+      "fullName": "node-operators-registry.lidopm.eth",
+      "name": "node-operators-registry",
+      "id": "0x7071f283424072341f856ac9e947e7ec0eb68719f757a7e785979b6b8717579d",
+      "ipfsCid": "Qma7PXHmEj4js2gjM9vtHPtqvuK82iS5EYPiJmzKLzU58G",
+      "contentURI": "0x697066733a516d61375058486d456a346a7332676a4d3976744850747176754b3832695335455950694a6d7a4b4c7a55353847"
+    }
+  },
+  "app:oracle": {
+    "proxy": {
+      "address": "0x442af784A788A5bd6F42A01Ebe9F287a871243fb"
+    },
+    "implementation": {
+      "address": "0xa29b819654cE6224A222bb5f586920105E2D7E0E",
+      "contract": "contracts/0.4.24/oracle/LegacyOracle.sol",
+      "deployTx": "0xe666e3ce409bb4c18e1016af0b9ed3495b20361a69f2856bccb9e67599795b6f",
+      "constructorArgs": []
+    },
+    "aragonApp": {
+      "fullName": "oracle.lidopm.eth",
+      "name": "oracle",
+      "id": "0x8b47ba2a8454ec799cd91646e7ec47168e91fd139b23f017455f3e5898aaba93",
+      "ipfsCid": "QmUMPfiEKq5Mxm8y2GYQPLujGaJiWz1tvep5W7EdAGgCR8",
+      "contentURI": "0x697066733a516d656138394d5533504852503763513157616b3672327355654d554146324c39727132624c6d5963644b764c57"
+    }
+  },
+  "app:simple-dvt": {
+    "stakingRouterModuleParams": {
+      "moduleName": "SimpleDVT",
+      "moduleType": "curated-onchain-v1",
+      "targetShare": 50,
+      "moduleFee": 800,
+      "treasuryFee": 200,
+      "penaltyDelay": 432000,
+      "easyTrackTrustedCaller": "0x08637515E85A4633E23dfc7861e2A9f53af640f7",
+      "easyTrackAddress": "0xF0211b7660680B49De1A7E9f25C65660F0a13Fea",
+      "easyTrackFactories": {
+        "AddNodeOperators": "0xcAa3AF7460E83E665EEFeC73a7a542E5005C9639",
+        "ActivateNodeOperators": "0xCBb418F6f9BFd3525CE6aADe8F74ECFEfe2DB5C8",
+        "DeactivateNodeOperators": "0x8B82C1546D47330335a48406cc3a50Da732672E7",
+        "SetVettedValidatorsLimits": "0xD75778b855886Fc5e1eA7D6bFADA9EB68b35C19D",
+        "SetNodeOperatorNames": "0x7d509BFF310d9460b1F613e4e40d342201a83Ae4",
+        "SetNodeOperatorRewardAddresses": "0x589e298964b9181D9938B84bB034C3BB9024E2C0",
+        "UpdateTargetValidatorLimits": "0x41CF3DbDc939c5115823Fba1432c4EC5E7bD226C",
+        "ChangeNodeOperatorManagers": "0xE31A0599A6772BCf9b2bFc9e25cf941e793c9a7D"
+      }
+    },
+    "aragonApp": {
+      "name": "simple-dvt",
+      "fullName": "simple-dvt.lidopm.eth",
+      "id": "0xe1635b63b5f7b5e545f2a637558a4029dea7905361a2f0fc28c66e9136cf86a4",
+      "ipfsCid": "QmaSSujHCGcnFuetAPGwVW5BegaMBvn5SCsgi3LSfvraSo",
+      "contentURI": "0x697066733a516d615353756a484347636e4675657441504777565735426567614d42766e355343736769334c5366767261536f"
+    },
+    "proxy": {
+      "address": "0xaE7B191A31f627b4eB1d4DaC64eaB9976995b433",
+      "contract": "@aragon/os/contracts/apps/AppProxyUpgradeable.sol",
+      "constructorArgs": [
+        "0xb8FFC3Cd6e7Cf5a098A1c92F48009765B24088Dc",
+        "0xe1635b63b5f7b5e545f2a637558a4029dea7905361a2f0fc28c66e9136cf86a4",
+        "0x"
+      ]
+    },
+    "implementation": {
+      "contract": "contracts/0.4.24/nos/NodeOperatorsRegistry.sol",
+      "address": "0x1770044a38402e3CfCa2Fcfa0C84a093c9B42135",
+      "constructorArgs": []
+    }
+  },
+  "aragon-acl": {
+    "proxy": {
+      "address": "0x9895f0f17cc1d1891b6f18ee0b483b6f221b37bb"
+    }
+  },
+  "aragon-kernel": {
+    "implementation": {
+      "contract": "@aragon/os/contracts/kernel/Kernel.sol",
+      "address": "0x2b33CF282f867A7FF693A66e11B0FcC5552e4425",
+      "constructorArgs": [true]
+    },
+    "proxy": {
+      "address": "0xb8FFC3Cd6e7Cf5a098A1c92F48009765B24088Dc",
+      "contract": "@aragon/os/contracts/kernel/KernelProxy.sol"
+    }
+  },
+  "aragon-lido-app-repo": {
+    "proxy": {
+      "address": "0xF5Dc67E54FC96F993CD06073f71ca732C1E654B1"
+    }
+  },
+  "aragon-node-operators-registry-app-repo": {
+    "proxy": {
+      "address": "0x0D97E876ad14DB2b183CFeEB8aa1A5C788eB1831"
+    }
+  },
+  "aragon-simple-dvt-app-repo": {
+    "proxy": {
+      "address": "0x2325b0a607808dE42D918DB07F925FFcCfBb2968"
+    }
+  },
+  "aragonIDAddress": "0x546aa2eae2514494eeadb7bbb35243348983c59d",
+  "burner": {
+    "address": "0xD15a672319Cf0352560eE76d9e89eAB0889046D3",
+    "contract": "contracts/0.8.9/Burner.sol",
+    "deployTx": "0xbebf5c85404a0d8e36b859046c984fdf6dd764b5d317feb7eb3525016005b1d9",
+    "constructorArgs": [
+      "0x8Ea83AD72396f1E0cD2f8E72b1461db8Eb6aF7B5",
+      "0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c",
+      "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
+      "0",
+      "32145684728326685744"
+    ],
+    "deployParameters": {
+      "totalCoverSharesBurnt": "0",
+      "totalNonCoverSharesBurnt": "32145684728326685744"
+    },
+    "proxy": {
+      "contract": "contracts/0.8.9/proxy/OssifiableProxy.sol",
+      "address": "0xD140f4f3C515E1a328F6804C5426d9e8b883ED50",
+      "constructorArgs": [
+        "0x0D3C621B5c3CE33159BeabB5E2B0D9bE3c68B590",
+        "0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c",
+        "0x400ada75000000000000000000000000d97d2666dc2fb490e9348a8bd17e9572a35b4f9d0000000000000000000000000000000000000000000000000000000000000001"
+      ]
+    },
+    "implementation": {
+      "contract": "contracts/0.8.9/Burner.sol",
+      "address": "0x0D3C621B5c3CE33159BeabB5E2B0D9bE3c68B590",
+      "constructorArgs": ["0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb", "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84"]
+    }
+  },
+  "chainSpec": {
+    "depositContractAddress": "0x00000000219ab540356cBB839Cbe05303d7705Fa",
+    "slotsPerEpoch": 32,
+    "secondsPerSlot": 12,
+    "genesisTime": 1606824023
+  },
+  "createAppReposTx": "0xf48cb21c6be021dd18bd8e02ce89ac7b924245b859f0a8b7c47e88a39016ed41",
+  "daoAragonId": "lido-dao",
+  "daoFactoryAddress": "0x7378ad1ba8f3c8e64bbb2a04473edd35846360f1",
+  "daoInitialSettings": {
+    "token": {
+      "name": "Lido DAO Token",
+      "symbol": "LDO"
+    },
+    "voting": {
+      "minSupportRequired": "500000000000000000",
+      "minAcceptanceQuorum": "50000000000000000",
+      "voteDuration": 86400
+    },
+    "fee": {
+      "totalPercent": 10,
+      "treasuryPercent": 0,
+      "insurancePercent": 50,
+      "nodeOperatorsPercent": 50
+    }
+  },
+  "daoTokenAddress": "0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32",
+  "dashboardImpl": {
+    "contract": "contracts/0.8.25/vaults/dashboard/Dashboard.sol",
+    "address": "0x08e197D82BC33Ddb7f3081f9aC31F3647cFabD46",
+    "constructorArgs": [
+      "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
+      "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+      "0xdcC04F506E24495E9F2599A7b214522647363669",
+      "0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb"
+    ]
+  },
+  "deployCommit": "e45c4d6fb8120fd29426b8d969c19d8a798ca974",
+  "deployer": "0x55Bc991b2edF3DDb4c520B222bE4F378418ff0fA",
+  "depositSecurityModule": {
+    "address": "0xfFA96D84dEF2EA035c7AB153D8B991128e3d72fD",
+    "contract": "contracts/0.8.9/DepositSecurityModule.sol",
+    "deployTx": "0x21307a2321f167f99de11ccec86d7bdd8233481bbffa493e15c519ca8d662c4f",
+    "constructorArgs": [
+      "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
+      "0x00000000219ab540356cBB839Cbe05303d7705Fa",
+      "0xFdDf38947aFB03C621C71b06C9C70bce73f12999",
+      6646,
+      200
+    ],
+    "deployParameters": {
+      "maxDepositsPerBlock": 150,
+      "minDepositBlockDistance": 25,
+      "pauseIntentValidityPeriodBlocks": 6646
+    }
+  },
+  "dg:dualGovernance": {
+    "proxy": {
+      "address": "0xC1db28B3301331277e307FDCfF8DE28242A4486E"
+    }
+  },
+  "dg:emergencyProtectedTimelock": {
+    "proxy": {
+      "address": "0xCE0425301C85c5Ea2A0873A2dEe44d78E02D2316"
+    }
+  },
+  "dummyEmptyContract": {
+    "address": "0x6F6541C2203196fEeDd14CD2C09550dA1CbEDa31",
+    "contract": "contracts/0.8.9/utils/DummyEmptyContract.sol",
+    "deployTx": "0x9d76786f639bd18365f10c087444761db5dafd0edc85c5c1a3e90219f2d1331d",
+    "constructorArgs": []
+  },
+  "easyTrack": {
+    "address": "0xF0211b7660680B49De1A7E9f25C65660F0a13Fea"
+  },
+  "easyTrackEVMScriptExecutor": {
+    "address": "0xFE5986E06210aC1eCC1aDCafc0cc7f8D63B3F977"
+  },
+  "eip712StETH": {
+    "address": "0x8F73e4C2A6D852bb4ab2A45E6a9CF5715b3228B7",
+    "contract": "contracts/0.8.9/EIP712StETH.sol",
+    "deployTx": "0xecb5010620fb13b0e2bbc98b8a0c82de0d7385491452cd36cf303cd74216ed91",
+    "constructorArgs": ["0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84"]
+  },
+  "ensAddress": "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
+  "executionLayerRewardsVault": {
+    "address": "0x388C818CA8B9251b393131C08a736A67ccB19297",
+    "contract": "contracts/0.8.9/LidoExecutionLayerRewardsVault.sol",
+    "deployTx": "0xd72cf25e4a5fe3677b6f9b2ae13771e02ad66f8d2419f333bb8bde3147bd4294"
+  },
+  "gateSeal": {
+    "address": "0x8A854C4E750CDf24f138f34A9061b2f556066912",
+    "factoryAddress": "0x6c82877cac5a7a739f16ca0a89c0a328b8764a24",
+    "sealDuration": 1209600,
+    "expiryTimestamp": 1788908579,
+    "sealingCommittee": "0x8772E3a2D86B9347A2688f9bc1808A6d8917760C"
+  },
+  "gateSealFactory": {
+    "address": "0x6c82877cac5a7a739f16ca0a89c0a328b8764a24"
+  },
+  "gateSealTW": {
+    "factoryAddress": "0x6c82877cac5a7a739f16ca0a89c0a328b8764a24",
+    "sealDuration": 1209600,
+    "expiryTimestamp": 1788908579,
+    "sealingCommittee": "0x8772E3a2D86B9347A2688f9bc1808A6d8917760C",
+    "address": "0xA6BC802fAa064414AA62117B4a53D27fFfF741F1"
+  },
+  "gateSealV3": {
+    "address": "0x9c2D30177DB12334998EB554f5d4E6dD44458167"
+  },
+  "hashConsensusForAccountingOracle": {
+    "address": "0xD624B08C83bAECF0807Dd2c6880C3154a5F0B288",
+    "contract": "contracts/0.8.9/oracle/HashConsensus.sol",
+    "deployTx": "0xd74dcca9bacede9f332d70562f49808254061853937ffbbfc7397ab5d017041a",
+    "constructorArgs": [
+      32,
+      12,
+      1606824023,
+      225,
+      100,
+      "0x8Ea83AD72396f1E0cD2f8E72b1461db8Eb6aF7B5",
+      "0x852deD011285fe67063a08005c71a85690503Cee"
+    ],
+    "deployParameters": {
+      "fastLaneLengthSlots": 100,
+      "epochsPerFrame": 225
+    }
+  },
+  "hashConsensusForValidatorsExitBusOracle": {
+    "address": "0x7FaDB6358950c5fAA66Cb5EB8eE5147De3df355a",
+    "contract": "contracts/0.8.9/oracle/HashConsensus.sol",
+    "deployTx": "0xed1ab73dd5458b5ec0b174508318d2f39a31029112af21f87d09106933bd3a9e",
+    "constructorArgs": [
+      32,
+      12,
+      1606824023,
+      75,
+      100,
+      "0x8Ea83AD72396f1E0cD2f8E72b1461db8Eb6aF7B5",
+      "0x0De4Ea0184c2ad0BacA7183356Aea5B8d5Bf5c6e"
+    ],
+    "deployParameters": {
+      "fastLaneLengthSlots": 100,
+      "epochsPerFrame": 75
+    }
+  },
+  "ipfsAPI": "https://ipfs.infura.io:5001/api/v0",
+  "lazyOracle": {
+    "proxy": {
+      "contract": "contracts/0.8.9/proxy/OssifiableProxy.sol",
+      "address": "0x4fA3c917BB8f8CD9d056C5DDF0a38bd1834c43F9",
+      "constructorArgs": [
+        "0xD517eA3605340291285136cee64F9a64A664F76C",
+        "0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c",
+        "0x4ec81af10000000000000000000000003e40d73eb977dc6a537af587d48316fee66e9c8c000000000000000000000000000000000000000000000000000000000003f480000000000000000000000000000000000000000000000000000000000000015e000000000000000000000000000000000000000000000000027f7d0bdb920000"
+      ]
+    },
+    "implementation": {
+      "contract": "contracts/0.8.25/vaults/LazyOracle.sol",
+      "address": "0xD517eA3605340291285136cee64F9a64A664F76C",
+      "constructorArgs": ["0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb"]
+    }
+  },
+  "lidoApm": {
+    "deployTx": "0xfa66476569ecef5790f2d0634997b952862bbca56aa088f151b8049421eeb87b",
+    "address": "0x0cb113890b04B49455DfE06554e2D784598A29C9"
+  },
+  "lidoApmEnsName": "lidopm.eth",
+  "lidoApmEnsRegDurationSec": 94608000,
+  "lidoLocator": {
+    "proxy": {
+      "address": "0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb",
+      "contract": "contracts/0.8.9/proxy/OssifiableProxy.sol",
+      "deployTx": "0x3a2910624533935cc8c21837b1705bcb159a760796930097016186be705cc455",
+      "constructorArgs": [
+        "0x6F6541C2203196fEeDd14CD2C09550dA1CbEDa31",
+        "0x8Ea83AD72396f1E0cD2f8E72b1461db8Eb6aF7B5",
+        "0x"
+      ]
+    },
+    "implementation": {
+      "contract": "contracts/0.8.9/LidoLocator.sol",
+      "address": "0x26329a3D4cF2F89923b5c4C14a25A2485cD01aA2",
+      "constructorArgs": [
+        {
+          "accountingOracle": "0x852deD011285fe67063a08005c71a85690503Cee",
+          "depositSecurityModule": "0xfFA96D84dEF2EA035c7AB153D8B991128e3d72fD",
+          "elRewardsVault": "0x388C818CA8B9251b393131C08a736A67ccB19297",
+          "lido": "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
+          "oracleReportSanityChecker": "0x4c42eF565ED49aDcC459a53C3abDCa86617E2f63",
+          "postTokenRebaseReceiver": "0x7c7419E1964188C6133051dF541cf2a525AA1038",
+          "burner": "0xD140f4f3C515E1a328F6804C5426d9e8b883ED50",
+          "stakingRouter": "0xFdDf38947aFB03C621C71b06C9C70bce73f12999",
+          "treasury": "0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c",
+          "validatorsExitBusOracle": "0x0De4Ea0184c2ad0BacA7183356Aea5B8d5Bf5c6e",
+          "withdrawalQueue": "0x889edC2eDab5f40e902b864aD4d7AdE8E412F9B1",
+          "withdrawalVault": "0xB9D7934878B5FB9610B3fE8A5e441e8fad7E293f",
+          "oracleDaemonConfig": "0xbf05A929c3D7885a6aeAd833a992dA6E5ac23b09",
+          "validatorExitDelayVerifier": "0xbDb567672c867DB533119C2dcD4FB9d8b44EC82f",
+          "triggerableWithdrawalsGateway": "0xDC00116a0D3E064427dA2600449cfD2566B3037B",
+          "accounting": "0xc9158c756D2a510eaC85792C847798a30dE20D46",
+          "predepositGuarantee": "0x7B49b203A100E326B84886dCC0e2c426f9b8cbBd",
+          "wstETH": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+          "vaultHub": "0xdcC04F506E24495E9F2599A7b214522647363669",
+          "vaultFactory": "0x676c573946ba7a34243f576C1F966F0ce5068739",
+          "lazyOracle": "0x4fA3c917BB8f8CD9d056C5DDF0a38bd1834c43F9",
+          "operatorGrid": "0x79e2685C1DD4756AC709a6CeE7C6cC960128B031"
+        }
+      ]
+    }
+  },
+  "lidoTemplate": {
+    "contract": "contracts/0.4.24/template/LidoTemplate.sol",
+    "address": "0x752350797CB92Ad3BF1295Faf904B27585e66BF5",
+    "deployTx": "0xdcd4ebe028aa3663a1fe8bbc92ae8489045e29d2a6ef5284083d9be5c3fa5f19",
+    "constructorArgs": [
+      "0x55Bc991b2edF3DDb4c520B222bE4F378418ff0fA",
+      "0x7378ad1ba8f3c8e64bbb2a04473edd35846360f1",
+      "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
+      "0x909d05f384d0663ed4be59863815ab43b4f347ec",
+      "0x546aa2eae2514494eeadb7bbb35243348983c59d",
+      "0xa0BC4B67F5FacDE4E50EAFF48691Cfc43F4E280A"
+    ]
+  },
+  "minFirstAllocationStrategy": {
+    "contract": "contracts/common/lib/MinFirstAllocationStrategy.sol",
+    "address": "0x7e70De6D1877B3711b2bEDa7BA00013C7142d993",
+    "constructorArgs": []
+  },
+  "miniMeTokenFactoryAddress": "0x909d05f384d0663ed4be59863815ab43b4f347ec",
+  "networkId": 1,
+  "newDaoTx": "0x3feabd79e8549ad68d1827c074fa7123815c80206498946293d5373a160fd866",
+  "operatorGrid": {
+    "proxy": {
+      "contract": "contracts/0.8.9/proxy/OssifiableProxy.sol",
+      "address": "0x79e2685C1DD4756AC709a6CeE7C6cC960128B031",
+      "constructorArgs": [
+        "0x0d442cD3D42F05D27596bEB3185dBC43A6840308",
+        "0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c",
+        "0x68d44bc0000000000000000000000000d97d2666dc2fb490e9348a8bd17e9572a35b4f9d00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001388000000000000000000000000000000000000000000000000000000000000136f0000000000000000000000000000000000000000000000000000000000000064000000000000000000000000000000000000000000000000000000000000028a0000000000000000000000000000000000000000000000000000000000000000"
+      ]
+    },
+    "implementation": {
+      "contract": "contracts/0.8.25/vaults/OperatorGrid.sol",
+      "address": "0x0d442cD3D42F05D27596bEB3185dBC43A6840308",
+      "constructorArgs": ["0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb"]
+    }
+  },
+  "oracleDaemonConfig": {
+    "address": "0xbf05A929c3D7885a6aeAd833a992dA6E5ac23b09",
+    "contract": "contracts/0.8.9/OracleDaemonConfig.sol",
+    "deployTx": "0xa4f380b8806f5a504ef67fce62989e09be5a48bf114af63483c01c22f0c9a36f",
+    "constructorArgs": ["0x8Ea83AD72396f1E0cD2f8E72b1461db8Eb6aF7B5", []],
+    "deployParameters": {
+      "NORMALIZED_CL_REWARD_PER_EPOCH": 64,
+      "NORMALIZED_CL_REWARD_MISTAKE_RATE_BP": 1000,
+      "REBASE_CHECK_NEAREST_EPOCH_DISTANCE": 1,
+      "REBASE_CHECK_DISTANT_EPOCH_DISTANCE": 23,
+      "VALIDATOR_DELAYED_TIMEOUT_IN_SLOTS": 7200,
+      "VALIDATOR_DELINQUENT_TIMEOUT_IN_SLOTS": 28800,
+      "PREDICTION_DURATION_IN_SLOTS": 50400,
+      "FINALIZATION_MAX_NEGATIVE_REBASE_EPOCH_SHIFT": 1350,
+      "NODE_OPERATOR_NETWORK_PENETRATION_THRESHOLD_BP": 100
+    }
+  },
+  "oracleReportSanityChecker": {
+    "address": "0x4c42eF565ED49aDcC459a53C3abDCa86617E2f63",
+    "contract": "contracts/0.8.9/sanity_checks/OracleReportSanityChecker.sol",
+    "deployTx": "0x700c83996ad7deefda286044280ad86108dfef9c880909bd8e75a3746f7d631c",
+    "constructorArgs": [
+      "0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb",
+      "0xb2295820F5286BE40c2da8102eB2cDB24aD608Be",
+      "0xc9158c756D2a510eaC85792C847798a30dE20D46",
+      "0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c",
+      ["3600", "1800", "1000", "50", "600", "8", "24", "7680", "750000", "8", "101", "50"]
+    ],
+    "deployParameters": {
+      "churnValidatorsPerDayLimit": 20000,
+      "oneOffCLBalanceDecreaseBPLimit": 500,
+      "annualBalanceIncreaseBPLimit": 1000,
+      "simulatedShareRateDeviationBPLimit": 50,
+      "maxValidatorExitRequestsPerReport": 600,
+      "maxAccountingExtraDataListItemsCount": 2,
+      "maxNodeOperatorsPerExtraDataItemCount": 100,
+      "requestTimestampMargin": 7680,
+      "maxPositiveTokenRebase": 750000
+    }
+  },
+  "predepositGuarantee": {
+    "proxy": {
+      "contract": "contracts/0.8.9/proxy/OssifiableProxy.sol",
+      "address": "0x7B49b203A100E326B84886dCC0e2c426f9b8cbBd",
+      "constructorArgs": [
+        "0x85cBc70D06CfD02D176c7e8474636cF9fCa414eA",
+        "0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c",
+        "0xc4d66de8000000000000000000000000d97d2666dc2fb490e9348a8bd17e9572a35b4f9d"
+      ]
+    },
+    "implementation": {
+      "contract": "contracts/0.8.25/vaults/predeposit_guarantee/PredepositGuarantee.sol",
+      "address": "0x85cBc70D06CfD02D176c7e8474636cF9fCa414eA",
+      "constructorArgs": [
+        "0x00000000",
+        "0x0000000000000000000000000000000000000000000000000096000000000028",
+        "0x0000000000000000000000000000000000000000000000000096000000000028",
+        0
+      ]
+    }
+  },
+  "resealManager": {
+    "address": "0x7914b5a1539b97Bd0bbd155757F25FD79A522d24"
+  },
+  "scratchDeployGasUsed": "60900782",
+  "stakingRouter": {
+    "proxy": {
+      "address": "0xFdDf38947aFB03C621C71b06C9C70bce73f12999",
+      "contract": "contracts/0.8.9/proxy/OssifiableProxy.sol",
+      "deployTx": "0xb8620f04a8db6bb52cfd0978c6677a5f16011e03d4622e5d660ea6ba34c2b122",
+      "constructorArgs": [
+        "0x6F6541C2203196fEeDd14CD2C09550dA1CbEDa31",
+        "0x8Ea83AD72396f1E0cD2f8E72b1461db8Eb6aF7B5",
+        "0x"
+      ]
+    },
+    "implementation": {
+      "contract": "contracts/0.8.9/StakingRouter.sol",
+      "address": "0x226f9265CBC37231882b7409658C18bB7738173A",
+      "constructorArgs": ["0x00000000219ab540356cBB839Cbe05303d7705Fa"]
+    }
+  },
+  "stakingVaultBeacon": {
+    "contract": "@openzeppelin/contracts-v5.2/proxy/beacon/UpgradeableBeacon.sol",
+    "address": "0x5D8508D1eA725d35a61886658FB4BD7795027f6C",
+    "constructorArgs": ["0xDAEf26cE8ba47d297e22A4318c1ACC5dB12dD3d6", "0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
+  },
+  "stakingVaultFactory": {
+    "contract": "contracts/0.8.25/vaults/VaultFactory.sol",
+    "address": "0x676c573946ba7a34243f576C1F966F0ce5068739",
+    "constructorArgs": [
+      "0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb",
+      "0x5D8508D1eA725d35a61886658FB4BD7795027f6C",
+      "0x08e197D82BC33Ddb7f3081f9aC31F3647cFabD46",
+      "0x0000000000000000000000000000000000000000"
+    ]
+  },
+  "stakingVaultImplementation": {
+    "contract": "contracts/0.8.25/vaults/StakingVault.sol",
+    "address": "0xDAEf26cE8ba47d297e22A4318c1ACC5dB12dD3d6",
+    "constructorArgs": ["0x00000000219ab540356cBB839Cbe05303d7705Fa"]
+  },
+  "tokenRebaseNotifier": {
+    "address": "0xe6793B9e4FbA7DE0ee833F9D02bba7DB5EB27823",
+    "contract": "contracts/0.8.9/TokenRateNotifier.sol",
+    "deployTx": "0xcbffe641fe89657368a79e7482e90ec8517b4ac6f27ad6301f52d0e9db97887d",
+    "constructorArgs": ["0xBb01c09DE4Bf967AbaB418450c3e18Df46358322", "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84"]
+  },
+  "tokenRebaseNotifierV3": {
+    "contract": "contracts/0.8.9/TokenRateNotifier.sol",
+    "address": "0x7c7419E1964188C6133051dF541cf2a525AA1038",
+    "constructorArgs": ["0xD97D2666DC2FB490e9348a8BD17E9572a35b4F9D", "0xc9158c756D2a510eaC85792C847798a30dE20D46"]
+  },
+  "triggerableWithdrawalsGateway": {
+    "contract": "contracts/0.8.9/TriggerableWithdrawalsGateway.sol",
+    "address": "0xDC00116a0D3E064427dA2600449cfD2566B3037B",
+    "constructorArgs": [
+      "0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c",
+      "0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb",
+      11200,
+      1,
+      48
+    ]
+  },
+  "v3Template": {
+    "contract": "contracts/upgrade/V3Template.sol",
+    "address": "0x2AE2847a77a1d24100be2163AfdC49B06DC808E4",
+    "constructorArgs": [
+      [
+        "0x2C298963FB763f74765829722a1ebe0784f4F5Cf",
+        "0x17144556fd3424EDC8Fc8A4C940B2D04936d17eb",
+        "0xE9906E543274cebcd335d2C560094089e9547e8d",
+        "0xe6793B9e4FbA7DE0ee833F9D02bba7DB5EB27823",
+        "0x26329a3D4cF2F89923b5c4C14a25A2485cD01aA2",
+        "0xD0b9826e0EAf6dE91CE7A6783Cd6fd137ae422Ec",
+        "0xb2295820F5286BE40c2da8102eB2cDB24aD608Be",
+        "0x7c7419E1964188C6133051dF541cf2a525AA1038",
+        "0x5D8508D1eA725d35a61886658FB4BD7795027f6C",
+        "0xDAEf26cE8ba47d297e22A4318c1ACC5dB12dD3d6",
+        "0x08e197D82BC33Ddb7f3081f9aC31F3647cFabD46",
+        "0x9c2D30177DB12334998EB554f5d4E6dD44458167",
+        "0xb8FFC3Cd6e7Cf5a098A1c92F48009765B24088Dc",
+        "0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c",
+        "0xF5Dc67E54FC96F993CD06073f71ca732C1E654B1",
+        "0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb",
+        "0x2e59A20f205bB85a89C53f1936454680651E618e",
+        "0xC1db28B3301331277e307FDCfF8DE28242A4486E",
+        "0x9895f0f17cc1d1891b6f18ee0b483b6f221b37bb",
+        "0x7914b5a1539b97Bd0bbd155757F25FD79A522d24",
+        "0xF0211b7660680B49De1A7E9f25C65660F0a13Fea",
+        "0x8cDA09f41970A8f4416b6bA4696a2f09a6080c76",
+        "0x25AB9D07356E8a3F95a5905f597c93CD8F31990b",
+        "0x9Ba3E4aDDe415943A831b97F9f7B8b842052b709",
+        "0x663cE8Aa1ded537Dc319529e71DE6BAb2E7D0747",
+        "0xAEDB8D15197984D39152A2814e0BdCDAEED5462d",
+        "0x88D32aABa5B6A972D82E55D26B212eBeca07C983",
+        "0x7DCf0746ff2F77A36ceC8E318b59dc8a8A5c066e",
+        "0x6D0F542591eF4f8ebA8c77a11dc3676D9E9F7e66",
+        "0xf61601787E84d89c30911e5A48d9CA630eC47044",
+        "0xD60671a489948641954736A0e7272137b3A335CE"
+      ],
+      1768435200,
+      300
+    ]
+  },
+  "v3TemporaryAdmin": {
+    "contract": "contracts/upgrade/V3TemporaryAdmin.sol",
+    "address": "0xD97D2666DC2FB490e9348a8BD17E9572a35b4F9D",
+    "constructorArgs": ["0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
+  },
+  "v3VoteScript": {
+    "contract": "contracts/upgrade/V3VoteScript.sol",
+    "address": "0x7e2ef38FeDFEc1e768E55D63cb0273a726d0a318",
+    "constructorArgs": [
+      [
+        "0x2AE2847a77a1d24100be2163AfdC49B06DC808E4",
+        "0x3ca7c3e38968823ccb4c78ea688df41356f182ae1d159e4ee608d30d68cef320",
+        "0x2a30F5aC03187674553024296bed35Aa49749DDa"
+      ]
+    ]
+  },
+  "validatorConsolidationRequests": {
+    "contract": "contracts/0.8.25/vaults/ValidatorConsolidationRequests.sol",
+    "address": "0x6c5e18E4d335f16EA7a938eD3D35F11bCa390104",
+    "constructorArgs": ["0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb"]
+  },
+  "validatorExitDelayVerifier": {
+    "contract": "contracts/0.8.25/ValidatorExitDelayVerifier.sol",
+    "address": "0xbDb567672c867DB533119C2dcD4FB9d8b44EC82f",
+    "constructorArgs": [
+      "0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb",
+      {
+        "gIFirstValidatorPrev": "0x0000000000000000000000000000000000000000000000000096000000000028",
+        "gIFirstValidatorCurr": "0x0000000000000000000000000000000000000000000000000096000000000028",
+        "gIFirstHistoricalSummaryPrev": "0x000000000000000000000000000000000000000000000000000000b600000018",
+        "gIFirstHistoricalSummaryCurr": "0x000000000000000000000000000000000000000000000000000000b600000018",
+        "gIFirstBlockRootInSummaryPrev": "0x000000000000000000000000000000000000000000000000000000000040000d",
+        "gIFirstBlockRootInSummaryCurr": "0x000000000000000000000000000000000000000000000000000000000040000d"
+      },
+      11649024,
+      11649024,
+      6209536,
+      8192,
+      32,
+      12,
+      1606824023,
+      98304
+    ]
+  },
+  "validatorsExitBusOracle": {
+    "proxy": {
+      "address": "0x0De4Ea0184c2ad0BacA7183356Aea5B8d5Bf5c6e",
+      "contract": "contracts/0.8.9/proxy/OssifiableProxy.sol",
+      "deployTx": "0xef3eea1523d2161c2f36ba61e327e3520231614c055b8a88c7f5928d18e423ea",
+      "constructorArgs": [
+        "0x6F6541C2203196fEeDd14CD2C09550dA1CbEDa31",
+        "0x8Ea83AD72396f1E0cD2f8E72b1461db8Eb6aF7B5",
+        "0x"
+      ]
+    },
+    "implementation": {
+      "contract": "contracts/0.8.9/oracle/ValidatorsExitBusOracle.sol",
+      "address": "0x905A211eD6830Cfc95643f0bE2ff64E7f3bf9b94",
+      "constructorArgs": [12, 1606824023, "0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb"]
+    }
+  },
+  "vaultHub": {
+    "proxy": {
+      "contract": "contracts/0.8.9/proxy/OssifiableProxy.sol",
+      "address": "0xdcC04F506E24495E9F2599A7b214522647363669",
+      "constructorArgs": [
+        "0xB4c523f115C40df5A9981DB804b488B0a9012002",
+        "0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c",
+        "0xc4d66de8000000000000000000000000d97d2666dc2fb490e9348a8bd17e9572a35b4f9d"
+      ]
+    },
+    "implementation": {
+      "contract": "contracts/0.8.25/vaults/VaultHub.sol",
+      "address": "0xB4c523f115C40df5A9981DB804b488B0a9012002",
+      "constructorArgs": [
+        "0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb",
+        "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
+        "0xD624B08C83bAECF0807Dd2c6880C3154a5F0B288",
+        1000
+      ]
+    }
+  },
+  "vestingParams": {
+    "unvestedTokensAmount": "363197500000000000000000000",
+    "holders": {
+      "0x9Bb75183646e2A0DC855498bacD72b769AE6ceD3": "20000000000000000000000000",
+      "0x0f89D54B02ca570dE82F770D33c7B7Cf7b3C3394": "25000000000000000000000000",
+      "0xe49f68B9A01d437B0b7ea416376a7AB21532624e": "2282000000000000000000000",
+      "0xb842aFD82d940fF5D8F6EF3399572592EBF182B0": "17718000000000000000000000",
+      "0x9849c2C1B73B41AEE843A002C332a2d16aaaB611": "10000000000000000000000000",
+      "0x96481cb0fcd7673254ebccc42dce9b92da10ea04": "5000000000000000000000000",
+      "0xB3DFe140A77eC43006499CB8c2E5e31975caD909": "7500000000000000000000000",
+      "0x61C808D82A3Ac53231750daDc13c777b59310bD9": "20000000000000000000000000",
+      "0x447f95026107aaed7472A0470931e689f51e0e42": "20000000000000000000000000",
+      "0x6ae83EAB68b7112BaD5AfD72d6B24546AbFF137D": "2222222220000000000000000",
+      "0xC24da173A250e9Ca5c54870639EbE5f88be5102d": "17777777780000000000000000",
+      "0x1f3813fE7ace2a33585F1438215C7F42832FB7B3": "20000000000000000000000000",
+      "0x82a8439BA037f88bC73c4CCF55292e158A67f125": "7000000000000000000000000",
+      "0x91715128a71c9C734CDC20E5EdEEeA02E72e428E": "15000000000000000000000000",
+      "0xB5587A54fF7022AC218438720BDCD840a32f0481": "5000000000000000000000000",
+      "0xf5fb27b912d987b5b6e02a1b1be0c1f0740e2c6f": "2000000000000000000000000",
+      "0x8b1674a617F103897Fb82eC6b8EB749BA0b9765B": "15000000000000000000000000",
+      "0x48Acf41D10a063f9A6B718B9AAd2e2fF5B319Ca2": "5000000000000000000000000",
+      "0x7eE09c11D6Dc9684D6D5a4C6d333e5b9e336bb6C": "10000000000000000000000000",
+      "0x11099aC9Cc097d0C9759635b8e16c6a91ECC43dA": "2000000000000000000000000",
+      "0x3d4AD2333629eE478E4f522d60A56Ae1Db5D3Cdb": "5000000000000000000000000",
+      "0xd5eCB56c6ca8f8f52D2DB4dC1257d6161cf3Da29": "100000000000000000000000",
+      "0x7F5e13a815EC9b4466d283CD521eE9829e7F6f0e": "200000000000000000000000",
+      "0x2057cbf2332ab2697a52B8DbC85756535d577e32": "500000000000000000000000",
+      "0x537dfB5f599A3d15C50E2d9270e46b808A52559D": "1000000000000000000000000",
+      "0x33c4c38e96337172d3de39df82060de26b638c4b": "550000000000000000000000",
+      "0x6094E1Dd925caCe56Fa501dAEc02b01a49E55770": "300000000000000000000000",
+      "0x977911f476B28f9F5332fA500387deE81e480a44": "40000000000000000000000",
+      "0x66d3FdA643320c6DddFBba39e635288A5dF75FB9": "200000000000000000000000",
+      "0xDFC0ae54af992217100845597982274A26d8CB28": "12500000000000000000000",
+      "0x32254b28F793CC18B3575C86c61fE3D7421cbbef": "500000000000000000000000",
+      "0x0Bf5566fB5F1f9934a3944AEF128a1b1a8cF3f17": "50000000000000000000000",
+      "0x1d3Fa8bf35870271115B997b8eCFe18529422a16": "50000000000000000000000",
+      "0x366B9729C5A89EC4618A0AB95F832E411eaE8237": "200000000000000000000000",
+      "0x20921142A35c89bE5D002973d2D6B72d9a625FB0": "200000000000000000000000",
+      "0x663b91628674846e8D1CBB779EFc8202d86284E2": "7500000000000000000000000",
+      "0xa6829908f728C6bC5627E2aFe93a0B71E978892D": "300000000000000000000000",
+      "0x9575B7859DF77F2A0EF034339b80e24dE44AB3F6": "200000000000000000000000",
+      "0xEe217c23131C6F055F7943Ef1f80Bec99dF35244": "400000000000000000000000",
+      "0xadde043f556d1083f060A7298E79eaBa08A3a077": "400000000000000000000000",
+      "0xaFBEfC8401c885A0bb6Ea6Af43f592A015433C65": "200000000000000000000000",
+      "0x8a62A63b877877bd5B1209B9b67F3d2685284268": "200000000000000000000000",
+      "0x62Ac238Ac055017DEcAb645E7E56176749f316d0": "200000000000000000000000",
+      "0x55Bc991b2edF3DDb4c520B222bE4F378418ff0fA": "5000000000000000000000000",
+      "0x8D689476EB446a1FB0065bFFAc32398Ed7F89165": "10000000000000000000000000",
+      "0x083fc10cE7e97CaFBaE0fE332a9c4384c5f54E45": "5000000000000000000000000",
+      "0x0028E24e4Fe5184792Bd0Cf498C11AE5b76185f5": "5000000000000000000000000",
+      "0xFe45baf0F18c207152A807c1b05926583CFE2e4b": "5000000000000000000000000",
+      "0x4a7C6899cdcB379e284fBFD045462e751DA4C7cE": "5000000000000000000000000",
+      "0xD7f0dDcBb0117A53e9ff2cad814B8B810a314f59": "5000000000000000000000000",
+      "0xb8d83908AAB38a159F3dA47a59d84dB8e1838712": "50000000000000000000000000",
+      "0xA2dfC431297aee387C05bEEf507E5335E684FbCD": "50000000000000000000000000",
+      "0x1597D19659F3DE52ABd475F7D2314DCca29359BD": "50000000000000000000000000",
+      "0x695C388153bEa0fbE3e1C049c149bAD3bc917740": "50000000000000000000000000",
+      "0x945755dE7EAc99008c8C57bdA96772d50872168b": "50000000000000000000000000",
+      "0xFea88380bafF95e85305419eB97247981b1a8eEE": "30000000000000000000000000",
+      "0xAD4f7415407B83a081A0Bee22D05A8FDC18B42da": "50000000000000000000000000",
+      "0x68335B3ac272C8238b722963368F87dE736b64D6": "5000000000000000000000000",
+      "0xfA2Ab7C161Ef7F83194498f36ca7aFba90FD08d4": "5000000000000000000000000",
+      "0x58A764028350aB15899fDCcAFFfd3940e602CEEA": "10000000000000000000000000"
+    },
+    "start": 1639785600,
+    "cliff": 1639785600,
+    "end": 1671321600,
+    "revokable": false
+  },
+  "withdrawalQueueERC721": {
+    "proxy": {
+      "address": "0x889edC2eDab5f40e902b864aD4d7AdE8E412F9B1",
+      "contract": "contracts/0.8.9/proxy/OssifiableProxy.sol",
+      "deployTx": "0x98c2170be034f750f5006cb69ea0aeeaf0858b11f6324ee53d582fa4dd49bc1a",
+      "constructorArgs": [
+        "0x6F6541C2203196fEeDd14CD2C09550dA1CbEDa31",
+        "0x8Ea83AD72396f1E0cD2f8E72b1461db8Eb6aF7B5",
+        "0x"
+      ]
+    },
+    "implementation": {
+      "address": "0xE42C659Dc09109566720EA8b2De186c2Be7D94D9",
+      "contract": "contracts/0.8.9/WithdrawalQueueERC721.sol",
+      "deployTx": "0x6ab0151735c01acdef518421358d41a08752169bc383c57d57f5bfa135ac6eb1",
+      "constructorArgs": ["0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0", "Lido: stETH Withdrawal NFT", "unstETH"],
+      "deployParameters": {
+        "name": "Lido: stETH Withdrawal NFT",
+        "symbol": "unstETH"
+      }
+    }
+  },
+  "withdrawalVault": {
+    "proxy": {
+      "address": "0xB9D7934878B5FB9610B3fE8A5e441e8fad7E293f"
+    },
+    "implementation": {
+      "contract": "contracts/0.8.9/WithdrawalVault.sol",
+      "address": "0x7D2BAa6094E1C4B60Da4cbAF4A77C3f4694fD53D",
+      "constructorArgs": [
+        "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
+        "0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c",
+        "0xDC00116a0D3E064427dA2600449cfD2566B3037B"
+      ]
+    }
+  },
+  "wstETH": {
+    "address": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+    "contract": "contracts/0.6.12/WstETH.sol",
+    "deployTx": "0xaf2c1a501d2b290ef1e84ddcfc7beb3406f8ece2c46dee14e212e8233654ff05",
+    "constructorArgs": ["0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84"]
+  }
+}

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -10,8 +10,8 @@ declare namespace NodeJS {
     /* Test execution mode: 'scratch' for fresh network, 'fork' for forked network */
     MODE?: "scratch" | "forking"; // default: "scratch"
 
-    /* URL of the network to fork from */
-    FORK_RPC_URL?: string; // default: "https://eth.drpc.org"
+    /* Block number to fork from. If not set, the fork will start from the latest block. */
+    FORKING_BLOCK_NUMBER?: number; // default: undefined
 
     /**
      * Flags for changing the behavior of the integration tests


### PR DESCRIPTION
This pull request updates the integration test configuration and refactors the helper for Hardhat forking settings to improve clarity and error handling. The main changes include updating documentation to use the correct environment variable and enhancing the logic for setting up Hardhat's forking configuration.

**Documentation update:**

* Updated the integration test instructions in `CONTRIBUTING.md` to reference `RPC_URL` instead of the deprecated `FORK_RPC_URL` variable, ensuring users set the correct environment variable for Ethereum Mainnet RPC.

**Hardhat forking configuration improvements:**

* Refactored `getHardhatForkingConfig` in `hardhat.helpers.ts` to use explicit conditional logic instead of a `switch` statement, improving readability and maintainability.
* Added support for the optional `FORKING_BLOCK_NUMBER` environment variable, with validation to ensure it is a positive number before including it in the forking config.
* Improved error handling for missing or invalid environment variables, providing clearer error messages when `MODE`, `RPC_URL`, or `FORKING_BLOCK_NUMBER` are not set or invalid.
* Added import for `HardhatNetworkForkingUserConfig` to strengthen type safety in the forking configuration logic.