### PR TITLE
fix: add missing getter to IReportAsyncProcessor

### DIFF
--- a/contracts/0.8.9/oracle/HashConsensus.sol
+++ b/contracts/0.8.9/oracle/HashConsensus.sol
@@ -65,6 +65,9 @@ interface IReportAsyncProcessor {
     /// one returned from this function.
     ///
     function getConsensusVersion() external view returns (uint256);
+
+    /// @notice Returns the address of the HashConsensus contract.
+    function getConsensusContract() external view returns (address);
 }
 
 

--- a/test/0.8.9/contracts/ReportProcessor__Mock.sol
+++ b/test/0.8.9/contracts/ReportProcessor__Mock.sol
@@ -56,6 +56,10 @@ contract ReportProcessor__Mock is IReportAsyncProcessor {
         return _consensusVersion;
     }
 
+    function getConsensusContract() external view returns (address) {
+        return address(0);
+    }
+
     function submitConsensusReport(bytes32 report, uint256 refSlot, uint256 deadline) external {
         _submitReportLastCall.report = report;
         _submitReportLastCall.refSlot = refSlot;


### PR DESCRIPTION
Add missing getter to `IReportAsyncProcessor`.
