### PR TITLE
feat: unify skipping tests

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -31,7 +31,6 @@ export const EPOCHS_PER_FRAME = 225n; // one day;
 export const GENESIS_FORK_VERSION = "0x00000000"; // for mainnet
 // Oracle report related
 export const GENESIS_TIME = 100n;
-export const GENESIS_TIME_MAINNET = 1606824023n;
 export const SLOTS_PER_EPOCH = 32n;
 export const BASE_CONSENSUS_VERSION = 1n;
 export const AO_CONSENSUS_VERSION = 3n;
@@ -70,3 +69,6 @@ export const LIMITER_PRECISION_BASE = 10n ** 9n;
 
 export const DISCONNECT_NOT_INITIATED = 2n ** 48n - 1n;
 export const MAX_SANE_SETTLED_GROWTH = MAX_INT104;
+
+export const MAINNET_CHAIN_ID = 1n;
+export const HOODI_CHAIN_ID = 560048n;

--- a/lib/network.ts
+++ b/lib/network.ts
@@ -1,5 +1,9 @@
 import { ethers } from "hardhat";
 
+export async function getNetworkChainId(): Promise<bigint> {
+  return BigInt(await ethers.provider.send("eth_chainId"));
+}
+
 export async function getNetworkName(): Promise<string> {
   let clientVersion = await ethers.provider.send("web3_clientVersion");
 

--- a/test/0.8.9/eip712.test.ts
+++ b/test/0.8.9/eip712.test.ts
@@ -4,7 +4,7 @@ import { ethers } from "hardhat";
 
 import { EIP712StETH } from "typechain-types";
 
-import { certainAddress } from "lib";
+import { certainAddress, getNetworkChainId } from "lib";
 
 import { Snapshot } from "test/suite";
 
@@ -19,7 +19,7 @@ describe("EIP712StETH.sol", () => {
     domain = {
       name: "Liquid staked Ether 2.0",
       version: "2",
-      chainId: await ethers.provider.send("eth_chainId", []),
+      chainId: await getNetworkChainId(),
       verifyingContract: certainAddress("eip712.test:domain:verifying-contract"),
     };
 

--- a/test/integration/report-validator-exit-delay.ts
+++ b/test/integration/report-validator-exit-delay.ts
@@ -3,7 +3,14 @@ import { ethers } from "hardhat";
 
 import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
 
-import { advanceChainTime, ether, GENESIS_TIME_MAINNET, getCurrentBlockTimestamp, updateBeaconBlockRoot } from "lib";
+import {
+  advanceChainTime,
+  ether,
+  getCurrentBlockTimestamp,
+  getNetworkChainId,
+  MAINNET_CHAIN_ID,
+  updateBeaconBlockRoot,
+} from "lib";
 import { getProtocolContext, ProtocolContext } from "lib/protocol";
 
 import {
@@ -133,12 +140,10 @@ describe("Integration: Report Validator Exit Delay", () => {
   });
 
   it("Should report validator exit delay historically", async function () {
-    const { nor, validatorsExitBusOracle, validatorExitDelayVerifier } = ctx.contracts;
-    if ((await validatorExitDelayVerifier.GENESIS_TIME()) != GENESIS_TIME_MAINNET) {
-      console.log("Skipping test because it's not mainnet");
-      this.skip();
-    }
+    // Skip if not mainnet
+    if ((await getNetworkChainId()) !== MAINNET_CHAIN_ID) this.skip();
 
+    const { nor, validatorsExitBusOracle, validatorExitDelayVerifier } = ctx.contracts;
     const nodeOpId = 2;
     const exitRequests = [
       {
@@ -206,12 +211,10 @@ describe("Integration: Report Validator Exit Delay", () => {
   });
 
   it("Should revert when validator reported multiple times in a single transaction", async function () {
-    const { validatorsExitBusOracle, validatorExitDelayVerifier, nor } = ctx.contracts;
+    // Skip if not mainnet
+    if ((await getNetworkChainId()) !== MAINNET_CHAIN_ID) this.skip();
 
-    if ((await validatorExitDelayVerifier.GENESIS_TIME()) != GENESIS_TIME_MAINNET) {
-      console.log("Skipping test because it's not mainnet");
-      this.skip();
-    }
+    const { validatorsExitBusOracle, validatorExitDelayVerifier, nor } = ctx.contracts;
 
     // Setup multiple exit requests with the same pubkey
     const nodeOpIds = [1, 2];
@@ -260,11 +263,10 @@ describe("Integration: Report Validator Exit Delay", () => {
   });
 
   it("Should revert when exit request hash is not submitted", async function () {
+    // Skip if not mainnet
+    if ((await getNetworkChainId()) !== MAINNET_CHAIN_ID) this.skip();
+
     const { validatorExitDelayVerifier, validatorsExitBusOracle } = ctx.contracts;
-    if ((await validatorExitDelayVerifier.GENESIS_TIME()) != GENESIS_TIME_MAINNET) {
-      console.log("Skipping test because it's not mainnet");
-      this.skip();
-    }
 
     const exitRequests = [
       {
@@ -302,12 +304,10 @@ describe("Integration: Report Validator Exit Delay", () => {
   });
 
   it("Should revert when exit request was not unpacked", async function () {
-    const { validatorExitDelayVerifier, validatorsExitBusOracle } = ctx.contracts;
+    // Skip if not mainnet
+    if ((await getNetworkChainId()) !== MAINNET_CHAIN_ID) this.skip();
 
-    if ((await validatorExitDelayVerifier.GENESIS_TIME()) != GENESIS_TIME_MAINNET) {
-      console.log("Skipping test because it's not mainnet");
-      this.skip();
-    }
+    const { validatorExitDelayVerifier, validatorsExitBusOracle } = ctx.contracts;
 
     const exitRequests = [
       {

--- a/test/integration/vaults/scenario/pdg-specific-validator.integration.ts
+++ b/test/integration/vaults/scenario/pdg-specific-validator.integration.ts
@@ -18,8 +18,10 @@ import {
 
 import {
   ether,
+  getNetworkChainId,
   impersonate,
   LocalMerkleTree,
+  MAINNET_CHAIN_ID,
   PDGPolicy,
   prepareLocalMerkleTree,
   toGwei,
@@ -42,13 +44,6 @@ import { bailOnFailure, Snapshot } from "test/suite";
  * Vault address: 0x62e0d92cf7b8752b5292b9bcbbace4cfa1633428
  */
 describe("Scenario: PDG specific validator prove and top up on mainnet fork", function () {
-  // Skip entire suite if not in forking mode
-  before(function () {
-    if (getMode() !== "forking") {
-      this.skip();
-    }
-  });
-
   let ctx: ProtocolContext;
   let originalSnapshot: string;
 
@@ -78,9 +73,8 @@ describe("Scenario: PDG specific validator prove and top up on mainnet fork", fu
   let slot: bigint;
 
   before(async function () {
-    if (getMode() !== "forking") {
-      return;
-    }
+    // Skip if not mainnet
+    if ((await getNetworkChainId()) !== MAINNET_CHAIN_ID) this.skip();
 
     ctx = await getProtocolContext();
     originalSnapshot = await Snapshot.take();
@@ -145,6 +139,7 @@ describe("Scenario: PDG specific validator prove and top up on mainnet fork", fu
   }
 
   beforeEach(bailOnFailure);
+
   after(async function () {
     if (getMode() === "forking" && originalSnapshot) {
       await Snapshot.restore(originalSnapshot);

--- a/test/integration/vaults/scenario/pdg-specific-validator.integration.ts
+++ b/test/integration/vaults/scenario/pdg-specific-validator.integration.ts
@@ -44,6 +44,13 @@ import { bailOnFailure, Snapshot } from "test/suite";
  * Vault address: 0x62e0d92cf7b8752b5292b9bcbbace4cfa1633428
  */
 describe("Scenario: PDG specific validator prove and top up on mainnet fork", function () {
+  // Skip entire suite if not in forking mode
+  before(function () {
+    if (getMode() !== "forking") {
+      this.skip();
+    }
+  });
+
   let ctx: ProtocolContext;
   let originalSnapshot: string;
 
@@ -74,7 +81,9 @@ describe("Scenario: PDG specific validator prove and top up on mainnet fork", fu
 
   before(async function () {
     // Skip if not mainnet
-    if ((await getNetworkChainId()) !== MAINNET_CHAIN_ID) this.skip();
+    const isMainnet = (await getNetworkChainId()) === MAINNET_CHAIN_ID;
+    const isForking = getMode() === "forking";
+    if (!isMainnet || isForking) this.skip();
 
     ctx = await getProtocolContext();
     originalSnapshot = await Snapshot.take();


### PR DESCRIPTION
This pull request refactors how the test suite determines when to run mainnet-specific tests by introducing a `getNetworkChainId` utility and using explicit chain ID checks. This makes the codebase more robust and less reliant on hardcoded values or indirect checks. Additionally, it introduces new chain ID constants and removes the unused `GENESIS_TIME_MAINNET` constant.

**Test infrastructure improvements:**

* Added `getNetworkChainId` utility in `lib/network.ts` to retrieve the current network's chain ID in tests and scripts.
* Updated test files (such as `test/0.8.9/eip712.test.ts`, `test/integration/report-validator-exit-delay.ts`, and `test/integration/vaults/scenario/pdg-specific-validator.integration.ts`) to use `getNetworkChainId` and the new `MAINNET_CHAIN_ID` constant for mainnet-specific test gating, replacing previous checks based on `GENESIS_TIME_MAINNET` or test mode. [[1]](diffhunk://#diff-c76ddd9180f28167c334e3f6c055aba4867d4ec7fa9c77021e38adbd63893130L22-R22) [[2]](diffhunk://#diff-f03a275a263b62dbdc24ad0c2e75e5784d8f5527e97eb12b26a235ad8b3b5547L136-R146) [[3]](diffhunk://#diff-f03a275a263b62dbdc24ad0c2e75e5784d8f5527e97eb12b26a235ad8b3b5547L209-R217) [[4]](diffhunk://#diff-f03a275a263b62dbdc24ad0c2e75e5784d8f5527e97eb12b26a235ad8b3b5547R266-L267) [[5]](diffhunk://#diff-f03a275a263b62dbdc24ad0c2e75e5784d8f5527e97eb12b26a235ad8b3b5547L305-R310) [[6]](diffhunk://#diff-e99d261dfc1b6a94dc3267cd60151dc1f304baedd3ca8185d7e393e550b86537L81-R77)

**Constants and configuration:**

* Added `MAINNET_CHAIN_ID` and `HOODI_CHAIN_ID` constants to `lib/constants.ts` for explicit chain identification.
* Removed the unused `GENESIS_TIME_MAINNET` constant from `lib/constants.ts`, as chain ID is now used for mainnet detection.

**Test suite cleanup:**

* Removed or simplified test suite setup code that previously relied on indirect checks (like `getMode() === "forking"`) in favor of direct chain ID checks, making test conditions clearer and more maintainable. [[1]](diffhunk://#diff-e99d261dfc1b6a94dc3267cd60151dc1f304baedd3ca8185d7e393e550b86537L45-L51) [[2]](diffhunk://#diff-e99d261dfc1b6a94dc3267cd60151dc1f304baedd3ca8185d7e393e550b86537L81-R77)