### PR TITLE
feat: develop updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is the core repository of the Lido on Ethereum protocol. The entire codebas
 ---
 
 <div>
-    <img alt="Lido" src="https://img.shields.io/badge/v3.0.0-version?label=lido&labelColor=rgb(91%2C%20162%2C%20252)&color=white"/>
+    <img alt="Lido" src="https://img.shields.io/badge/v3.0.1-version?label=lido&labelColor=rgb(91%2C%20162%2C%20252)&color=white"/>
     <img alt="GitHub license" src="https://img.shields.io/github/license/lidofinance/lido-dao?labelColor=orange&color=white"/>
     <img alt="Solidity" src="https://img.shields.io/badge/multiver-s?style=flat&label=solidity&labelColor=rgb(86%2C%2085%2C%20212)&color=white"/>
     <img alt="Aragon OS" src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Flidofinance%2Fcore%2Fmaster%2Fpackage.json&query=%24.dependencies%5B'%40aragon%2Fos'%5D&style=flat&label=aragon%2Fos&labelColor=rgb(70%2C%20100%2C%20246)&color=white"/>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lido-on-ethereum",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Lido on Ethereum is a liquid-staking protocol allowing anyone to earn staking rewards without locking ether or maintaining infrastructure",
   "license": "GPL-3.0-only",
   "engines": {


### PR DESCRIPTION
This pull request contains a version bump for the Lido on Ethereum protocol, updating the version from 3.0.0 to 3.0.1. This is a minor change to reflect the new release version in both the documentation and the package metadata.

Version update:

* Updated the version badge in `README.md` to display `v3.0.1` instead of `v3.0.0`.
* Changed the version field in `package.json` from `3.0.0` to `3.0.1`.