### PR TITLE
ci: fix state-mate

### DIFF
--- a/.github/workflows/verify-state.yml
+++ b/.github/workflows/verify-state.yml
@@ -69,7 +69,7 @@ jobs:
         run: yarn install
 
       - name: Run state-mate (V3 Mainnet)
-        run: yarn start configs/lidov3/mainnet/lidov3-core-post-vote.yaml
+        run: yarn start configs/lidov3/mainnet/lidov3-core-post-phase-2.yaml
 
       - name: Run state-mate (V3 Mainnet Easy Track)
-        run: yarn start configs/lidov3/mainnet/lidov3-et-post-vote.yml
+        run: yarn start configs/lidov3/mainnet/lidov3-et-post-vote-phase-2.yml


### PR DESCRIPTION
This pull request updates the workflow configuration to use new Phase 2 configuration files for the V3 Mainnet and Mainnet Easy Track jobs. This ensures that the state verification process runs against the latest configuration files.

Workflow configuration updates:

* Updated the V3 Mainnet state verification job to use `lidov3-core-post-phase-2.yaml` instead of the previous post-vote configuration.
* Updated the V3 Mainnet Easy Track state verification job to use `lidov3-et-post-vote-phase-2.yml` instead of the previous post-vote configuration.