### PR TITLE
Prevent msg.value overflow in PredepositGuarantee

### DIFF
--- a/contracts/0.8.25/vaults/predeposit_guarantee/PredepositGuarantee.sol
+++ b/contracts/0.8.25/vaults/predeposit_guarantee/PredepositGuarantee.sol
@@ -802,6 +802,7 @@ contract PredepositGuarantee is IPredepositGuarantee, CLProofVerifier, PausableU
     }
 
     function _topUpNodeOperatorBalance(address _nodeOperator) internal onlyGuarantorOf(_nodeOperator) {
+        if (msg.value > type(uint128).max) revert ValueTooLarge(msg.value);
         uint128 amount = uint128(msg.value);
 
         // _nodeOperator != address(0) is enforced by onlyGuarantorOf()
@@ -951,4 +952,5 @@ contract PredepositGuarantee is IPredepositGuarantee, CLProofVerifier, PausableU
     // general
     error ZeroArgument(string argument);
     error ArrayLengthsNotMatch();
+    error ValueTooLarge(uint256 value);
 }


### PR DESCRIPTION
Prevent msg.value overflow truncation in PredepositGuarantee by reverting when it exceeds uint128 max during node operator top-ups.
