### PR TITLE
Bugfix/withdrawal queue guard

### DIFF
--- a/contracts/0.8.25/vaults/predeposit_guarantee/PredepositGuarantee.sol
+++ b/contracts/0.8.25/vaults/predeposit_guarantee/PredepositGuarantee.sol
@@ -802,6 +802,7 @@ contract PredepositGuarantee is IPredepositGuarantee, CLProofVerifier, PausableU
     }
 
     function _topUpNodeOperatorBalance(address _nodeOperator) internal onlyGuarantorOf(_nodeOperator) {
+        if (msg.value > type(uint128).max) revert ValueTooLarge(msg.value);
         uint128 amount = uint128(msg.value);
 
         // _nodeOperator != address(0) is enforced by onlyGuarantorOf()
@@ -951,4 +952,5 @@ contract PredepositGuarantee is IPredepositGuarantee, CLProofVerifier, PausableU
     // general
     error ZeroArgument(string argument);
     error ArrayLengthsNotMatch();
+    error ValueTooLarge(uint256 value);
 }

--- a/contracts/0.8.9/WithdrawalQueue.sol
+++ b/contracts/0.8.9/WithdrawalQueue.sol
@@ -72,6 +72,7 @@ abstract contract WithdrawalQueue is AccessControlEnumerable, PausableUntil, Wit
     error RequestIdsNotSorted();
     error ZeroRecipient();
     error ArraysLengthMismatch(uint256 _firstArrayLength, uint256 _secondArrayLength);
+    error AmountTooLarge(uint256 _amount);
 
     /// @param _wstETH address of WstETH contract
     constructor(IWstETH _wstETH) {
@@ -374,6 +375,8 @@ abstract contract WithdrawalQueue is AccessControlEnumerable, PausableUntil, Wit
         STETH.transferFrom(msg.sender, address(this), _amountOfStETH);
 
         uint256 amountOfShares = STETH.getSharesByPooledEth(_amountOfStETH);
+        if (_amountOfStETH > type(uint128).max) revert AmountTooLarge(_amountOfStETH);
+        if (amountOfShares > type(uint128).max) revert AmountTooLarge(amountOfShares);
 
         requestId = _enqueue(uint128(_amountOfStETH), uint128(amountOfShares), _owner);
 
@@ -386,6 +389,8 @@ abstract contract WithdrawalQueue is AccessControlEnumerable, PausableUntil, Wit
         _checkWithdrawalRequestAmount(amountOfStETH);
 
         uint256 amountOfShares = STETH.getSharesByPooledEth(amountOfStETH);
+        if (amountOfStETH > type(uint128).max) revert AmountTooLarge(amountOfStETH);
+        if (amountOfShares > type(uint128).max) revert AmountTooLarge(amountOfShares);
 
         requestId = _enqueue(uint128(amountOfStETH), uint128(amountOfShares), _owner);
 


### PR DESCRIPTION
Context

This touches the withdrawal request flow. The requested stETH amount and share amount are later handled in a context that expects values to fit into uint128, so we should fail early with a clear error instead of allowing an implicit truncation or a confusing downstream revert.

Problem

_requestWithdrawal and _requestWithdrawalWstETH accept user supplied amounts that can exceed type(uint128).max. If oversized values pass through, they can cause incorrect casting behavior or unexpected reverts later in the flow.

Solution

Add a dedicated error AmountTooLarge(uint256 _amount) and introduce explicit bounds checks in _requestWithdrawal and _requestWithdrawalWstETH. If amountOfStETH or amountOfShares is greater than type(uint128).max, the call reverts with AmountTooLarge, preventing unsafe or ambiguous behavior.
