### PR TITLE
Withdrawal queue checkpoint hint zero

### DIFF
--- a/contracts/0.8.25/vaults/predeposit_guarantee/PredepositGuarantee.sol
+++ b/contracts/0.8.25/vaults/predeposit_guarantee/PredepositGuarantee.sol
@@ -802,6 +802,7 @@ contract PredepositGuarantee is IPredepositGuarantee, CLProofVerifier, PausableU
     }
 
     function _topUpNodeOperatorBalance(address _nodeOperator) internal onlyGuarantorOf(_nodeOperator) {
+        if (msg.value > type(uint128).max) revert ValueTooLarge(msg.value);
         uint128 amount = uint128(msg.value);
 
         // _nodeOperator != address(0) is enforced by onlyGuarantorOf()
@@ -951,4 +952,5 @@ contract PredepositGuarantee is IPredepositGuarantee, CLProofVerifier, PausableU
     // general
     error ZeroArgument(string argument);
     error ArrayLengthsNotMatch();
+    error ValueTooLarge(uint256 value);
 }

--- a/contracts/0.8.9/WithdrawalQueue.sol
+++ b/contracts/0.8.9/WithdrawalQueue.sol
@@ -306,7 +306,9 @@ abstract contract WithdrawalQueue is AccessControlEnumerable, PausableUntil, Wit
         for (uint256 i = 0; i < _requestIds.length; ++i) {
             if (_requestIds[i] < prevRequestId) revert RequestIdsNotSorted();
             hintIds[i] = _findCheckpointHint(_requestIds[i], _firstIndex, _lastIndex);
-            _firstIndex = hintIds[i];
+            if (hintIds[i] != 0) {
+                _firstIndex = hintIds[i];
+            }
             prevRequestId = _requestIds[i];
         }
     }

--- a/contracts/0.8.9/WithdrawalQueue.sol
+++ b/contracts/0.8.9/WithdrawalQueue.sol
@@ -72,6 +72,7 @@ abstract contract WithdrawalQueue is AccessControlEnumerable, PausableUntil, Wit
     error RequestIdsNotSorted();
     error ZeroRecipient();
     error ArraysLengthMismatch(uint256 _firstArrayLength, uint256 _secondArrayLength);
+    error AmountTooLarge(uint256 _amount);
 
     /// @param _wstETH address of WstETH contract
     constructor(IWstETH _wstETH) {
@@ -374,6 +375,8 @@ abstract contract WithdrawalQueue is AccessControlEnumerable, PausableUntil, Wit
         STETH.transferFrom(msg.sender, address(this), _amountOfStETH);
 
         uint256 amountOfShares = STETH.getSharesByPooledEth(_amountOfStETH);
+        if (_amountOfStETH > type(uint128).max) revert AmountTooLarge(_amountOfStETH);
+        if (amountOfShares > type(uint128).max) revert AmountTooLarge(amountOfShares);
 
         requestId = _enqueue(uint128(_amountOfStETH), uint128(amountOfShares), _owner);
 
@@ -386,6 +389,8 @@ abstract contract WithdrawalQueue is AccessControlEnumerable, PausableUntil, Wit
         _checkWithdrawalRequestAmount(amountOfStETH);
 
         uint256 amountOfShares = STETH.getSharesByPooledEth(amountOfStETH);
+        if (amountOfStETH > type(uint128).max) revert AmountTooLarge(amountOfStETH);
+        if (amountOfShares > type(uint128).max) revert AmountTooLarge(amountOfShares);
 
         requestId = _enqueue(uint128(amountOfStETH), uint128(amountOfShares), _owner);
 


### PR DESCRIPTION
Context

This affects findCheckpointHints, which is used to build hint indices for batches of withdrawal request IDs. The function is expected to work with lists that can contain a mix of finalized and unfinalized requests.

Problem

When _findCheckpointHint returns 0 for an ID (common for unfinalized requests), the previous logic still assigned _firstIndex = 0. On the next iterations this can lead to a revert inside _findCheckpointHint because it receives _start == 0. This breaks processing for mixed finalized/unfinalized lists even when the request IDs are properly sorted.

Solution

Update findCheckpointHints to only advance _firstIndex when a non zero hint is returned. This preserves a valid search start index across the loop and prevents _start == 0 reverts while keeping the existing sorted ID validation intact.
