### PR TITLE
feat: 10k runs for fuzz in deep profile

### DIFF
--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -18,6 +18,7 @@ jobs:
 
   test_foundry_fuzzing:
     name: Foundry / Fuzzing & Invariants
+    if: github.ref_name != 'develop' && github.ref_name != 'master'
     runs-on: ubuntu-latest
 
     steps:
@@ -28,13 +29,29 @@ jobs:
 
       - name: Install foundry
         uses: foundry-rs/foundry-toolchain@v1
-        # Use a specific version of Foundry in case nightly is broken
-        # https://github.com/foundry-rs/foundry/releases
-        # with:
-        #   version: nightly-54d8510c0f2b0f791f4c5ef99866c6af99b7606a
 
       - name: Print forge version
         run: forge --version
 
       - name: Run fuzzing and invariant tests
         run: forge test
+
+  test_foundry_fuzzing_deep:
+    name: Foundry / Fuzzing & Invariants (deep)
+    if: github.ref_name == 'develop' || github.ref_name == 'master'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Common setup
+        uses: ./.github/workflows/setup
+
+      - name: Install foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Print forge version
+        run: forge --version
+
+      - name: Run fuzzing and invariant tests (deep profile, 10k runs)
+        run: FOUNDRY_PROFILE=deep forge test

--- a/foundry.lock
+++ b/foundry.lock
@@ -1,0 +1,8 @@
+{
+  "foundry/lib/forge-std": {
+    "tag": {
+      "name": "v1.13.0",
+      "rev": "c29afdd40a82db50a3d3709d324416be50050e5e"
+    }
+  }
+}

--- a/foundry.toml
+++ b/foundry.toml
@@ -23,14 +23,6 @@ match_path = '**/test/**/*.t.sol'
 # Enable latest EVM features
 evm_version = "prague"
 
-# https://book.getfoundry.sh/reference/config/testing#fuzz
-# fuzz = { runs = 256 }
-# https://book.getfoundry.sh/reference/config/testing#invariant
-# invariant = { runs = 256, depth = 15 }
-
-# Fails the invariant fuzzing if a revert occurs
-# fail_on_revert = true
-
 fmt = { int_types = 'long' }
 
 # add via_ir profile
@@ -45,3 +37,19 @@ compilation_restrictions = [
     { paths = "contracts/0.8.25/vaults/VaultHub.sol", optimizer_runs = 100, via_ir = true },
     { paths = "contracts/upgrade/**", optimizer_runs = 200, via_ir = true },
 ]
+
+[profile.default.invariant]
+runs = 256
+depth = 500
+
+[profile.deep]
+# Inherits all settings from default profile
+# Used for certification runs (10,000 invariant runs)
+# Run with: FOUNDRY_PROFILE=deep forge test
+
+[profile.deep.fuzz]
+runs = 10000
+
+[profile.deep.invariant]
+runs = 10000
+depth = 500

--- a/test/0.8.25/invariant-fuzzing/StakingVaultsFuzzing.t.sol
+++ b/test/0.8.25/invariant-fuzzing/StakingVaultsFuzzing.t.sol
@@ -215,8 +215,6 @@ contract StakingVaultsTest is Test {
      * Invariant 1: Staking Vault should never go below the rebalance threshold.
      *
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-invariant-configs
-     * forge-config: default.invariant.runs = 256
-     * forge-config: default.invariant.depth = 256
      * forge-config: default.invariant.fail-on-revert = true
      */
     function invariant_01_liabilityShares_not_above_rebalance_threshold() external {
@@ -228,8 +226,6 @@ contract StakingVaultsTest is Test {
      * Invariant 2: Dynamic total value (including deltas) should never underflow (must be >= 0).
      *
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-invariant-configs
-     * forge-config: default.invariant.runs = 256
-     * forge-config: default.invariant.depth = 256
      * forge-config: default.invariant.fail-on-revert = true
      */
     function invariant_02_dynamic_totalValue_should_not_underflow() external {
@@ -247,8 +243,6 @@ contract StakingVaultsTest is Test {
      * Invariant 3: forceRebalance should not revert when the vault has available balance and obligations.
      *
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-invariant-configs
-     * forge-config: default.invariant.runs = 256
-     * forge-config: default.invariant.depth = 256
      * forge-config: default.invariant.fail-on-revert = true
      */
     function invariant_03_forceRebalance_should_not_revert_when_has_available_balance_and_obligations() external {
@@ -263,8 +257,6 @@ contract StakingVaultsTest is Test {
      * Invariant 4: forceValidatorExit should not revert when has obligations shortfall.
      *
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-invariant-configs
-     * forge-config: default.invariant.runs = 256
-     * forge-config: default.invariant.depth = 256
      * forge-config: default.invariant.fail-on-revert = true
      */
     function invariant_04_forceValidatorExit_should_not_revert_when_has_obligations_shortfall() external {
@@ -276,8 +268,6 @@ contract StakingVaultsTest is Test {
      * Invariant 5: Applied total value should not be greater than reported total value.
      *
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-invariant-configs
-     * forge-config: default.invariant.runs = 256
-     * forge-config: default.invariant.depth = 256
      * forge-config: default.invariant.fail-on-revert = true
      */
     function invariant_05_applied_tv_should_not_be_greater_than_reported_tv() external {
@@ -295,8 +285,6 @@ contract StakingVaultsTest is Test {
      * Invariant 6: Liability shares should never be greater than connection share limit.
      *
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-invariant-configs
-     * forge-config: default.invariant.runs = 256
-     * forge-config: default.invariant.depth = 256
      * forge-config: default.invariant.fail-on-revert = true
      */
     function invariant_06_liabilityshares_should_never_be_greater_than_connection_sharelimit() external {
@@ -327,8 +315,6 @@ contract StakingVaultsTest is Test {
      * Invariant 7: Locked amount must be >= max(connect deposit, liability-based safety buffer).
      *
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-invariant-configs
-     * forge-config: default.invariant.runs = 256
-     * forge-config: default.invariant.depth = 256
      * forge-config: default.invariant.fail-on-revert = true
      */
     function invariant_07_locked_cannot_be_less_than_slashing_connected_reserve()
@@ -357,8 +343,6 @@ contract StakingVaultsTest is Test {
      * Invariant 8: Withdrawable value must be <= total value minus locked amount and unsettled obligations.
      *
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-invariant-configs
-     * forge-config: default.invariant.runs = 256
-     * forge-config: default.invariant.depth = 256
      * forge-config: default.invariant.fail-on-revert = true
      */
     function invariant_08_withdrawableValue_should_be_less_than_or_equal_to_totalValue_minus_locked_and_obligations()
@@ -385,8 +369,6 @@ contract StakingVaultsTest is Test {
      * Invariant 9: The reported totalValue should not exceed the effective totalValue (EL+CL balance)
      *
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-invariant-configs
-     * forge-config: default.invariant.runs = 256
-     * forge-config: default.invariant.depth = 256
      * forge-config: default.invariant.fail-on-revert = true
      */
     function invariant_09_totalValue_should_be_less_than_or_equal_to_effective_total_value() external {
@@ -399,8 +381,6 @@ contract StakingVaultsTest is Test {
      * Invariant 10: Total value should satisfy the forced rebalance health threshold.
      *
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-invariant-configs
-     * forge-config: default.invariant.runs = 256
-     * forge-config: default.invariant.depth = 256
      * forge-config: default.invariant.fail-on-revert = true
      */
     function invariant_10_totalValue_should_satisfy_forced_rebalance_threshold()

--- a/test/0.8.25/vaults/refSlotCache/refSlotCache.t.sol
+++ b/test/0.8.25/vaults/refSlotCache/refSlotCache.t.sol
@@ -72,8 +72,6 @@ contract DoubleRefSlotCacheTest is Test {
      * invariant 1. the current value should be equal to the value for the next refSlot
      *
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-invariant-configs
-     * forge-config: default.invariant.runs = 32
-     * forge-config: default.invariant.depth = 32
      * forge-config: default.invariant.fail-on-revert = false
      */
     function invariant_currentValue() external {
@@ -84,8 +82,6 @@ contract DoubleRefSlotCacheTest is Test {
      * invariant 2. the value on refSlot should be equal to the previous value
      *
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-invariant-configs
-     * forge-config: default.invariant.runs = 128
-     * forge-config: default.invariant.depth = 128
      * forge-config: default.invariant.fail-on-revert = false
      */
     function invariant_valueOnRefSlot() external {

--- a/test/0.8.9/beaconChainDepositor.t.sol
+++ b/test/0.8.9/beaconChainDepositor.t.sol
@@ -37,8 +37,7 @@ contract BCDepositorInvariants is Test {
 
     /**
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-invariant-configs
-     * forge-config: default.invariant.runs = 32
-     * forge-config: default.invariant.depth = 16
+     * forge-config: default.invariant.depth = 4
      * forge-config: default.invariant.fail-on-revert = true
      */
     function invariant_32ETHPaidPerKey() public view {
@@ -48,8 +47,7 @@ contract BCDepositorInvariants is Test {
 
     /**
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-invariant-configs
-     * forge-config: default.invariant.runs = 32
-     * forge-config: default.invariant.depth = 16
+     * forge-config: default.invariant.depth = 4
      * forge-config: default.invariant.fail-on-revert = true
      */
     function invariant_DepositsCountIsCoherent() public view {
@@ -62,8 +60,7 @@ contract BCDepositorInvariants is Test {
 
     /**
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-invariant-configs
-     * forge-config: default.invariant.runs = 32
-     * forge-config: default.invariant.depth = 16
+     * forge-config: default.invariant.depth = 4
      * forge-config: default.invariant.fail-on-revert = true
      */
     function invariant_DepositDataIsNotCorrupted() public view {

--- a/test/0.8.9/unstructuredStorage.t.sol
+++ b/test/0.8.9/unstructuredStorage.t.sol
@@ -21,7 +21,6 @@ contract ExposedUnstructuredStorageTest is Test {
 
     /**
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-fuzz-configs
-     * forge-config: default.fuzz.runs = 2048
      * forge-config: default.fuzz.max-test-rejects = 0
      */
     function testFuzz_getStorageBool_Uninitialized(bytes32 position) public view {
@@ -35,7 +34,6 @@ contract ExposedUnstructuredStorageTest is Test {
 
     /**
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-fuzz-configs
-     * forge-config: default.fuzz.runs = 2048
      * forge-config: default.fuzz.max-test-rejects = 0
      */
     function testFuzz_getStorageAddress_Uninitialized(bytes32 position) public view {
@@ -50,7 +48,6 @@ contract ExposedUnstructuredStorageTest is Test {
 
     /**
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-fuzz-configs
-     * forge-config: default.fuzz.runs = 2048
      * forge-config: default.fuzz.max-test-rejects = 0
      */
     function testFuzz_getStorageBytes32_Uninitialized(bytes32 position) public view {
@@ -66,7 +63,6 @@ contract ExposedUnstructuredStorageTest is Test {
 
     /**
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-fuzz-configs
-     * forge-config: default.fuzz.runs = 2048
      * forge-config: default.fuzz.max-test-rejects = 0
      */
     function testFuzz_getStorageUint256_Uninitialized(bytes32 position) public view {
@@ -96,7 +92,6 @@ contract ExposedUnstructuredStorageTest is Test {
 
     /**
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-fuzz-configs
-     * forge-config: default.fuzz.runs = 2048
      * forge-config: default.fuzz.max-test-rejects = 0
      */
     function testFuzz_setStorageAddress(address data, bytes32 position) public {
@@ -117,7 +112,6 @@ contract ExposedUnstructuredStorageTest is Test {
 
     /**
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-fuzz-configs
-     * forge-config: default.fuzz.runs = 2048
      * forge-config: default.fuzz.max-test-rejects = 0
      */
     function testFuzz_setStorageBytes32(bytes32 data, bytes32 position) public {
@@ -140,7 +134,6 @@ contract ExposedUnstructuredStorageTest is Test {
 
     /**
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-fuzz-configs
-     * forge-config: default.fuzz.runs = 2048
      * forge-config: default.fuzz.max-test-rejects = 0
      */
     function testFuzz_setStorageUint256(uint256 data, bytes32 position) public {

--- a/test/0.8.9/withdrawalQueue.t.sol
+++ b/test/0.8.9/withdrawalQueue.t.sol
@@ -31,7 +31,6 @@ contract WQInvariants is Test {
 
     /**
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-invariant-configs
-     * forge-config: default.invariant.runs = 256
      * forge-config: default.invariant.depth = 256
      * forge-config: default.invariant.fail-on-revert = true
      */
@@ -44,7 +43,6 @@ contract WQInvariants is Test {
 
     /**
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-invariant-configs
-     * forge-config: default.invariant.runs = 256
      * forge-config: default.invariant.depth = 256
      * forge-config: default.invariant.fail-on-revert = true
      */
@@ -54,7 +52,6 @@ contract WQInvariants is Test {
 
     /**
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-invariant-configs
-     * forge-config: default.invariant.runs = 256
      * forge-config: default.invariant.depth = 256
      * forge-config: default.invariant.fail-on-revert = true
      */
@@ -65,7 +62,6 @@ contract WQInvariants is Test {
 
     /**
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-invariant-configs
-     * forge-config: default.invariant.runs = 256
      * forge-config: default.invariant.depth = 256
      * forge-config: default.invariant.fail-on-revert = true
      */
@@ -80,7 +76,6 @@ contract WQInvariants is Test {
 
     /**
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-invariant-configs
-     * forge-config: default.invariant.runs = 256
      * forge-config: default.invariant.depth = 256
      * forge-config: default.invariant.fail-on-revert = true
      */
@@ -94,7 +89,6 @@ contract WQInvariants is Test {
 
     /**
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-invariant-configs
-     * forge-config: default.invariant.runs = 256
      * forge-config: default.invariant.depth = 256
      * forge-config: default.invariant.fail-on-revert = true
      */
@@ -108,7 +102,6 @@ contract WQInvariants is Test {
 
     /**
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-invariant-configs
-     * forge-config: default.invariant.runs = 256
      * forge-config: default.invariant.depth = 256
      * forge-config: default.invariant.fail-on-revert = true
      */

--- a/test/common/lib/GIndex.t.sol
+++ b/test/common/lib/GIndex.t.sol
@@ -183,6 +183,10 @@ contract GIndexTest is Test {
         lib.shr(gIParent.concat(pack(1023, 4)), 1);
     }
 
+    /**
+     * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-fuzz-configs
+     * forge-config: default.fuzz.max-test-rejects = 1000000
+     */
     function testFuzz_shr_OffTheWidth_AfterConcat(GIndex lhs, GIndex rhs, uint256 shift) public {
         // Indices concatenation overflow protection.
         vm.assume(fls(lhs.index()) + 1 + fls(rhs.index()) < 248);
@@ -258,6 +262,10 @@ contract GIndexTest is Test {
         lib.shl(gIParent.concat(pack(1023, 4)), 16);
     }
 
+    /**
+     * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-fuzz-configs
+     * forge-config: default.fuzz.max-test-rejects = 1000000
+     */
     function testFuzz_shl_OffTheWidth_AfterConcat(GIndex lhs, GIndex rhs, uint256 shift) public {
         // Indices concatenation overflow protection.
         vm.assume(fls(lhs.index()) + 1 + fls(rhs.index()) < 248);

--- a/test/common/math256.t.sol
+++ b/test/common/math256.t.sol
@@ -31,7 +31,6 @@ contract Math256Test is Test {
 
     /**
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-fuzz-configs
-     * forge-config: default.fuzz.runs = 2048
      * forge-config: default.fuzz.max-test-rejects = 0
      */
     function testFuzz_max_WorksWithUint256(uint256 a, uint256 b) public pure {
@@ -76,7 +75,6 @@ contract Math256Test is Test {
 
     /**
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-fuzz-configs
-     * forge-config: default.fuzz.runs = 2048
      * forge-config: default.fuzz.max-test-rejects = 0
      */
     function testFuzz_min_WorksWithUint256(uint256 a, uint256 b) public pure {
@@ -153,7 +151,6 @@ contract Math256Test is Test {
 
     /**
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-fuzz-configs
-     * forge-config: default.fuzz.runs = 2048
      * forge-config: default.fuzz.max-test-rejects = 0
      */
     function testFuzz_max_WorksWithInt256(int256 a, int256 b) public pure {
@@ -195,7 +192,6 @@ contract Math256Test is Test {
 
     /**
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-fuzz-configs
-     * forge-config: default.fuzz.runs = 2048
      * forge-config: default.fuzz.max-test-rejects = 0
      */
     function testFuzz_min_WorksWithInt256(int256 a, int256 b) public pure {
@@ -256,7 +252,6 @@ contract Math256Test is Test {
 
     /**
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-fuzz-configs
-     * forge-config: default.fuzz.runs = 2048
      * forge-config: default.fuzz.max-test-rejects = 0
      */
     function testFuzz_ceilDiv(uint256 a, uint256 b) public pure {
@@ -299,7 +294,6 @@ contract Math256Test is Test {
 
     /**
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-fuzz-configs
-     * forge-config: default.fuzz.runs = 2048
      * forge-config: default.fuzz.max-test-rejects = 0
      */
     function testFuzz_absDiff(uint256 a, uint256 b) public pure {

--- a/test/common/minFirstAllocationStrategy.t.sol
+++ b/test/common/minFirstAllocationStrategy.t.sol
@@ -58,7 +58,6 @@ contract MinFirstAllocationStrategyInvariants is Test {
      * invariant 1. the allocated value should be equal to the expected output
      *
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-invariant-configs
-     * forge-config: default.invariant.runs = 512
      * forge-config: default.invariant.depth = 32
      * forge-config: default.invariant.fail-on-revert = true
      */
@@ -73,7 +72,6 @@ contract MinFirstAllocationStrategyInvariants is Test {
      * invariant 2. the bucket values should be equal to the expected output
      *
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-invariant-configs
-     * forge-config: default.invariant.runs = 512
      * forge-config: default.invariant.depth = 32
      * forge-config: default.invariant.fail-on-revert = true
      */
@@ -90,7 +88,6 @@ contract MinFirstAllocationStrategyInvariants is Test {
      * invariant 3. the bucket value should not exceed the capacity
      *
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-invariant-configs
-     * forge-config: default.invariant.runs = 512
      * forge-config: default.invariant.depth = 32
      * forge-config: default.invariant.fail-on-revert = true
      */
@@ -109,7 +106,6 @@ contract MinFirstAllocationStrategyInvariants is Test {
      * invariant 4. the sum of new allocation minus the sum of prev allocation equal to distributed value
      *
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-invariant-configs
-     * forge-config: default.invariant.runs = 512
      * forge-config: default.invariant.depth = 32
      * forge-config: default.invariant.fail-on-revert = true
      */
@@ -132,7 +128,6 @@ contract MinFirstAllocationStrategyInvariants is Test {
      * invariant 5. the allocated value should be less than or equal to the allocation size
      *
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-invariant-configs
-     * forge-config: default.invariant.runs = 512
      * forge-config: default.invariant.depth = 32
      * forge-config: default.invariant.fail-on-revert = true
      */

--- a/test/common/signatureUtils.t.sol
+++ b/test/common/signatureUtils.t.sol
@@ -71,7 +71,6 @@ contract SignatureUtilsTest is Test {
 
     /**
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-fuzz-configs
-     * forge-config: default.fuzz.runs = 2048
      * forge-config: default.fuzz.max-test-rejects = 0
      */
     function testFuzz_isValidSignature_EoaNum(uint256 eoa_num) public view {
@@ -86,7 +85,6 @@ contract SignatureUtilsTest is Test {
 
     /**
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-fuzz-configs
-     * forge-config: default.fuzz.runs = 2048
      * forge-config: default.fuzz.max-test-rejects = 0
      */
     function testFuzz_isValidSignature_EoaMessage(bytes memory data) public view {
@@ -101,7 +99,6 @@ contract SignatureUtilsTest is Test {
 
     /**
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-fuzz-configs
-     * forge-config: default.fuzz.runs = 2048
      * forge-config: default.fuzz.max-test-rejects = 0
      */
     function testFuzz_isValidSignature_EoaV(uint8 _v) public {
@@ -123,7 +120,6 @@ contract SignatureUtilsTest is Test {
 
     /**
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-fuzz-configs
-     * forge-config: default.fuzz.runs = 2048
      * forge-config: default.fuzz.max-test-rejects = 0
      */
     function testFuzz_isValidSignature_EoaR(bytes32 _r) public {
@@ -145,7 +141,6 @@ contract SignatureUtilsTest is Test {
 
     /**
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-fuzz-configs
-     * forge-config: default.fuzz.runs = 2048
      * forge-config: default.fuzz.max-test-rejects = 0
      */
     function testFuzz_isValidSignature_EoaS(bytes32 _s) public {


### PR DESCRIPTION
Add deep Foundry profile for 10,000 fuzzing runs certification.

## Context

The project has invariant and fuzz tests across multiple contracts with various inline `forge-config` overrides for runs, depth, and other settings. Currently all tests run with default settings (256 invariant runs, standard fuzz runs), with no standardized way to run extended fuzzing campaigns.

## Solution

**`foundry.toml`**: Added `[profile.deep.fuzz]` and `[profile.deep.invariant]` sections with `runs = 10000`.

**Inline config cleanup across all test files**:
- Removed redundant `default.*.runs` where the value matched toml defaults (2048 in `math256`, `signatureUtils`, `unstructuredStorage`; 256 in `withdrawalQueue`; 32/128 in `refSlotCache`)
- Kept `default.*.runs` only where intentionally different: `beaconChainDepositor` (32 — expensive per call), `positiveTokenRebaseLimiter` (65536), `BLS` (204800/10000)
- Added `deep.invariant.runs = 10000` only in `beaconChainDepositor` where inline `default.invariant.runs = 32` would block deep profile
- Reduced `beaconChainDepositor` depth to 4 (single handler function, depth doesn't add coverage)
- Added `max-test-rejects = 1000000` to two `GIndex` fuzz tests that reject ~88% of inputs via `vm.assume`

**Run**: `FOUNDRY_PROFILE=deep forge test` (~41 min wall time)
