### PR TITLE
feat: fix console warnings

### DIFF
--- a/contracts/0.8.9/oracle/AccountingOracle.sol
+++ b/contracts/0.8.9/oracle/AccountingOracle.sol
@@ -45,7 +45,7 @@ interface IStakingRouter {
 
     function reportStakingModuleOperatorBalances(
         uint256 _stakingModuleId,
-        bytes calldata _operatorIds,
+        bytes calldata _nodeOperatorIds,
         bytes calldata _totalBalancesGwei
     ) external;
 

--- a/tasks/check-interfaces.ts
+++ b/tasks/check-interfaces.ts
@@ -54,6 +54,11 @@ const PAIRS_TO_SKIP: {
     ],
   },
   {
+    interfaceFqn: "contracts/0.4.24/Lido.sol:IAccountingOracle",
+    contractFqn: "contracts/0.8.9/oracle/AccountingOracle.sol:AccountingOracle",
+    reason: "Fixing requires Lido redeploy",
+  },
+  {
     interfaceFqn: "contracts/0.4.24/Lido.sol:IStakingRouter",
     contractFqn: "contracts/0.8.25/sr/StakingRouter.sol:StakingRouter",
     reason: "only var names/state modifiers are diff., can be safely ignored",

--- a/test/0.8.25/contracts/StakingRouter__Harness.sol
+++ b/test/0.8.25/contracts/StakingRouter__Harness.sol
@@ -113,23 +113,23 @@ contract StakingRouter__Harness is StakingRouter {
         ModuleStateAccounting storage moduleAcc = SRStorage.getModuleState(_stakingModuleId).accounting;
         RouterStateAccounting storage routerAcc = SRStorage.getRouterState().accounting;
 
-        uint64 totalValidatorBalanceGwei = routerAcc.validatorsBalanceGwei;
+        uint64 totalValidatorsBalanceGwei = routerAcc.validatorsBalanceGwei;
         uint64 totalPendingBalanceGwei = routerAcc.pendingBalanceGwei;
 
         // update totals incrementally as we iterate through the part of modules in general case
         // 1. subtract old values
         unchecked {
-            totalValidatorBalanceGwei -= moduleAcc.validatorsBalanceGwei;
+            totalValidatorsBalanceGwei -= moduleAcc.validatorsBalanceGwei;
             totalPendingBalanceGwei -= moduleAcc.pendingBalanceGwei;
         }
         // 2. validate and add new values
 
         unchecked {
-            totalValidatorBalanceGwei += validatorsBalanceGwei;
+            totalValidatorsBalanceGwei += validatorsBalanceGwei;
             totalPendingBalanceGwei += pendingBalanceGwei;
         }
 
-        routerAcc.validatorsBalanceGwei = totalValidatorBalanceGwei;
+        routerAcc.validatorsBalanceGwei = totalValidatorsBalanceGwei;
         routerAcc.pendingBalanceGwei = totalPendingBalanceGwei;
 
         moduleAcc.validatorsBalanceGwei = validatorsBalanceGwei;


### PR DESCRIPTION
Fix console warnings


❌ ABI mismatch between:
   Interface: contracts/0.8.9/oracle/AccountingOracle.sol:IStakingRouter
   Contract:  contracts/0.8.25/sr/StakingRouter.sol:StakingRouter
   Match type: Sub-interface

📋 Parameter name mismatches (1 functions):
   Interface: function reportStakingModuleOperatorBalances(uint256 _stakingModuleId, bytes _operatorIds, bytes _totalBalancesGwei) returns ()
   Contract:  function reportStakingModuleOperatorBalances(uint256 _stakingModuleId, bytes _nodeOperatorIds, bytes _totalBalancesGwei) returns ()
   
**Fix:** Update parameter name.   
   

❌ ABI mismatch between:
Interface: contracts/0.4.24/Lido.sol:IAccountingOracle
Contract: contracts/0.8.9/oracle/AccountingOracle.sol:AccountingOracle
Match type: Sub-interface

**Fix:** The mismatch is because AccountingOracle.getProcessingState() returns a ProcessingState struct (ABI: tuple), but the interface in Lido.sol (Solidity 0.4.24, which can't use struct returns) declares individual return values. These are wire-compatible but differ in ABI JSON representation. Since Lido version can't be changed right now, the fix is to add this pair to the skip list in the check-interfaces task.