### PR TITLE
chore: bump forge-std to v1.13.0 and split ci fuzzing flows

### DIFF
--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -18,6 +18,7 @@ jobs:
 
   test_foundry_fuzzing:
     name: Foundry / Fuzzing & Invariants
+    if: github.ref_name != 'develop' && github.ref_name != 'master'
     runs-on: ubuntu-latest
 
     steps:
@@ -28,13 +29,29 @@ jobs:
 
       - name: Install foundry
         uses: foundry-rs/foundry-toolchain@v1
-        # Use a specific version of Foundry in case nightly is broken
-        # https://github.com/foundry-rs/foundry/releases
-        # with:
-        #   version: nightly-54d8510c0f2b0f791f4c5ef99866c6af99b7606a
 
       - name: Print forge version
         run: forge --version
 
       - name: Run fuzzing and invariant tests
         run: forge test
+
+  test_foundry_fuzzing_deep:
+    name: Foundry / Fuzzing & Invariants (deep)
+    if: github.ref_name == 'develop' || github.ref_name == 'master'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Common setup
+        uses: ./.github/workflows/setup
+
+      - name: Install foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Print forge version
+        run: forge --version
+
+      - name: Run fuzzing and invariant tests (deep profile, 10k runs)
+        run: FOUNDRY_PROFILE=deep forge test

--- a/foundry.lock
+++ b/foundry.lock
@@ -1,0 +1,8 @@
+{
+  "foundry/lib/forge-std": {
+    "tag": {
+      "name": "v1.13.0",
+      "rev": "c29afdd40a82db50a3d3709d324416be50050e5e"
+    }
+  }
+}


### PR DESCRIPTION
This pull request updates the fuzzing and invariant test workflows to optimize test coverage and efficiency based on the target branch, and also updates the `forge-std` submodule. The main improvements include running deeper fuzzing tests only on the main development branches and a submodule update.

**Workflow improvements:**

* Modified the `test_foundry_fuzzing` job in `.github/workflows/tests-unit.yml` to only run on branches other than `develop` and `master`, reducing redundant test runs on main branches.
* Added a new `test_foundry_fuzzing_deep` job to `.github/workflows/tests-unit.yml` that runs a more thorough fuzzing test (with the `deep` profile and 10,000 runs) exclusively on the `develop` and `master` branches, ensuring higher test coverage where it matters most.

**Dependency updates:**

* Updated the `forge-std` submodule to the latest commit, potentially bringing in bug fixes and new features.