### PR TITLE
feat: track only a pending batches in the consolidation bus

### DIFF
--- a/contracts/0.8.25/ConsolidationBus.sol
+++ b/contracts/0.8.25/ConsolidationBus.sol
@@ -56,22 +56,16 @@ contract ConsolidationBus is AccessControlEnumerableUpgradeable {
     error BatchTooLarge(uint256 size, uint256 limit);
 
     /**
-     * @notice Thrown when trying to add a batch that already exists
-     * @param batchHash Hash of the duplicate batch
-     */
-    error BatchAlreadyAdded(bytes32 batchHash);
+     * @notice Thrown when attempting to add a batch that is already pending execution
+     * @param batchHash Hash of the batch that already exists in the pending queue
+    */
+    error BatchAlreadyPending(bytes32 batchHash);
 
     /**
      * @notice Thrown when batch is not found in storage
      * @param batchHash Hash of the missing batch
      */
     error BatchNotFound(bytes32 batchHash);
-
-    /**
-     * @notice Thrown when trying to execute or remove an already executed batch
-     * @param batchHash Hash of the executed batch
-     */
-    error BatchAlreadyExecuted(bytes32 batchHash);
 
     /**
      * @notice Thrown when source and target pubkeys are the same
@@ -125,13 +119,8 @@ contract ConsolidationBus is AccessControlEnumerableUpgradeable {
 
     IConsolidationGateway internal immutable CONSOLIDATION_GATEWAY;
 
-    struct BatchInfo {
-        address publisher;
-        bool executed;
-    }
-
     uint256 internal _batchSize;
-    mapping(bytes32 batchHash => BatchInfo) internal _batches;
+    mapping(bytes32 batchHash => address publisher) internal _pendingBatches;
 
     constructor(
         address admin,
@@ -192,12 +181,10 @@ contract ConsolidationBus is AccessControlEnumerableUpgradeable {
     function removeBatches(bytes32[] calldata batchHashes) external onlyRole(MANAGER_ROLE) {
         for (uint256 i = 0; i < batchHashes.length; ++i) {
             bytes32 batchHash = batchHashes[i];
-            BatchInfo storage batch = _batches[batchHash];
 
-            if (batch.publisher == address(0)) revert BatchNotFound(batchHash);
-            if (batch.executed) revert BatchAlreadyExecuted(batchHash);
+            if (_pendingBatches[batchHash] == address(0)) revert BatchNotFound(batchHash);
 
-            delete _batches[batchHash];
+            delete _pendingBatches[batchHash];
         }
         emit BatchesRemoved(batchHashes);
     }
@@ -215,30 +202,20 @@ contract ConsolidationBus is AccessControlEnumerableUpgradeable {
     }
 
     /**
-     * @notice Checks if a batch has been added
-     * @param batchHash Hash of the batch to check
-     * @return True if batch exists and is not executed
-     */
-    function isBatchAdded(bytes32 batchHash) external view returns (bool) {
-        BatchInfo storage batch = _batches[batchHash];
-        return batch.publisher != address(0) && !batch.executed;
-    }
-
-    /**
-     * @notice Returns the publisher address for a batch
-     * @param batchHash Hash of the batch
-     * @return Address of the publisher who added the batch
-     */
-    function addedBy(bytes32 batchHash) external view returns (address) {
-        return _batches[batchHash].publisher;
-    }
-
-    /**
      * @notice Returns the address of the ConsolidationGateway
      * @return Address of the ConsolidationGateway contract
      */
     function getConsolidationGateway() external view returns (address) {
         return address(CONSOLIDATION_GATEWAY);
+    }
+
+    /**
+     * @notice Returns the publisher address for a pending batch, or zero address if batch is not in queue
+     * @param batchHash Hash of the batch to check
+     * @return Address of the publisher who added the batch, or zero address if not in queue
+     */
+    function getBatchPublisher(bytes32 batchHash) external view returns (address) {
+        return _pendingBatches[batchHash];
     }
 
     // ===============
@@ -276,12 +253,9 @@ contract ConsolidationBus is AccessControlEnumerableUpgradeable {
 
         bytes32 batchHash = _computeBatchHash(sourcePubkeys, targetPubkeys);
 
-        if (_batches[batchHash].publisher != address(0)) revert BatchAlreadyAdded(batchHash);
+        if (_pendingBatches[batchHash] != address(0)) revert BatchAlreadyPending(batchHash);
 
-        _batches[batchHash] = BatchInfo({
-            publisher: msg.sender,
-            executed: false
-        });
+        _pendingBatches[batchHash] = msg.sender;
 
         emit RequestsAdded(msg.sender, abi.encode(sourcePubkeys, targetPubkeys));
     }
@@ -305,11 +279,9 @@ contract ConsolidationBus is AccessControlEnumerableUpgradeable {
     ) external payable onlyRole(EXECUTER_ROLE) {
         bytes32 batchHash = _computeBatchHash(sourcePubkeys, targetPubkeys);
 
-        BatchInfo storage batch = _batches[batchHash];
-        if (batch.publisher == address(0)) revert BatchNotFound(batchHash);
-        if (batch.executed) revert BatchAlreadyExecuted(batchHash);
+        if (_pendingBatches[batchHash] == address(0)) revert BatchNotFound(batchHash);
 
-        batch.executed = true;
+        delete _pendingBatches[batchHash];
 
         CONSOLIDATION_GATEWAY.addConsolidationRequests{value: msg.value}(
             sourcePubkeys,

--- a/test/0.8.25/consolidationBus/consolidationBus.executor.test.ts
+++ b/test/0.8.25/consolidationBus/consolidationBus.executor.test.ts
@@ -77,8 +77,8 @@ describe("ConsolidationBus.sol: executor", () => {
         .to.emit(consolidationBus, "RequestsExecuted")
         .withArgs(batchHash, fee);
 
-      // Verify batch is marked as executed (isBatchAdded returns false for executed batches)
-      expect(await consolidationBus.isBatchAdded(batchHash)).to.be.false;
+      // Verify batch is removed from storage after execution
+      expect(await consolidationBus.getBatchPublisher(batchHash)).to.equal(ethers.ZeroAddress);
     });
 
     it("should forward call to ConsolidationGateway", async () => {
@@ -114,9 +114,9 @@ describe("ConsolidationBus.sol: executor", () => {
       // Execute first time
       await consolidationBus.connect(executor).executeConsolidation(sourcePubkeys, targetPubkeys, { value: 10 });
 
-      // Try to execute again
+      // Try to execute again — batch was deleted, so it's not found
       await expect(consolidationBus.connect(executor).executeConsolidation(sourcePubkeys, targetPubkeys, { value: 10 }))
-        .to.be.revertedWithCustomError(consolidationBus, "BatchAlreadyExecuted")
+        .to.be.revertedWithCustomError(consolidationBus, "BatchNotFound")
         .withArgs(batchHash);
     });
 
@@ -173,17 +173,6 @@ describe("ConsolidationBus.sol: executor", () => {
       await expect(consolidationBus.connect(executor).executeConsolidation(sourcePubkeys, targetPubkeys, { value: 10 }))
         .to.emit(consolidationGateway, "AddConsolidationRequestsCalled")
         .withArgs(sourcePubkeys, targetPubkeys, executor.address, 10);
-    });
-
-    it("should preserve addedBy after execution", async () => {
-      // Before execution
-      expect(await consolidationBus.addedBy(batchHash)).to.equal(publisher.address);
-
-      // Execute
-      await consolidationBus.connect(executor).executeConsolidation(sourcePubkeys, targetPubkeys, { value: 10 });
-
-      // After execution, addedBy should still return the publisher
-      expect(await consolidationBus.addedBy(batchHash)).to.equal(publisher.address);
     });
   });
 

--- a/test/0.8.25/consolidationBus/consolidationBus.management.test.ts
+++ b/test/0.8.25/consolidationBus/consolidationBus.management.test.ts
@@ -135,13 +135,13 @@ describe("ConsolidationBus.sol: management", () => {
     });
 
     it("should remove batches", async () => {
-      expect(await consolidationBus.isBatchAdded(batchHash)).to.be.true;
+      expect(await consolidationBus.getBatchPublisher(batchHash)).to.not.equal(ethers.ZeroAddress);
 
       await expect(consolidationBus.connect(manager).removeBatches([batchHash]))
         .to.emit(consolidationBus, "BatchesRemoved")
         .withArgs([batchHash]);
 
-      expect(await consolidationBus.isBatchAdded(batchHash)).to.be.false;
+      expect(await consolidationBus.getBatchPublisher(batchHash)).to.equal(ethers.ZeroAddress);
     });
 
     it("should revert if caller does not have MANAGER_ROLE", async () => {
@@ -168,9 +168,9 @@ describe("ConsolidationBus.sol: management", () => {
 
       await consolidationBus.connect(manager).executeConsolidation(sourcePubkeys, targetPubkeys, { value: 10 });
 
-      // Try to remove the executed batch
+      // Try to remove the executed batch — batch was deleted, so it's not found
       await expect(consolidationBus.connect(manager).removeBatches([batchHash]))
-        .to.be.revertedWithCustomError(consolidationBus, "BatchAlreadyExecuted")
+        .to.be.revertedWithCustomError(consolidationBus, "BatchNotFound")
         .withArgs(batchHash);
     });
 
@@ -189,8 +189,8 @@ describe("ConsolidationBus.sol: management", () => {
         .to.emit(consolidationBus, "BatchesRemoved")
         .withArgs([batchHash, batchHash2]);
 
-      expect(await consolidationBus.isBatchAdded(batchHash)).to.be.false;
-      expect(await consolidationBus.isBatchAdded(batchHash2)).to.be.false;
+      expect(await consolidationBus.getBatchPublisher(batchHash)).to.equal(ethers.ZeroAddress);
+      expect(await consolidationBus.getBatchPublisher(batchHash2)).to.equal(ethers.ZeroAddress);
     });
   });
 });

--- a/test/0.8.25/consolidationBus/consolidationBus.publisher.test.ts
+++ b/test/0.8.25/consolidationBus/consolidationBus.publisher.test.ts
@@ -64,8 +64,7 @@ describe("ConsolidationBus.sol: publisher", () => {
         .to.emit(consolidationBus, "RequestsAdded")
         .withArgs(publisher.address, batchData);
 
-      expect(await consolidationBus.isBatchAdded(batchHash)).to.be.true;
-      expect(await consolidationBus.addedBy(batchHash)).to.equal(publisher.address);
+      expect(await consolidationBus.getBatchPublisher(batchHash)).to.equal(publisher.address);
     });
 
     it("should add multiple requests in a batch", async () => {
@@ -82,7 +81,7 @@ describe("ConsolidationBus.sol: publisher", () => {
         .to.emit(consolidationBus, "RequestsAdded")
         .withArgs(publisher.address, batchData);
 
-      expect(await consolidationBus.isBatchAdded(batchHash)).to.be.true;
+      expect(await consolidationBus.getBatchPublisher(batchHash)).to.not.equal(ethers.ZeroAddress);
     });
 
     it("should revert if caller does not have PUBLISHER_ROLE", async () => {
@@ -152,7 +151,7 @@ describe("ConsolidationBus.sol: publisher", () => {
 
       // Try to add again
       await expect(consolidationBus.connect(publisher).addConsolidationRequests(sourcePubkeys, targetPubkeys))
-        .to.be.revertedWithCustomError(consolidationBus, "BatchAlreadyAdded")
+        .to.be.revertedWithCustomError(consolidationBus, "BatchAlreadyPending")
         .withArgs(batchHash);
     });
 
@@ -195,20 +194,15 @@ describe("ConsolidationBus.sol: publisher", () => {
         ethers.AbiCoder.defaultAbiCoder().encode(["bytes[]", "bytes[]"], [sourcePubkeys2, targetPubkeys2]),
       );
 
-      expect(await consolidationBus.addedBy(batchHash1)).to.equal(publisher.address);
-      expect(await consolidationBus.addedBy(batchHash2)).to.equal(publisher2.address);
+      expect(await consolidationBus.getBatchPublisher(batchHash1)).to.equal(publisher.address);
+      expect(await consolidationBus.getBatchPublisher(batchHash2)).to.equal(publisher2.address);
     });
   });
 
   context("view methods", () => {
-    it("isBatchAdded should return false for non-existent batch", async () => {
+    it("getBatchPublisher should return zero address for non-existent batch", async () => {
       const fakeBatchHash = ethers.keccak256(ethers.toUtf8Bytes("fake"));
-      expect(await consolidationBus.isBatchAdded(fakeBatchHash)).to.be.false;
-    });
-
-    it("addedBy should return zero address for non-existent batch", async () => {
-      const fakeBatchHash = ethers.keccak256(ethers.toUtf8Bytes("fake"));
-      expect(await consolidationBus.addedBy(fakeBatchHash)).to.equal(ethers.ZeroAddress);
+      expect(await consolidationBus.getBatchPublisher(fakeBatchHash)).to.equal(ethers.ZeroAddress);
     });
   });
 });

--- a/test/integration/core/consolidation-migration.integration.ts
+++ b/test/integration/core/consolidation-migration.integration.ts
@@ -220,8 +220,7 @@ describe("Integration: Consolidation Migration Flow (Real NOR)", () => {
           ],
         ),
       );
-      expect(await consolidationBus.isBatchAdded(batchHash)).to.be.true;
-      expect(await consolidationBus.addedBy(batchHash)).to.equal(await consolidationMigrator.getAddress());
+      expect(await consolidationBus.getBatchPublisher(batchHash)).to.equal(await consolidationMigrator.getAddress());
 
       // Step 3: Executor calls executeConsolidation
       const fee = await withdrawalVault.getConsolidationRequestFee();
@@ -236,8 +235,8 @@ describe("Integration: Consolidation Migration Flow (Real NOR)", () => {
           value: totalFee,
         });
 
-      // Step 4: Verify batch is marked as executed
-      expect(await consolidationBus.isBatchAdded(batchHash)).to.be.false; // returns false for executed batches
+      // Step 4: Verify batch is removed from storage after execution
+      expect(await consolidationBus.getBatchPublisher(batchHash)).to.equal(ethers.ZeroAddress);
 
       // Step 5: Verify ConsolidationGateway rate limit was consumed
       const finalLimit = (await consolidationGateway.getConsolidationRequestLimitFullInfo())
@@ -331,7 +330,7 @@ describe("Integration: Consolidation Migration Flow (Real NOR)", () => {
       // Try to execute again
       await expect(
         consolidationBus.connect(executor).executeConsolidation([SOURCE_PUBKEY_1], [TARGET_PUBKEY_1], { value: fee }),
-      ).to.be.revertedWithCustomError(consolidationBus, "BatchAlreadyExecuted");
+      ).to.be.revertedWithCustomError(consolidationBus, "BatchNotFound");
     });
   });
 
@@ -348,12 +347,12 @@ describe("Integration: Consolidation Migration Flow (Real NOR)", () => {
         ethers.AbiCoder.defaultAbiCoder().encode(["bytes[]", "bytes[]"], [[SOURCE_PUBKEY_1], [TARGET_PUBKEY_1]]),
       );
 
-      expect(await consolidationBus.isBatchAdded(batchHash)).to.be.true;
+      expect(await consolidationBus.getBatchPublisher(batchHash)).to.not.equal(ethers.ZeroAddress);
 
       // Manager removes the batch
       await consolidationBus.connect(agentSigner).removeBatches([batchHash]);
 
-      expect(await consolidationBus.isBatchAdded(batchHash)).to.be.false;
+      expect(await consolidationBus.getBatchPublisher(batchHash)).to.equal(ethers.ZeroAddress);
     });
   });
 
@@ -630,7 +629,7 @@ describe("Integration: Consolidation Migration Flow (Real NOR)", () => {
       const batchHash1 = ethers.keccak256(
         ethers.AbiCoder.defaultAbiCoder().encode(["bytes[]", "bytes[]"], [[SOURCE_PUBKEY_1], [TARGET_PUBKEY_1]]),
       );
-      expect(await consolidationBus.isBatchAdded(batchHash1)).to.be.false;
+      expect(await consolidationBus.getBatchPublisher(batchHash1)).to.equal(ethers.ZeroAddress);
 
       // Execute second batch
       await consolidationBus
@@ -641,7 +640,7 @@ describe("Integration: Consolidation Migration Flow (Real NOR)", () => {
       const batchHash2 = ethers.keccak256(
         ethers.AbiCoder.defaultAbiCoder().encode(["bytes[]", "bytes[]"], [[SOURCE_PUBKEY_2], [TARGET_PUBKEY_2]]),
       );
-      expect(await consolidationBus.isBatchAdded(batchHash2)).to.be.false;
+      expect(await consolidationBus.getBatchPublisher(batchHash2)).to.equal(ethers.ZeroAddress);
     });
 
     it("Should revert executeConsolidation if batch was removed", async () => {
@@ -684,7 +683,7 @@ describe("Integration: Consolidation Migration Flow (Real NOR)", () => {
         .withArgs(2, 1);
     });
 
-    it("Should revert addConsolidationRequests if batch already added (duplicate submission)", async () => {
+    it("Should revert addConsolidationRequests if batch already pending (duplicate submission)", async () => {
       // Submit batch first time
       await consolidationMigrator
         .connect(submitter)
@@ -700,7 +699,7 @@ describe("Integration: Consolidation Migration Flow (Real NOR)", () => {
           .connect(submitter)
           .submitConsolidationBatch(sourceOperatorId, targetOperatorId, [0n], [0n]),
       )
-        .to.be.revertedWithCustomError(consolidationBus, "BatchAlreadyAdded")
+        .to.be.revertedWithCustomError(consolidationBus, "BatchAlreadyPending")
         .withArgs(batchHash);
     });
   });


### PR DESCRIPTION
Currently, batch hashes are stored to prevent duplicate submissions. If the same batch is submitted again, the transaction reverts because the hash already exists.

However, this approach is flawed.

Consider a batch containing a single request. If the request fails (e.g., the validator has not yet become active), it is rejected on the CL. Although `ConsolidationMigrator` verifies that a deposit was made, this does not guarantee the validator is already active.

If the same batch is then resubmitted, it fails immediately because its hash is already stored, making retry impossible even though the original request never succeeded.
