### PR TITLE
feat: consolidation requests processing paused if DSM stopped deposits

### DIFF
--- a/contracts/0.8.25/ConsolidationGateway.sol
+++ b/contracts/0.8.25/ConsolidationGateway.sol
@@ -8,6 +8,10 @@ import {ILidoLocator} from "contracts/common/interfaces/ILidoLocator.sol";
 import {LimitData, RateLimitStorage, RateLimit} from "contracts/common/lib/RateLimit.sol";
 import {PausableUntilWithRoles} from "./utils/PausableUntilWithRoles.sol";
 
+interface IDepositSecurityModule {
+    function isDepositsPaused() external view returns (bool);
+}
+
 interface IWithdrawalVault {
     function addConsolidationRequests(
         bytes[] calldata sourcePubkeys,
@@ -60,6 +64,11 @@ contract ConsolidationGateway is PausableUntilWithRoles {
      * @notice Thrown when source and target arrays have different lengths
      */
     error ArraysLengthMismatch(uint256 firstArrayLength, uint256 secondArrayLength);
+
+    /**
+     * @notice Thrown when DSM deposits are paused
+     */
+    error DSMDepositsPaused();
 
     /**
      * @notice Emitted when limits configs are set.
@@ -122,6 +131,8 @@ contract ConsolidationGateway is PausableUntilWithRoles {
         if (requestsCount != targetPubkeys.length)
             revert ArraysLengthMismatch(requestsCount, targetPubkeys.length);
 
+        _ensureDSMDepositsNotPaused();    
+
         _consumeConsolidationRequestLimit(requestsCount);
 
         IWithdrawalVault withdrawalVault = IWithdrawalVault(LOCATOR.withdrawalVault());
@@ -179,6 +190,14 @@ contract ConsolidationGateway is PausableUntilWithRoles {
     }
 
     /// Internal functions
+
+    function _ensureDSMDepositsNotPaused() internal view {
+        // If the DSM has stopped deposits, some validators may have non-Lido withdrawal credentials. 
+        // In that case, processing of all new consolidation requests should be paused.
+        if (IDepositSecurityModule(LOCATOR.depositSecurityModule()).isDepositsPaused()) {
+            revert DSMDepositsPaused();
+        }
+    }
 
     function _checkFee(uint256 fee) internal view returns (uint256 refund) {
         if (msg.value < fee) {

--- a/test/0.8.25/consolidationBus/consolidationBus.gas.test.ts
+++ b/test/0.8.25/consolidationBus/consolidationBus.gas.test.ts
@@ -74,6 +74,9 @@ describe("ConsolidationBus.sol: gas limit (full stack)", () => {
     const locator = await deployLidoLocator();
     const locatorAddress = await locator.getAddress();
 
+    // 3a. Deploy DSM mock (needed for _ensureDSMDepositsNotPaused check in ConsolidationGateway)
+    const dsm = await ethers.deployContract("DepositSecurityModule__MockForConsolidationGateway");
+
     // 4. Deploy ConsolidationGateway
     consolidationGateway = await ethers.deployContract("ConsolidationGateway", [
       admin.address,
@@ -93,9 +96,10 @@ describe("ConsolidationBus.sol: gas limit (full stack)", () => {
     const [vault] = await proxify({ impl: vaultImpl, admin });
     withdrawalVault = vault as unknown as WithdrawalVault;
 
-    // 6. Update LidoLocator to point to real WithdrawalVault
+    // 6. Update LidoLocator to point to real WithdrawalVault and DSM mock
     await updateLidoLocatorImplementation(locatorAddress, {
       withdrawalVault: await withdrawalVault.getAddress(),
+      depositSecurityModule: await dsm.getAddress(),
     });
 
     // 7. Deploy ConsolidationBus

--- a/test/0.8.25/consolidationGateway/consolidationGateway.addConsolidationRequests.test.ts
+++ b/test/0.8.25/consolidationGateway/consolidationGateway.addConsolidationRequests.test.ts
@@ -3,7 +3,11 @@ import { ethers } from "hardhat";
 
 import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
 
-import { ConsolidationGateway, WithdrawalVault__MockForConsolidationGateway } from "typechain-types";
+import {
+  ConsolidationGateway,
+  DepositSecurityModule__MockForConsolidationGateway,
+  WithdrawalVault__MockForConsolidationGateway,
+} from "typechain-types";
 
 import { advanceChainTime } from "lib";
 
@@ -63,6 +67,7 @@ const expectLimitData = async (
 describe("ConsolidationGateway.sol: addConsolidationRequests", () => {
   let consolidationGateway: ConsolidationGateway;
   let withdrawalVault: WithdrawalVault__MockForConsolidationGateway;
+  let dsm: DepositSecurityModule__MockForConsolidationGateway;
   let admin: HardhatEthersSigner;
   let authorizedEntity: HardhatEthersSigner;
   let stranger: HardhatEthersSigner;
@@ -76,9 +81,11 @@ describe("ConsolidationGateway.sol: addConsolidationRequests", () => {
     const locatorAddr = await locator.getAddress();
 
     withdrawalVault = await ethers.deployContract("WithdrawalVault__MockForConsolidationGateway");
+    dsm = await ethers.deployContract("DepositSecurityModule__MockForConsolidationGateway");
 
     await updateLidoLocatorImplementation(locatorAddr, {
       withdrawalVault: await withdrawalVault.getAddress(),
+      depositSecurityModule: await dsm.getAddress(),
     });
 
     consolidationGateway = await ethers.deployContract("ConsolidationGateway", [
@@ -136,6 +143,26 @@ describe("ConsolidationGateway.sol: addConsolidationRequests", () => {
     )
       .to.be.revertedWithCustomError(consolidationGateway, "ArraysLengthMismatch")
       .withArgs(1, 2);
+  });
+
+  it("should revert with DSMDepositsPaused error if DSM deposits are paused", async () => {
+    await dsm.mock__setDepositsPaused(true);
+
+    await expect(
+      consolidationGateway
+        .connect(authorizedEntity)
+        .addConsolidationRequests([PUBKEYS[0]], [PUBKEYS[1]], ZERO_ADDRESS, { value: 2 }),
+    ).to.be.revertedWithCustomError(consolidationGateway, "DSMDepositsPaused");
+  });
+
+  it("should not revert when DSM deposits are not paused", async () => {
+    await dsm.mock__setDepositsPaused(false);
+
+    const tx = await consolidationGateway
+      .connect(authorizedEntity)
+      .addConsolidationRequests([PUBKEYS[0]], [PUBKEYS[1]], ZERO_ADDRESS, { value: 2 });
+
+    await expect(tx).to.emit(withdrawalVault, "AddConsolidationRequestsCalled");
   });
 
   it("should revert if total fee value sent is insufficient to cover all provided consolidation requests", async () => {

--- a/test/0.8.25/consolidationGateway/consolidationGateway.pausable.test.ts
+++ b/test/0.8.25/consolidationGateway/consolidationGateway.pausable.test.ts
@@ -3,7 +3,11 @@ import { ethers } from "hardhat";
 
 import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
 
-import { ConsolidationGateway, WithdrawalVault__MockForConsolidationGateway } from "typechain-types";
+import {
+  ConsolidationGateway,
+  DepositSecurityModule__MockForConsolidationGateway,
+  WithdrawalVault__MockForConsolidationGateway,
+} from "typechain-types";
 
 import { advanceChainTime, getCurrentBlockTimestamp } from "lib";
 
@@ -21,6 +25,7 @@ const ZERO_ADDRESS = ethers.ZeroAddress;
 describe("ConsolidationGateway.sol: pausable", () => {
   let consolidationGateway: ConsolidationGateway;
   let withdrawalVault: WithdrawalVault__MockForConsolidationGateway;
+  let dsm: DepositSecurityModule__MockForConsolidationGateway;
   let admin: HardhatEthersSigner;
   let authorizedEntity: HardhatEthersSigner;
   let stranger: HardhatEthersSigner;
@@ -37,9 +42,11 @@ describe("ConsolidationGateway.sol: pausable", () => {
     const locatorAddr = await locator.getAddress();
 
     withdrawalVault = await ethers.deployContract("WithdrawalVault__MockForConsolidationGateway");
+    dsm = await ethers.deployContract("DepositSecurityModule__MockForConsolidationGateway");
 
     await updateLidoLocatorImplementation(locatorAddr, {
       withdrawalVault: await withdrawalVault.getAddress(),
+      depositSecurityModule: await dsm.getAddress(),
     });
 
     consolidationGateway = await ethers.deployContract("ConsolidationGateway", [admin, locatorAddr, 100, 1, 48]);

--- a/test/0.8.25/contracts/DepositSecurityModule__MockForConsolidationGateway.sol
+++ b/test/0.8.25/contracts/DepositSecurityModule__MockForConsolidationGateway.sol
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2025 Lido <info@lido.fi>
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity 0.8.25;
+
+contract DepositSecurityModule__MockForConsolidationGateway {
+    bool public isDepositsPaused;
+
+    function mock__setDepositsPaused(bool _paused) external {
+        isDepositsPaused = _paused;
+    }
+}


### PR DESCRIPTION
If DSM stopped deposits, we might have validator with non lido WC, all new consolidation requests processing should be paused.