### PR TITLE
fix(VaultHub): add safe cast for reported values

### DIFF
--- a/contracts/0.8.25/vaults/VaultHub.sol
+++ b/contracts/0.8.25/vaults/VaultHub.sol
@@ -1107,8 +1107,8 @@ contract VaultHub is PausableUntilWithRoles {
         uint256 _reportMaxLiabilityShares,
         uint256 _reportSlashingReserve
     ) internal {
-        _record.cumulativeLidoFees = uint128(_reportCumulativeLidoFees);
-        _record.minimalReserve = uint128(Math256.max(CONNECT_DEPOSIT, _reportSlashingReserve));
+        _record.cumulativeLidoFees = SafeCast.toUint128(_reportCumulativeLidoFees);
+        _record.minimalReserve = SafeCast.toUint128(Math256.max(CONNECT_DEPOSIT, _reportSlashingReserve));
 
         // We want to prevent 1 tx looping here:
         // 1. bring ETH (TV+)
@@ -1121,8 +1121,10 @@ contract VaultHub is PausableUntilWithRoles {
         // if any stETH is minted on funds added after the refslot
         // in that case we don't update it (preventing unlock)
         if (_record.maxLiabilityShares == _reportMaxLiabilityShares) {
-            _record.maxLiabilityShares = uint96(Math256.max(_record.liabilityShares, _reportLiabilityShares));
+            _record.maxLiabilityShares = SafeCast.toUint96(Math256.max(_record.liabilityShares, _reportLiabilityShares));
         }
+
+        // report values is not safecasted because they're checked extensively in LazyOracle
         _record.report = Report({
             totalValue: uint104(_reportTotalValue),
             inOutDelta: int104(_reportInOutDelta),

--- a/deployed-mainnet.json
+++ b/deployed-mainnet.json
@@ -409,7 +409,7 @@
     },
     "implementation": {
       "contract": "contracts/0.8.25/vaults/LazyOracle.sol",
-      "address": "0x47f3a6b1E70F7Ec7dBC3CB510B1fdB948C863a5B",
+      "address": "0x96c9a897D116ef660086d3aA67b3af653324aB37",
       "constructorArgs": ["0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb"]
     }
   },
@@ -736,7 +736,7 @@
     },
     "implementation": {
       "contract": "contracts/0.8.25/vaults/VaultHub.sol",
-      "address": "0x7c7d957D0752AB732E73400624C4a1eb1cb6CF50",
+      "address": "0x6330fE7756FBE8649adfb9A541d61C5edB8B4D70",
       "constructorArgs": [
         "0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb",
         "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",


### PR DESCRIPTION
In `_applyVaultReport()`, the oracle-reported `_reportSlashingReserve` value (uint256) is downcast
to uint128 without using SafeCast, despite the contract importing it. Solidity 0.8.25 does not
check explicit narrowing type conversions -- higher-order bits are silently truncated. If
`_reportSlashingReserve` exceeds `type(uint128).max`, the `minimalReserve `would be set to an
incorrect (lower) value, undermining slashing reserve enforcement.

```
_record.minimalReserve = uint128(Math256.max(CONNECT_DEPOSIT,
_reportSlashingReserve));
```
While `type(uint128).max` (~3.4 * 10^38 wei, ~3.4 * 10^20 ETH) far exceeds any realistic value, the
inconsistency with the contract's own SafeCast import suggests the check was intended but
overlooked. Similar unchecked downcasts exist for `_reportCumulativeLidoFees` and other fields in the Report struct.

**Recommendations:**

 Use `SafeCast.toUint128()` for the downcast to ensure a clean revert with a
descriptive error rather than silent truncation in edge cases. Apply the same treatment to other
unchecked downcasts in `_applyVaultReport()`.