### PR TITLE
 configure source and target module for consolidation migrator in scratch deploy

### DIFF
--- a/scripts/scratch/steps/0000-populate-deploy-artifact-from-env.ts
+++ b/scripts/scratch/steps/0000-populate-deploy-artifact-from-env.ts
@@ -65,6 +65,17 @@ export async function main() {
     };
   }
 
+  const consolidationMigratorSourceModuleId = process.env.CONSOLIDATION_MIGRATOR_SOURCE_MODULE_ID;
+  const consolidationMigratorTargetModuleId = process.env.CONSOLIDATION_MIGRATOR_TARGET_MODULE_ID;
+
+  if (consolidationMigratorSourceModuleId || consolidationMigratorTargetModuleId) {
+    state.consolidationMigrator.deployParameters = {
+      ...state.consolidationMigrator.deployParameters,
+      ...(consolidationMigratorSourceModuleId && { sourceModuleId: parseInt(consolidationMigratorSourceModuleId) }),
+      ...(consolidationMigratorTargetModuleId && { targetModuleId: parseInt(consolidationMigratorTargetModuleId) }),
+    };
+  }
+
   // Initialize gas usage tracking
   state[Sk.scratchDeployGasUsed] = 0n.toString();
 

--- a/scripts/scratch/steps/0000-populate-deploy-artifact-from-env.ts
+++ b/scripts/scratch/steps/0000-populate-deploy-artifact-from-env.ts
@@ -22,6 +22,8 @@ export async function main() {
   const withdrawalQueueBaseUri = getEnvVariable("WITHDRAWAL_QUEUE_BASE_URI", "");
   const dsmPredefinedAddress = getEnvVariable("DSM_PREDEFINED_ADDRESS", "");
   const genesisForkVersion = getEnvVariable("GENESIS_FORK_VERSION", "0x00000000");
+  const consolidationMigratorSourceModuleId = getEnvVariable("CONSOLIDATION_MIGRATOR_SOURCE_MODULE_ID", "");
+  const consolidationMigratorTargetModuleId = getEnvVariable("CONSOLIDATION_MIGRATOR_TARGET_MODULE_ID", "");
 
   await resetStateFileFromDeployParams();
   const state = readNetworkState();
@@ -65,16 +67,11 @@ export async function main() {
     };
   }
 
-  const consolidationMigratorSourceModuleId = process.env.CONSOLIDATION_MIGRATOR_SOURCE_MODULE_ID;
-  const consolidationMigratorTargetModuleId = process.env.CONSOLIDATION_MIGRATOR_TARGET_MODULE_ID;
-
-  if (consolidationMigratorSourceModuleId || consolidationMigratorTargetModuleId) {
-    state.consolidationMigrator.deployParameters = {
-      ...state.consolidationMigrator.deployParameters,
-      ...(consolidationMigratorSourceModuleId && { sourceModuleId: parseInt(consolidationMigratorSourceModuleId) }),
-      ...(consolidationMigratorTargetModuleId && { targetModuleId: parseInt(consolidationMigratorTargetModuleId) }),
-    };
-  }
+  state.consolidationMigrator.deployParameters = {
+    ...state.consolidationMigrator.deployParameters,
+    ...(consolidationMigratorSourceModuleId && { sourceModuleId: parseInt(consolidationMigratorSourceModuleId) }),
+    ...(consolidationMigratorTargetModuleId && { targetModuleId: parseInt(consolidationMigratorTargetModuleId) }),
+  };
 
   // Initialize gas usage tracking
   state[Sk.scratchDeployGasUsed] = 0n.toString();


### PR DESCRIPTION
The `sourceModuleId` and `targetModuleId` for ConsolidationMigrator are currently hardcoded in deploy-params-testnet.toml. 
This makes it difficult to test consolidation migration between different staking modules without modifying the config file. Adding env var overrides allows flexible configuration per deployment run for devnets.