### PR TITLE
remove deadcode in VEBO contract

### DIFF
--- a/contracts/0.8.9/oracle/ValidatorsExitBusOracle.sol
+++ b/contracts/0.8.9/oracle/ValidatorsExitBusOracle.sol
@@ -21,8 +21,6 @@ contract ValidatorsExitBusOracle is BaseOracle, ValidatorsExitBus {
     error SenderNotAllowed();
     error UnexpectedRequestsDataLength();
 
-    event WarnDataIncompleteProcessing(uint256 indexed refSlot, uint256 requestsProcessed, uint256 requestsCount);
-
     struct DataProcessingState {
         uint64 refSlot;
         uint64 requestsCount;
@@ -210,13 +208,8 @@ contract ValidatorsExitBusOracle is BaseOracle, ValidatorsExitBus {
     function _handleConsensusReport(
         ConsensusReport memory /* report */,
         uint256 /* prevSubmittedRefSlot */,
-        uint256 prevProcessingRefSlot
-    ) internal override {
-        DataProcessingState memory state = _storageDataProcessingState().value;
-        if (state.refSlot == prevProcessingRefSlot && state.requestsProcessed < state.requestsCount) {
-            emit WarnDataIncompleteProcessing(prevProcessingRefSlot, state.requestsProcessed, state.requestsCount);
-        }
-    }
+        uint256 /* prevProcessingRefSlot */
+    ) internal override {}
 
     function _checkMsgSenderIsAllowedToSubmitData() internal view {
         address sender = _msgSender();


### PR DESCRIPTION
Remove unreachable `WarnDataIncompleteProcessing` event and the check in _handleConsensusReport that emitted it. 

All exit requests are submitted atomically in a single submitReportData call, so requestsProcessed is always equal to requestsCount,  the `requestsProcessed < requestsCount` condition can never be true.

```
function _handleConsensusReportData(ReportData calldata data) internal {
        _storageDataProcessingState().value = DataProcessingState({
            refSlot: data.refSlot.toUint64(),
            requestsCount: data.requestsCount.toUint64(),                 // same value!!!
            requestsProcessed: data.requestsCount.toUint64(),         // same value!!!
            dataFormat: uint16(data.dataFormat)
        });
}
```