### PR TITLE
chore: remove mock upgrade in tests

### DIFF
--- a/.github/workflows/tests-integration-hoodi.yml
+++ b/.github/workflows/tests-integration-hoodi.yml
@@ -20,7 +20,7 @@ jobs:
         uses: ./.github/workflows/setup
 
       - name: Run integration tests
-        run: yarn test:integration:upgrade
+        run: yarn test:integration
         env:
           RPC_URL: "${{ secrets.HOODI_RPC_URL }}"
           NETWORK_STATE_FILE: deployed-hoodi.json

--- a/.github/workflows/tests-integration-mainnet.yml
+++ b/.github/workflows/tests-integration-mainnet.yml
@@ -20,7 +20,7 @@ jobs:
         uses: ./.github/workflows/setup
 
       - name: Run integration tests
-        run: yarn test:integration:upgrade
+        run: yarn test:integration
         env:
           RPC_URL: "${{ secrets.ETH_RPC_URL }}"
           NETWORK_STATE_FILE: deployed-mainnet.json


### PR DESCRIPTION
Remove mock v3.0.2 upgrade in integration tests.