### PR TITLE
ci: fix state-mate paths and env vars

### DIFF
--- a/.github/workflows/verify-state.yml
+++ b/.github/workflows/verify-state.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - "main"
       - "develop"
+  pull_request:
+    paths:
+      - ".github/workflows/verify-state.yml"
   schedule:
     - cron: "0 0 * * *" # runs every day at midnight UTC
 

--- a/.github/workflows/verify-state.yml
+++ b/.github/workflows/verify-state.yml
@@ -34,13 +34,13 @@ jobs:
         run: corepack enable
 
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --immutable
 
-      - name: Run state-mate (V3 Hoodi Testnet)
-        run: yarn start configs/lidov3/hoodi/lidov3-testnet.yaml
+      - name: Run state-mate (Hoodi Testnet)
+        run: yarn start configs/lido/hoodi/lido-testnet.yaml
 
-      - name: Run state-mate (V3 Hoodi Easy Track)
-        run: yarn start configs/lidov3/hoodi/lidov3-et-testnet.yml
+      - name: Run state-mate (Hoodi Easy Track)
+        run: yarn start configs/lido/hoodi/lido-et-testnet.yaml
 
   run_state_mate_mainnet:
     name: Mainnet State
@@ -48,7 +48,7 @@ jobs:
     timeout-minutes: 120
     env:
       STATE_MATE_BRANCH: "main"
-      REMOTE_RPC_URL: "${{ secrets.ETH_RPC_URL }}"
+      MAINNET_REMOTE_RPC_URL: "${{ secrets.ETH_RPC_URL }}"
 
     steps:
       - name: Checkout state-mate
@@ -66,10 +66,10 @@ jobs:
         run: corepack enable
 
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --immutable
 
-      - name: Run state-mate (V3 Mainnet)
-        run: yarn start configs/lidov3/mainnet/lidov3-core-post-phase-2.yaml
+      - name: Run state-mate (Mainnet)
+        run: yarn start configs/lido/mainnet/lido.yaml
 
-      - name: Run state-mate (V3 Mainnet Easy Track)
-        run: yarn start configs/lidov3/mainnet/lidov3-et-post-vote-phase-2.yml
+      - name: Run state-mate (Mainnet Easy Track)
+        run: yarn start configs/lido/mainnet/lido-et.yaml


### PR DESCRIPTION
This pull request updates the `.github/workflows/verify-state.yml` workflow to use new configuration file paths and environment variable names, and improves dependency installation reliability. The changes primarily focus on updating references from `lidov3` to `lido`, ensuring the workflow uses the latest configuration structure.

Configuration updates:

* Updated state-mate configuration file paths from `configs/lidov3/...` to `configs/lido/...` for both Hoodi Testnet and Mainnet jobs, reflecting the new directory structure and naming conventions. [[1]](diffhunk://#diff-8d39f5361643ede4bd0a5d405d337095e4c4cd440603275a14afc26857b6a8f8L37-R51) [[2]](diffhunk://#diff-8d39f5361643ede4bd0a5d405d337095e4c4cd440603275a14afc26857b6a8f8L69-R75)
* Changed the configuration file extensions from `.yml` to `.yaml` for consistency. [[1]](diffhunk://#diff-8d39f5361643ede4bd0a5d405d337095e4c4cd440603275a14afc26857b6a8f8L37-R51) [[2]](diffhunk://#diff-8d39f5361643ede4bd0a5d405d337095e4c4cd440603275a14afc26857b6a8f8L69-R75)

Workflow improvements:

* Added the `--immutable` flag to `yarn install` to ensure dependency consistency and prevent accidental changes to `yarn.lock`. [[1]](diffhunk://#diff-8d39f5361643ede4bd0a5d405d337095e4c4cd440603275a14afc26857b6a8f8L37-R51) [[2]](diffhunk://#diff-8d39f5361643ede4bd0a5d405d337095e4c4cd440603275a14afc26857b6a8f8L69-R75)
* Renamed the environment variable `REMOTE_RPC_URL` to `MAINNET_REMOTE_RPC_URL` for clarity in the Mainnet job.

These updates help keep the workflow in sync with recent project structure changes and improve build reliability.