### PR TITLE
feat: skip consolidation tests for non scratch environment

### DIFF
--- a/lib/protocol/networks.ts
+++ b/lib/protocol/networks.ts
@@ -141,6 +141,8 @@ async function getForkingNetworkConfig(): Promise<ProtocolNetworkConfig> {
     stakingVaultBeacon: state[Sk.stakingVaultBeacon]?.address,
     operatorGrid: state[Sk.operatorGrid]?.proxy.address,
     validatorConsolidationRequests: state[Sk.validatorConsolidationRequests]?.address,
+    consolidationBus: state[Sk.consolidationBus]?.proxy.address,
+    consolidationMigrator: state[Sk.consolidationMigrator]?.proxy.address,
   };
 
   const chainId = state[Sk.chainId];

--- a/test/integration/consolidation/consolidation-gas.integration.ts
+++ b/test/integration/consolidation/consolidation-gas.integration.ts
@@ -13,6 +13,7 @@ import {
   norSdvtAddNodeOperator,
   norSdvtAddOperatorKeys,
   norSdvtSetOperatorStakingLimit,
+  report,
 } from "lib/protocol/helpers";
 import { NOR_MODULE_ID } from "lib/protocol/helpers/staking-module";
 import { LoadedContract } from "lib/protocol/types";
@@ -65,11 +66,22 @@ describe("Integration: Consolidation gas measurement (full stack via Migrator)",
 
   let originalState: string;
 
-  before(async () => {
+  before(async function () {
     ctx = await getProtocolContext();
 
-    // Take snapshot before any modifications to restore clean state for other tests
     originalState = await Snapshot.take();
+
+    // ToDo: adapt tests for non-scratch contexts (forking/upgrade).
+    // This suite assumes both source and target modules resolve to NOR (module 1),
+    // which is only true on scratch deploys. In forking/upgrade mode the migrator's
+    // targetModuleId points at CMv2, so the NOR-based fixtures here would mismatch.
+    if (!ctx.isScratch) {
+      // Post-migration alignment: report() with no explicit per-module balances
+      // produces a self-consistent first report.
+      await report(ctx);
+
+      this.skip();
+    }
 
     [, submitter, executor] = await ethers.getSigners();
 

--- a/test/integration/consolidation/consolidation-migration.integration.ts
+++ b/test/integration/consolidation/consolidation-migration.integration.ts
@@ -13,6 +13,7 @@ import {
   norSdvtAddNodeOperator,
   norSdvtAddOperatorKeys,
   norSdvtSetOperatorStakingLimit,
+  report,
 } from "lib/protocol/helpers";
 import { NOR_MODULE_ID } from "lib/protocol/helpers/staking-module";
 import { LoadedContract } from "lib/protocol/types";
@@ -69,9 +70,22 @@ describe("Integration: Consolidation Migration Flow (Real NOR)", () => {
   let globalSnapshot: string;
   let testSnapshot: string;
 
-  before(async () => {
+  before(async function () {
     ctx = await getProtocolContext();
+
     globalSnapshot = await Snapshot.take();
+
+    // ToDo: adapt tests for non-scratch contexts (forking/upgrade).
+    // This suite assumes both source and target modules resolve to NOR (module 1),
+    // which is only true on scratch deploys. In forking/upgrade mode the migrator's
+    // targetModuleId points at CMv2, so the NOR-based fixtures here would mismatch.
+    if (!ctx.isScratch) {
+      // Post-migration alignment: report() with no explicit per-module balances
+      // produces a self-consistent first report.
+      await report(ctx);
+
+      this.skip();
+    }
 
     [, executor, submitter, stranger] = await ethers.getSigners();
 


### PR DESCRIPTION
Skip `consolidation-gas.integration.ts` and `consolidation-migration.integration.ts` if the protocol context is not a scratch deploy (`ctx.isScratch`).