### PR TITLE
Delete canTopUp & delete unnecessary check of depositable keys

### DIFF
--- a/contracts/0.8.25/TopUpGateway.sol
+++ b/contracts/0.8.25/TopUpGateway.sol
@@ -242,25 +242,6 @@ contract TopUpGateway is CLValidatorVerifier, AccessControlEnumerableUpgradeable
     }
 
     /**
-     * @notice Checks if top-up is possible for a given staking module
-     * @param _stakingModuleId Id of the staking module
-     * @return True if top-up is possible, false otherwise
-     * @dev Checks: module exists, module is active, block distance passed, Lido can deposit, and withdrawal credentials are 0x02
-     */
-    function canTopUp(uint256 _stakingModuleId) external view returns (bool) {
-        if (isPaused()) return false;
-
-        IStakingRouter stakingRouter = IStakingRouter(LOCATOR.stakingRouter());
-
-        if (!stakingRouter.canDeposit(_stakingModuleId)) return false;
-        if (!ILido(LOCATOR.lido()).canDeposit()) return false;
-        if (!_isBlockDistancePassed()) return false;
-
-        bytes32 wc = stakingRouter.getStakingModuleWithdrawalCredentials(_stakingModuleId);
-        return wc.isType2();
-    }
-
-    /**
      * @notice Returns the timestamp when last top up happened
      */
     function getLastTopUpTimestamp() external view returns (uint256) {

--- a/contracts/0.8.25/sr/StakingRouter.sol
+++ b/contracts/0.8.25/sr/StakingRouter.sol
@@ -946,15 +946,12 @@ contract StakingRouter is ISRBase, AccessControlEnumerableUpgradeable {
         bytes32 withdrawalCredentials = _getWithdrawalCredentialsWithType(stateConfig.withdrawalCredentialsType);
         address stakingModuleAddress = stateConfig.moduleAddress;
 
-        // Get depositable ether from Lido (similar to topUp)
         uint256 depositableEther = LIDO.getDepositableEther();
         uint256 stakingModuleDepositableEthAmount =
             _getModuleDepositAllocation(_stakingModuleId, depositableEther, false);
-        // Calculate max deposits count (capped by max and module capacity)
-        (,, uint256 depositableValidatorsCount) = _getStakingModuleSummary(_stakingModuleId);
         uint256 maxDepositsCount = Math.min(
-            Math.min(state.deposits.maxDepositsPerBlock, depositableValidatorsCount),
-            stakingModuleDepositableEthAmount / MAX_EFFECTIVE_BALANCE_WC_TYPE_01 // max possible initial deposits count
+            state.deposits.maxDepositsPerBlock,
+            stakingModuleDepositableEthAmount / MAX_EFFECTIVE_BALANCE_WC_TYPE_01
         );
 
         if (maxDepositsCount == 0) revert ZeroDeposits();

--- a/test/0.8.25/topUpGateway/topUpGateway.test.ts
+++ b/test/0.8.25/topUpGateway/topUpGateway.test.ts
@@ -625,6 +625,41 @@ describe("TopUpGateway.sol", () => {
       await topUpGateway.connect(admin).grantRole(resumeRole, admin.address);
     });
 
+    describe("isPaused", () => {
+      it("returns false on a fresh contract", async () => {
+        expect(await topUpGateway.isPaused()).to.equal(false);
+      });
+
+      it("is callable by any address (no role required)", async () => {
+        expect(await topUpGateway.connect(stranger).isPaused()).to.equal(false);
+
+        await topUpGateway.connect(admin).pauseFor(1000n);
+
+        expect(await topUpGateway.connect(stranger).isPaused()).to.equal(true);
+      });
+
+      it("returns true within the pause window and false right after it expires", async () => {
+        const duration = 100n;
+        await topUpGateway.connect(admin).pauseFor(duration);
+
+        // at the very last second of the pause window — still paused
+        await time.increase(Number(duration) - 1);
+        expect(await topUpGateway.isPaused()).to.equal(true);
+
+        // one second past the window — auto-resumed
+        await time.increase(1);
+        expect(await topUpGateway.isPaused()).to.equal(false);
+      });
+
+      it("returns false after an explicit resume", async () => {
+        await topUpGateway.connect(admin).pauseFor(1000n);
+        expect(await topUpGateway.isPaused()).to.equal(true);
+
+        await topUpGateway.connect(admin).resume();
+        expect(await topUpGateway.isPaused()).to.equal(false);
+      });
+    });
+
     describe("resume", () => {
       it("should revert if the sender does not have the RESUME_ROLE", async () => {
         await topUpGateway.connect(admin).pauseFor(1000n);
@@ -829,37 +864,6 @@ describe("TopUpGateway.sol", () => {
         const data = await buildTopUpData();
         await topUpGateway.connect(topUpOperator).topUp(data);
       });
-    });
-  });
-
-  describe("canTopUp", () => {
-    it("returns false when module is not registered", async () => {
-      expect(await topUpGateway.canTopUp(999n)).to.equal(false);
-    });
-
-    it("returns false when module is inactive", async () => {
-      await stakingRouter.setModuleActive(MODULE_ID, false);
-      expect(await topUpGateway.canTopUp(MODULE_ID)).to.equal(false);
-    });
-
-    it("returns false when block distance is not met", async () => {
-      await topUpGateway.connect(limitsManager).setMinBlockDistance(DEFAULT_MIN_BLOCK_DISTANCE + 1n);
-      await topUpGateway.harness_setLastTopUpData();
-      expect(await topUpGateway.canTopUp(MODULE_ID)).to.equal(false);
-    });
-
-    it("returns false when Lido cannot deposit", async () => {
-      await lido.setCanDeposit(false);
-      expect(await topUpGateway.canTopUp(MODULE_ID)).to.equal(false);
-    });
-
-    it("returns false when withdrawal credentials are not 0x02", async () => {
-      await stakingRouter.setWithdrawalCredentials(MODULE_ID, WC_TYPE_01);
-      expect(await topUpGateway.canTopUp(MODULE_ID)).to.equal(false);
-    });
-
-    it("returns true when all conditions are satisfied", async () => {
-      expect(await topUpGateway.canTopUp(MODULE_ID)).to.equal(true);
     });
   });
 });


### PR DESCRIPTION
A short summary of the changes.

- Delete canTopUp method: off-chain will make separate checks instead of use canTopUp method
- Removed unnecessary depositableValidatorsCount cap as it is already checked in SR._getModuleDepositAllocation