### PR TITLE
Validate empty PDG witness batches

### DIFF
--- a/contracts/0.8.25/vaults/dashboard/Dashboard.sol
+++ b/contracts/0.8.25/vaults/dashboard/Dashboard.sol
@@ -745,6 +745,8 @@ contract Dashboard is NodeOperatorFee {
     function _proveUnknownValidatorsToPDG(
         IPredepositGuarantee.ValidatorWitness[] calldata _witnesses
     ) internal onlyRoleMemberOrAdmin(NODE_OPERATOR_PROVE_UNKNOWN_VALIDATOR_ROLE) {
+        _requireNotZero(_witnesses.length);
+
         for (uint256 i = 0; i < _witnesses.length; i++) {
             VAULT_HUB.proveUnknownValidatorToPDG(address(_stakingVault()), _witnesses[i]);
         }

--- a/test/0.8.25/vaults/dashboard/dashboard.test.ts
+++ b/test/0.8.25/vaults/dashboard/dashboard.test.ts
@@ -1148,6 +1148,13 @@ describe("Dashboard.sol", () => {
         .withArgs(stranger, await dashboard.NODE_OPERATOR_PROVE_UNKNOWN_VALIDATOR_ROLE());
     });
 
+    it("reverts when witnesses are empty", async () => {
+      await expect(dashboard.connect(nodeOperator).proveUnknownValidatorsToPDG([])).to.be.revertedWithCustomError(
+        dashboard,
+        "ZeroArgument",
+      );
+    });
+
     it("proves unknown validators to PDG when policy is set to ALLOW_DEPOSIT_AND_PROVE", async () => {
       expect(await dashboard.pdgPolicy()).to.equal(PDGPolicy.ALLOW_DEPOSIT_AND_PROVE);
 


### PR DESCRIPTION
## Summary
- make `proveUnknownValidatorsToPDG` reject empty witness batches
- add a dashboard unit regression for the empty-witness path

Closes #1618.

## Tests
- `SKIP_INTERFACES_CHECK=true SKIP_LINT_SOLIDITY=true SKIP_CONTRACT_SIZE=true SKIP_GAS_REPORT=true corepack yarn hardhat test test/0.8.25/vaults/dashboard/dashboard.test.ts` (125 passing)
- `git diff --check`