### PR TITLE
Remove unused AccountingOracle migration error

### DIFF
--- a/contracts/0.8.9/oracle/AccountingOracle.sol
+++ b/contracts/0.8.9/oracle/AccountingOracle.sol
@@ -52,7 +52,6 @@ contract AccountingOracle is BaseOracle {
     error LidoLocatorCannotBeZero();
     error AdminCannotBeZero();
     error LidoCannotBeZero();
-    error IncorrectOracleMigration(uint256 code);
     error SenderNotAllowed();
     error InvalidExitedValidatorsData();
     error UnsupportedExtraDataFormat(uint256 format);


### PR DESCRIPTION
## Summary
- Removes the unused `IncorrectOracleMigration` custom error from `AccountingOracle`.
- Closes the audit cleanup item reported in #1560.

Closes #1560

## Testing
- `node_modules/.bin/solhint.cmd contracts/0.8.9/oracle/AccountingOracle.sol`
- `SKIP_INTERFACES_CHECK=true SKIP_LINT_SOLIDITY=true yarn hardhat compile --quiet`
- `git diff --check`

Note: `yarn lint:sol` and the default compile hook currently print a solhint JSON parsing/tooling error in this Windows shell even when exiting 0, so I also ran solhint directly against the touched contract.