### PR TITLE
Fix CL balance storage layout comment

### DIFF
--- a/contracts/0.4.24/Lido.sol
+++ b/contracts/0.4.24/Lido.sol
@@ -137,9 +137,9 @@ contract Lido is Versioned, StETHPermit, AragonApp {
     bytes32 internal constant DEPOSITED_NEXT_REPORT_AND_LAST_DEPOSIT_NONCE_POSITION =
         0x8d3ed945c7718edcdb639b1235f2bbe3fa81f4a6cec7a436d8ea13fbc502d957;
 
-    /// @dev CL validators balance and CL pending deposit balance
-    /// |----- 128 bit ------------|------ 128 bit -------|
-    /// | CL validators balance    |  CL pending balance  |
+    /// @dev CL pending deposit balance and CL validators balance
+    /// |----- 128 bit ---------|------ 128 bit -----------|
+    /// |  CL pending balance   | CL validators balance    |
     /// keccak256("lido.Lido.clValidatorsBalanceAndClPendingBalance");
     bytes32 internal constant CL_VALIDATORS_BALANCE_AND_CL_PENDING_BALANCE_POSITION =
         0x096e465397f38e659238ccd5d5a2c434ced54a63fd8d694045bfb058ab9d8112;


### PR DESCRIPTION
## Summary
- Fixes the CL validators/pending balance storage layout comment in `Lido.sol`.
- Aligns the high/low 128-bit diagram with `getLowAndHighUint128` / `setLowAndHighUint128` usage, where validators balance is stored low and pending balance is stored high.

Closes #1805

## Testing
- `node_modules/.bin/solhint.cmd contracts/0.4.24/Lido.sol`
- `SKIP_INTERFACES_CHECK=true SKIP_LINT_SOLIDITY=true yarn hardhat compile --quiet`
- `git diff --check`