### PR TITLE
Clarify beaconValidators compatibility value

### DIFF
--- a/contracts/0.4.24/Lido.sol
+++ b/contracts/0.4.24/Lido.sol
@@ -710,7 +710,8 @@ contract Lido is Versioned, StETHPermit, AragonApp {
      * @dev DEPRECATED: Use getBalanceStats() for new integrations
      * @notice Get the key values related to the Consensus Layer side of the contract.
      * @return depositedValidators - number of deposited validators from Lido contract side
-     * @return beaconValidators - number of Lido validators visible on Consensus Layer, reported by oracle
+     * @return beaconValidators - deprecated compatibility alias for depositedValidators, not a separate
+     *      Consensus Layer validator count reported by oracle
      * @return beaconBalance - total amount of ether on the Consensus Layer side (sum of all the balances of Lido validators)
      */
     function getBeaconStat()


### PR DESCRIPTION
## Summary
- Clarifies `getBeaconStat()` NatSpec for `beaconValidators`.
- Notes that the return value is kept as a compatibility alias for `depositedValidators` and no longer reflects a separate CL validator count from the oracle.

Closes #1808

## Testing
- `node_modules/.bin/solhint.cmd contracts/0.4.24/Lido.sol`
- `SKIP_INTERFACES_CHECK=true SKIP_LINT_SOLIDITY=true yarn hardhat compile --quiet`
- `git diff --check`