### PR TITLE
Cap static staking limit restoration after external burns

### DIFF
--- a/contracts/0.4.24/Lido.sol
+++ b/contracts/0.4.24/Lido.sol
@@ -1365,6 +1365,9 @@ contract Lido is Versioned, StETHPermit, AragonApp {
         /// NB: burning external shares must be allowed even when staking is paused to allow external ether withdrawals
         if (stakeLimitData.isStakingLimitSet() && !stakeLimitData.isStakingPaused()) {
             uint256 newStakeLimit = stakeLimitData.calculateCurrentStakeLimit() + _amount;
+            if (stakeLimitData.maxStakeLimitGrowthBlocks == 0 && newStakeLimit > stakeLimitData.maxStakeLimit) {
+                newStakeLimit = stakeLimitData.maxStakeLimit;
+            }
 
             STAKING_STATE_POSITION.setStorageStakeLimitStruct(stakeLimitData.updatePrevStakeLimit(newStakeLimit));
         }

--- a/test/0.4.24/lido/lido.externalShares.test.ts
+++ b/test/0.4.24/lido/lido.externalShares.test.ts
@@ -421,6 +421,19 @@ describe("Lido.sol:externalShares", () => {
       expect(await lido.getCurrentStakeLimit()).to.equal(limit + amountToBurn);
     });
 
+    it("Caps static staking limit when burning external shares", async () => {
+      await lido.setMaxExternalRatioBP(maxExternalRatioBP);
+      await lido.connect(vaultHubSigner).mintExternalShares(vaultHubSigner, 1n);
+
+      const maxStakeLimit = 10n;
+      await lido.setStakingLimit(maxStakeLimit, 0n);
+      expect(await lido.getCurrentStakeLimit()).to.equal(maxStakeLimit);
+
+      await lido.connect(vaultHubSigner).burnExternalShares(1n);
+
+      expect(await lido.getCurrentStakeLimit()).to.equal(maxStakeLimit);
+    });
+
     it("Burns shares correctly when staking is paused", async () => {
       await lido.setMaxExternalRatioBP(maxExternalRatioBP);
       await lido.setStakingLimit(ether("1500000"), ether("1000000"));


### PR DESCRIPTION
﻿## Summary
- Caps `_increaseStakingLimit()` at `maxStakeLimit` when staking limit recovery is disabled.
- Preserves the existing over-max recovery behavior when `maxStakeLimitGrowthBlocks` is non-zero.
- Adds coverage for burning external shares after enabling a static staking limit.

Closes #1822

## Testing
- targeted external-shares regression test for "Caps static staking limit"
- full `test/0.4.24/lido/lido.externalShares.test.ts`
- solhint on `contracts/0.4.24/Lido.sol`
- prettier on changed files
- `git diff --check`
