### PR TITLE
Clarify withdrawal reserve naming

### DIFF
--- a/contracts/0.4.24/Lido.sol
+++ b/contracts/0.4.24/Lido.sol
@@ -568,14 +568,14 @@ contract Lido is Versioned, StETHPermit, AragonApp {
      *        beyond the deposits reserve
      * @param depositsReserve Buffer portion available for CL deposits, protected from withdrawals demand.
      *        Resets on each oracle report, decreases via `withdrawDepositableEther()`
-     * @param withdrawalsReserve Buffer portion allocated to unfinalized withdrawals. Not depositable to CL.
+     * @param withdrawalReserve Buffer portion allocated to unfinalized withdrawals. Not depositable to CL.
      *        Zero when all withdrawal requests are finalized
      */
     struct BufferedEtherAllocation {
         uint256 total;
         uint256 unreserved;
         uint256 depositsReserve;
-        uint256 withdrawalsReserve;
+        uint256 withdrawalReserve;
     }
 
     /**
@@ -583,22 +583,22 @@ contract Lido is Versioned, StETHPermit, AragonApp {
      * @dev Buffer is split by priority:
      *
      *      1. depositsReserve    - per-frame CL deposit allowance, filled first
-     *      2. withdrawalsReserve - covers unfinalized withdrawal requests
+     *      2. withdrawalReserve  - covers unfinalized withdrawal requests
      *      3. unreserved         - excess, available for additional CL deposits
      *
      *      ┌─────────── Total Buffered Ether ───────────┐
      *      ├────────────────────┬───────────────────────┼─────┬──────────────┐
      *      │●●●●●●●●●●●●●●●●●●●●│●●●●●●●●●●●●●●●●●●●●●●●●○○○○○│○○○○○○○○○○○○○○│
      *      ├────────────────────┼───────────────────────┼─────┼──────────────┤
-     *      └─ Deposits Reserve ─┼─ Withdrawals Reserve ─┘     ├─ Unreserved ─┘
+     *      └─ Deposits Reserve ─┼─ Withdrawal Reserve ─┘      ├─ Unreserved ─┘
      *                           └───── Unfinalized stETH ─────┘
      *
      *      ● - covered by Buffered Ether
      *      ○ - not covered by Buffered Ether
      *
      *      depositsReserve    = min(total, stored deposits reserve)
-     *      withdrawalsReserve = min(total - depositsReserve, unfinalizedStETH)
-     *      unreserved         = total - depositsReserve - withdrawalsReserve
+     *      withdrawalReserve  = min(total - depositsReserve, unfinalizedStETH)
+     *      unreserved         = total - depositsReserve - withdrawalReserve
      */
     function _getBufferedEtherAllocation() internal view returns (BufferedEtherAllocation allocation) {
         uint256 remaining = _getBufferedEther();
@@ -607,8 +607,8 @@ contract Lido is Versioned, StETHPermit, AragonApp {
         allocation.depositsReserve = Math256.min(remaining, DEPOSITS_RESERVE_POSITION.getStorageUint256());
         remaining -= allocation.depositsReserve;
 
-        allocation.withdrawalsReserve = Math256.min(remaining, _withdrawalQueue().unfinalizedStETH());
-        remaining -= allocation.withdrawalsReserve;
+        allocation.withdrawalReserve = Math256.min(remaining, _withdrawalQueue().unfinalizedStETH());
+        remaining -= allocation.withdrawalReserve;
 
         allocation.unreserved = remaining;
     }
@@ -636,7 +636,7 @@ contract Lido is Versioned, StETHPermit, AragonApp {
      * @return Amount reserved to satisfy unfinalized withdrawals
      */
     function getWithdrawalsReserve() external view returns (uint256) {
-        return _getBufferedEtherAllocation().withdrawalsReserve;
+        return _getBufferedEtherAllocation().withdrawalReserve;
     }
 
     /**


### PR DESCRIPTION
﻿## Summary
- rename the internal buffered allocation field from `withdrawalsReserve` to `withdrawalReserve`
- align the NatSpec, formulas, and buffer diagram label with the singular reserve name
- keep the public `getWithdrawalsReserve()` API unchanged

Closes #1810

## Tests
- `corepack yarn install --immutable`
- `corepack yarn prettier contracts/0.4.24/Lido.sol --check`
- `corepack yarn solhint --config .solhint.json contracts/0.4.24/Lido.sol`
- `SKIP_INTERFACES_CHECK=true SKIP_LINT_SOLIDITY=true SKIP_GAS_REPORT=true corepack yarn compile`

Notes:
- `corepack yarn compile` without skip flags compiled successfully but the repo's Solidity lint subtask failed to parse solhint JSON output on Windows after compilation.
- `SKIP_INTERFACES_CHECK=true SKIP_LINT_SOLIDITY=true SKIP_GAS_REPORT=true corepack yarn hardhat test test/0.4.24/lido/lido.misc.test.ts --grep "withdrawalsReserve"` is blocked on Windows because the existing test-contract glob does not compile `test/**/*.sol` mocks, causing missing artifact `WithdrawalQueue__MockForLidoMisc`.
