### PR TITLE
Clarify getBalanceStats deposit return naming

### DIFF
--- a/contracts/0.4.24/Lido.sol
+++ b/contracts/0.4.24/Lido.sol
@@ -730,7 +730,10 @@ contract Lido is Versioned, StETHPermit, AragonApp {
     /// @notice Returns current balance statistics
     /// @return clValidatorsBalanceAtLastReport Sum of validator's active balances in wei
     /// @return clPendingBalanceAtLastReport Sum of validator's pending deposits in wei
-    /// @return depositedSinceLastReport Deposits made since last oracle report
+    /// @return depositedSinceLastReport Total deposits made since the last oracle report, including deposits after the
+    ///         current frame refSlot that will be handled by the next report
+    /// @return depositedBeforeCurrentReportRefSlot Deposits made since the last oracle report and before the current
+    ///         frame refSlot, to be accounted in the current report
     function getBalanceStats()
         external
         view
@@ -738,15 +741,16 @@ contract Lido is Versioned, StETHPermit, AragonApp {
             uint256 clValidatorsBalanceAtLastReport,
             uint256 clPendingBalanceAtLastReport,
             uint256 depositedSinceLastReport,
-            uint256 depositedForCurrentReport
+            uint256 depositedBeforeCurrentReportRefSlot
         )
     {
         (clValidatorsBalanceAtLastReport, clPendingBalanceAtLastReport) = _getClValidatorsBalanceAndClPendingBalance();
 
         depositedSinceLastReport = _getDepositedPostReport();
-        (depositedForCurrentReport,) = _getDepositedNextReportAdjusted();
+        uint256 depositedAfterCurrentReportRefSlot;
+        (depositedAfterCurrentReportRefSlot,) = _getDepositedNextReportAdjusted();
         /// @dev depositedNextReport is always less than depositedPostReport, so we can safely subtract
-        depositedForCurrentReport = depositedSinceLastReport - depositedForCurrentReport;
+        depositedBeforeCurrentReportRefSlot = depositedSinceLastReport - depositedAfterCurrentReportRefSlot;
     }
 
     /**

--- a/contracts/common/interfaces/ILido.sol
+++ b/contracts/common/interfaces/ILido.sol
@@ -48,7 +48,7 @@ interface ILido is IERC20, IVersioned {
             uint256 clValidatorsBalanceAtLastReport,
             uint256 clPendingBalanceAtLastReport,
             uint256 depositedSinceLastReport,
-            uint256 depositedForCurrentReport
+            uint256 depositedBeforeCurrentReportRefSlot
         );
 
     function processClStateUpdate(

--- a/contracts/upgrade/UpgradeTemplate.sol
+++ b/contracts/upgrade/UpgradeTemplate.sol
@@ -570,7 +570,7 @@ contract UpgradeTemplate is IUpgradeTemplate {
             uint256 clValidatorsBalanceAtLastReport,
             uint256 clPendingBalanceAtLastReport,
             uint256 depositedSinceLastReport,
-            uint256 depositedForCurrentReport
+            uint256 depositedBeforeCurrentReportRefSlot
         ) = ILidoUpgrade(g.lido).getBalanceStats();
 
         if (clValidatorsBalanceAtLastReport != initialBeaconBalance || clPendingBalanceAtLastReport != 0) {
@@ -579,7 +579,7 @@ contract UpgradeTemplate is IUpgradeTemplate {
 
         if (
             depositedSinceLastReport != (initialDepositedValidators - initialBeaconValidators) * 32 ether
-                || depositedForCurrentReport != 0
+                || depositedBeforeCurrentReportRefSlot != 0
         ) {
             revert LidoMigrationIncorrectDepositedSinceLastReport();
         }

--- a/lib/protocol/helpers/accounting.ts
+++ b/lib/protocol/helpers/accounting.ts
@@ -149,10 +149,10 @@ export const report = async (
   const {
     clValidatorsBalanceAtLastReport,
     clPendingBalanceAtLastReport,
-    depositedForCurrentReport,
+    depositedBeforeCurrentReportRefSlot,
     depositedSinceLastReport,
   } = await lido.getBalanceStats();
-  const deposited = waitNextReportTime ? depositedForCurrentReport : depositedSinceLastReport;
+  const deposited = waitNextReportTime ? depositedBeforeCurrentReportRefSlot : depositedSinceLastReport;
   clDiff = clDiff ?? deposited;
   const preCLBalance = clValidatorsBalanceAtLastReport + clPendingBalanceAtLastReport;
 

--- a/test/0.4.24/lido/lido.finalizeUpgrade_v4.test.ts
+++ b/test/0.4.24/lido/lido.finalizeUpgrade_v4.test.ts
@@ -96,7 +96,7 @@ describe("Lido.sol:finalizeUpgrade_v4", () => {
       expect((await lido.getBalanceStats()).clValidatorsBalanceAtLastReport).to.equal(clBalance);
       expect((await lido.getBalanceStats()).clPendingBalanceAtLastReport).to.equal(0);
       expect((await lido.getBalanceStats()).depositedSinceLastReport).to.equal(depositedBalance);
-      expect((await lido.getBalanceStats()).depositedForCurrentReport).to.equal(0);
+      expect((await lido.getBalanceStats()).depositedBeforeCurrentReportRefSlot).to.equal(0);
     });
   });
 });

--- a/test/0.8.9/contracts/Lido__MockForAccounting.sol
+++ b/test/0.8.9/contracts/Lido__MockForAccounting.sol
@@ -68,13 +68,13 @@ contract Lido__MockForAccounting {
             uint256 clValidatorsBalanceAtLastReport,
             uint256 clPendingBalanceAtLastReport,
             uint256 depositedSinceLastReport,
-            uint256 depositedForCurrentReport
+            uint256 depositedBeforeCurrentReportRefSlot
         )
     {
         clValidatorsBalanceAtLastReport = reportClValidatorsBalance;
         clPendingBalanceAtLastReport = reportClPendingBalance;
         depositedSinceLastReport = depositedLastReport;
-        depositedForCurrentReport = depositedCurrentReport;
+        depositedBeforeCurrentReportRefSlot = depositedCurrentReport;
     }
 
     function getTotalPooledEther() external pure returns (uint256) {

--- a/test/0.8.9/contracts/Lido__MockForSanityChecker.sol
+++ b/test/0.8.9/contracts/Lido__MockForSanityChecker.sol
@@ -33,13 +33,13 @@ contract Lido__MockForSanityChecker {
             uint256 clValidatorsBalanceAtLastReport,
             uint256 clPendingBalanceAtLastReport,
             uint256 depositedSinceLastReport,
-            uint256 depositedForCurrentReport
+            uint256 depositedBeforeCurrentReportRefSlot
         )
     {
         clValidatorsBalanceAtLastReport = clValidatorsBalance;
         clPendingBalanceAtLastReport = clPendingBalance;
         depositedSinceLastReport = depositedLastReport;
-        depositedForCurrentReport = depositedCurrentReport;
+        depositedBeforeCurrentReportRefSlot = depositedCurrentReport;
     }
 
     function getContractVersion() external view returns (uint256) {


### PR DESCRIPTION
﻿## Summary
- rename the ambiguous `depositedForCurrentReport` return value to `depositedBeforeCurrentReportRefSlot`
- expand `getBalanceStats()` NatSpec to distinguish the total post-report deposits from the portion already before the current frame refSlot
- update the upgrade check, accounting helper, mocks, and finalize-upgrade assertion to use the clearer name

Fixes #1807

## Validation
- `corepack yarn hardhat compile` with `SKIP_LINT_SOLIDITY=true` passed, including interface checks
- `.\node_modules\.bin\solhint.cmd "contracts/0.4.24/Lido.sol" "contracts/common/interfaces/ILido.sol" "contracts/upgrade/UpgradeTemplate.sol"`
- `.\node_modules\.bin\prettier.cmd --write ...`
- `git diff --check`

Note: I also attempted `hardhat test test/0.4.24/lido/lido.finalizeUpgrade_v4.test.ts`, but in this Windows checkout the existing Hardhat source-path glob does not include `test/**/*.sol`, so the run stops before tests with a missing `Lido__HarnessForFinalizeUpgradeV4` artifact.
