### PR TITLE
Remove redundant deposit nonce update

### DIFF
--- a/contracts/0.4.24/Lido.sol
+++ b/contracts/0.4.24/Lido.sol
@@ -1002,9 +1002,7 @@ contract Lido is Versioned, StETHPermit, AragonApp {
         _whenNotStopped();
         _auth(_accounting());
 
-        (uint256 depositedNextReport, uint256 curNonce) = _getDepositedNextReportAdjusted();
-        /// @dev just save adjusted depositedNextReport
-        _setDepositedNextReportAndLastDepositNonce(depositedNextReport, curNonce);
+        (uint256 depositedNextReport,) = _getDepositedNextReportAdjusted();
         /// @dev Since `depositedPostReport` accumulates all deposits, including those that occurred
         ///      after `refSlot` but before the report, we must retain only the amount not
         ///      reflected in the report


### PR DESCRIPTION
﻿## Summary
- remove the redundant `DEPOSITED_NEXT_REPORT_AND_LAST_DEPOSIT_NONCE_POSITION` write during `processClStateUpdate()`
- keep `depositedPostReport` based on the adjusted `depositedNextReport`, preserving the post-report accounting behavior while avoiding an unnecessary storage update

Fixes #1806

## Validation
- `SKIP_LINT_SOLIDITY=true corepack yarn hardhat compile` passed, including interface checks
- `.\node_modules\.bin\solhint.cmd "contracts/0.4.24/Lido.sol"`
- `.\node_modules\.bin\prettier.cmd --write "contracts/0.4.24/Lido.sol"`
- `git diff --check`
