### PR TITLE
ci: update all actions to latest versions pinned to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directories:
+      - "/"
+      - "/.github/workflows/setup"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns: ["*"]
+    labels: ["dependencies", "github-actions"]
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/analyse.yml
+++ b/.github/workflows/analyse.yml
@@ -15,7 +15,7 @@ jobs:
       security-events: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Common setup
         uses: ./.github/workflows/setup
@@ -23,7 +23,7 @@ jobs:
       - name: Install poetry
         run: pipx install poetry
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
           cache: "poetry"
@@ -52,7 +52,7 @@ jobs:
           echo 'value=not' >> $GITHUB_OUTPUT
 
       - name: Upload results.sarif file
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         if: ${{ always() && steps.results.outputs.value == 'present' }}
         with:
           sarif_file: results.sarif

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Common setup
         uses: ./.github/workflows/setup

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Common setup
         uses: ./.github/workflows/setup
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Common setup
         uses: ./.github/workflows/setup
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Common setup
         uses: ./.github/workflows/setup
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Common setup
         uses: ./.github/workflows/setup
@@ -63,7 +63,7 @@ jobs:
   #   runs-on: ubuntu-latest
 
   #   steps:
-  #     - uses: actions/checkout@v4
+  #     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
   #     - name: Common setup
   #       uses: ./.github/workflows/setup

--- a/.github/workflows/release-abis.yml
+++ b/.github/workflows/release-abis.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Common setup
         uses: ./.github/workflows/setup
@@ -25,7 +25,7 @@ jobs:
         run: zip -j ABIs.zip lib/abi/*.json
 
       - name: Upload ABIs to release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: ABIs.zip

--- a/.github/workflows/setup/action.yml
+++ b/.github/workflows/setup/action.yml
@@ -9,7 +9,7 @@ runs:
       shell: bash
       run: corepack enable
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version-file: .nvmrc
         cache: yarn

--- a/.github/workflows/tests-integration-hoodi.yml
+++ b/.github/workflows/tests-integration-hoodi.yml
@@ -14,7 +14,7 @@ jobs:
       SKIP_INTERFACES_CHECK: true
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Common setup
         uses: ./.github/workflows/setup

--- a/.github/workflows/tests-integration-mainnet.yml
+++ b/.github/workflows/tests-integration-mainnet.yml
@@ -14,7 +14,7 @@ jobs:
       SKIP_INTERFACES_CHECK: true
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Common setup
         uses: ./.github/workflows/setup

--- a/.github/workflows/tests-integration-scratch.yml
+++ b/.github/workflows/tests-integration-scratch.yml
@@ -19,14 +19,14 @@ jobs:
           - 8555:8545
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Common setup
         uses: ./.github/workflows/setup
 
       # https://github.com/foundry-rs/foundry-toolchain
       - name: Install foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1.8.0
 
       - name: Set env
         run: cp .env.example .env

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Common setup
         uses: ./.github/workflows/setup
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Common setup
         uses: ./.github/workflows/setup
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Common setup
         uses: ./.github/workflows/setup

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -28,7 +28,7 @@ jobs:
         uses: ./.github/workflows/setup
 
       - name: Install foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1.8.0
 
       - name: Print forge version
         run: forge --version
@@ -48,7 +48,7 @@ jobs:
         uses: ./.github/workflows/setup
 
       - name: Install foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1.8.0
 
       - name: Print forge version
         run: forge --version

--- a/.github/workflows/verify-state.yml
+++ b/.github/workflows/verify-state.yml
@@ -23,13 +23,13 @@ jobs:
 
     steps:
       - name: Checkout state-mate
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: lidofinance/state-mate
           ref: ${{ env.STATE_MATE_BRANCH }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "20"
 
@@ -55,13 +55,13 @@ jobs:
 
     steps:
       - name: Checkout state-mate
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: lidofinance/state-mate
           ref: ${{ env.STATE_MATE_BRANCH }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "20"
 


### PR DESCRIPTION
Addresses [review comment](https://github.com/lidofinance/core/pull/1570#discussion_r3382854119) in #1570 (bump `actions/checkout` to v6 to avoid the [Node 20 deprecation](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)), extended to all actions across workflows. Every action is pinned to a release commit SHA instead of a mutable tag.

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | v4 | v6.0.3 (`df4cb1c`) |
| `actions/setup-node` | v4 | v6.4.0 (`48b55a0`) |
| `actions/setup-python` | v5 | v6.2.0 (`a309ff8`) |
| `foundry-rs/foundry-toolchain` | v1 | v1.8.0 (`c7450ba`) |
| `softprops/action-gh-release` | v2 | v3.0.0 (`b430933`) |
| `github/codeql-action/upload-sarif` | v3 | v4.36.2 (`8aad20d`) |

`lidofinance/coverage-action` is left as is: its current pin is newer than the latest tag (v2.7.1), and HEAD only adds a CODEOWNERS change.

Also adds a Dependabot config (`.github/dependabot.yml`) to keep actions up to date: weekly grouped PRs, 7-day cooldown on fresh releases, SHA pins updated automatically. The extra `/.github/workflows/setup` directory entry covers the composite setup action, which the root entry does not scan.