### PR TITLE
ci: extend dependabot config to npm and pip ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,31 @@ updates:
     labels: ["dependencies", "github-actions"]
     commit-message:
       prefix: "ci"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      javascript:
+        patterns: ["*"]
+    labels: ["dependencies", "javascript"]
+    commit-message:
+      prefix: "build"
+      include: "scope"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      python:
+        patterns: ["*"]
+    labels: ["dependencies", "python"]
+    commit-message:
+      prefix: "build"
+      include: "scope"


### PR DESCRIPTION
Extends the Dependabot config added in #1851 (github-actions only) to `npm` (Yarn) and `pip` (Poetry) ecosystems, with the same supply-chain-focused rules for each:

- **weekly schedule** — updates checked once a week;
- **single grouped PR per ecosystem** — `patterns: ["*"]`, no PR flood;
- **7-day cooldown** — a new release is only proposed after it has been public for 7 days, so compromised package versions are likely to be caught and yanked before they ever reach a PR.

Note: the cooldown applies to scheduled version updates; Dependabot security updates are raised immediately regardless.