### PR TITLE
test: fix gindex fuzz config

### DIFF
--- a/test/common/lib/GIndex.t.sol
+++ b/test/common/lib/GIndex.t.sol
@@ -185,7 +185,10 @@ contract GIndexTest is Test {
 
     /**
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-fuzz-configs
+     * The concat overflow guard below rejects the vast majority of random inputs, so the
+     * cumulative reject budget must scale with the number of runs (deep profile: 10k runs).
      * forge-config: default.fuzz.max-test-rejects = 1000000
+     * forge-config: deep.fuzz.max-test-rejects = 10000000
      */
     function testFuzz_shr_OffTheWidth_AfterConcat(GIndex lhs, GIndex rhs, uint256 shift) public {
         // Indices concatenation overflow protection.
@@ -264,7 +267,10 @@ contract GIndexTest is Test {
 
     /**
      * https://book.getfoundry.sh/reference/config/inline-test-config#in-line-fuzz-configs
+     * The concat overflow guard below rejects the vast majority of random inputs, so the
+     * cumulative reject budget must scale with the number of runs (deep profile: 10k runs).
      * forge-config: default.fuzz.max-test-rejects = 1000000
+     * forge-config: deep.fuzz.max-test-rejects = 10000000
      */
     function testFuzz_shl_OffTheWidth_AfterConcat(GIndex lhs, GIndex rhs, uint256 shift) public {
         // Indices concatenation overflow protection.


### PR DESCRIPTION
Fix `GIndex` fuzzing tests config for deep profile.