### PR TITLE
fix: skip deactivated node operator

### DIFF
--- a/lib/protocol/helpers/nor-sdvt.ts
+++ b/lib/protocol/helpers/nor-sdvt.ts
@@ -34,6 +34,9 @@ export const norSdvtEnsureOperators = async (
   for (let operatorId = 0n; operatorId < minOperatorsCount; operatorId++) {
     const nodeOperatorBefore = await module.getNodeOperator(operatorId, false);
 
+    // cannot set staking limit for a deactivated operator
+    if (!nodeOperatorBefore.active) continue;
+
     if (nodeOperatorBefore.totalVettedValidators < nodeOperatorBefore.totalAddedValidators) {
       await norSdvtSetOperatorStakingLimit(ctx, module, {
         operatorId,


### PR DESCRIPTION
Why: The helper reverts with WRONG_OPERATOR_ACTIVE_STATE if the operator is inactive.

The loop in norSdvtEnsureOperators blindly tries to bump every operator's staking limit up to its total keys whenever vetted < added, implicitly assuming operators 0..N-1 are all active. The pending Circuit Breaker vote deactivates Chorus One (NOR op 3), and the scripts "Core tests" CI runs core's integration tests on a post-vote fork — so after the vote enacts, the helper hits op 3, sees vetted < added, calls setNodeOperatorStakingLimit, and reverts.

Deactivation guarantees this state, because it trims vetted down to deposited while leaving total added keys untouched.

**Is it the first deactivated operator?** No — but it's the first one that trips this code path. NOR has 39 operators, only 36 active. Op 1 (Jump Crypto, ex-Certus One) has been inactive for a long time and sits inside every tested range. It never broke the helper because its counts are even — vetted = added = deposited = 1000 (unused keys were removed at offboarding) — so the vetted < added condition is false and the revert branch is never reached.

Chorus One post-vote is the first operator in the tested range that's deactivated while still holding undeposited keys (added = 11999 > vetted = deposited = 11552).