### PR TITLE
fix: skip deactivated node operator

### DIFF
--- a/lib/protocol/helpers/nor-sdvt.ts
+++ b/lib/protocol/helpers/nor-sdvt.ts
@@ -34,6 +34,9 @@ export const norSdvtEnsureOperators = async (
   for (let operatorId = 0n; operatorId < minOperatorsCount; operatorId++) {
     const nodeOperatorBefore = await module.getNodeOperator(operatorId, false);
 
+    // cannot set staking limit for a deactivated operator
+    if (!nodeOperatorBefore.active) continue;
+
     if (nodeOperatorBefore.totalVettedValidators < nodeOperatorBefore.totalAddedValidators) {
       await norSdvtSetOperatorStakingLimit(ctx, module, {
         operatorId,


### PR DESCRIPTION
(cherry picked from commit bd75214dc11dee53f4c1f0ad3754611a566bc1d1)
