### PR TITLE
fix: fix vote items count

### DIFF
--- a/contracts/upgrade/UpgradeVoteScript.sol
+++ b/contracts/upgrade/UpgradeVoteScript.sol
@@ -56,8 +56,7 @@ contract UpgradeVoteScript is OmnibusBase {
     //
     // Constants
     //
-    // TODO set upon finish with items
-    uint256 public constant DG_ITEMS_COUNT = 66;
+    uint256 public constant DG_ITEMS_COUNT = 67;
     uint256 public constant VOTING_ITEMS_COUNT = 11;
 
     // Aragon Kernel APP_BASES_NAMESPACE


### PR DESCRIPTION
Increased the `DG_ITEMS_COUNT` constant in `UpgradeVoteScript.sol` from 66 to 67.