### PR TITLE
[codex] register staking module circuit breaker pausers

### DIFF
--- a/scripts/scratch/steps/0140-plug-staking-modules.ts
+++ b/scripts/scratch/steps/0140-plug-staking-modules.ts
@@ -25,6 +25,11 @@ const EXTERNAL_HASH_CONSENSUS_ABI = [
   "function updateInitialEpoch(uint256 initialEpoch)",
 ];
 
+const EXTERNAL_CIRCUIT_BREAKER_ABI = [
+  "function getPauser(address _pausable) external view returns (address)",
+  "function registerPauser(address _pausable, address _newPauser)",
+];
+
 const NOR_STAKING_MODULE_STAKE_SHARE_LIMIT_BP = 10000; // 100%
 const NOR_STAKING_MODULE_PRIORITY_EXIT_SHARE_THRESHOLD_BP = 10000; // 100%
 const NOR_STAKING_MODULE_MODULE_FEE_BP = 500; // 5%
@@ -200,9 +205,22 @@ async function enableExternalModule(
 
   const circuitBreakerAddress = state[Sk.circuitBreaker]?.address;
   if (circuitBreakerAddress) {
+    const circuitBreakerPauser = ethers.getAddress(agent);
+    const circuitBreaker = externalContract(
+      "CircuitBreaker",
+      circuitBreakerAddress,
+      EXTERNAL_CIRCUIT_BREAKER_ABI,
+      agentSigner,
+    );
+
     for (const pausable of setup.pausableContracts) {
       const contract = externalContract(pausable.label, pausable.address, EXTERNAL_ACCESS_CONTROL_ABI, agentSigner);
       await makeTx(contract, "grantRole", [await contract.PAUSE_ROLE(), circuitBreakerAddress], { from: agent });
+
+      const currentPauser = ethers.getAddress(await circuitBreaker.getPauser(pausable.address));
+      if (currentPauser !== circuitBreakerPauser) {
+        await makeTx(circuitBreaker, "registerPauser", [pausable.address, circuitBreakerPauser], { from: agent });
+      }
     }
   }
 }

--- a/scripts/utils/staking-modules.ts
+++ b/scripts/utils/staking-modules.ts
@@ -380,6 +380,7 @@ export async function deployStakingModules(state: DeploymentState): Promise<void
       CSM_LOCATOR_ADDRESS: state[Sk.lidoLocator].proxy.address,
       CSM_ARAGON_AGENT_ADDRESS: state[Sk.appAgent].proxy.address,
       CSM_FIRST_ADMIN_ADDRESS: state[Sk.appAgent].proxy.address,
+      CSM_CIRCUIT_BREAKER_ADDRESS: state[Sk.circuitBreaker]?.address,
       CSM_RESEAL_MANAGER_ADDRESS: state[Sk.resealManager]?.address || state[Sk.appAgent].proxy.address,
       EVM_SCRIPT_EXECUTOR_ADDRESS: state[Sk.appVoting].proxy.address,
     } as unknown as NodeJS.ProcessEnv;


### PR DESCRIPTION
## What changed

- Pass `CSM_CIRCUIT_BREAKER_ADDRESS` to the external staking-modules deploy environment.
- Register the current `CSM_FIRST_ADMIN_ADDRESS` value, which core sets to the Agent, as CircuitBreaker pauser for every external CSM/CMv2 pausable contract wired in `0140-plug-staking-modules`.
- Keep the existing `PAUSE_ROLE` grants to CircuitBreaker and make pauser registration idempotent via `getPauser` before `registerPauser`.

## Why

The staking-modules local-devnet deploy scripts now read the CircuitBreaker address from env and use `CSM_FIRST_ADMIN_ADDRESS` as the local committee/dev-team stand-in pauser. Core needs to provide that address during deployment and then register the same pauser in CircuitBreaker; otherwise the modules receive `PAUSE_ROLE` wiring but CircuitBreaker has no pauser for those targets.

## Master check

I checked current `origin/master` for newer CircuitBreaker pauser registration steps. `master` does not contain `registerPauser` usage in contracts/scripts/tests and its scratch `0140-plug-staking-modules.ts` predates the external CSM/CMv2 flow, so there was no more current scratch pattern to port. The closest develop-side pattern is the upgrade vote helper that encodes `ICircuitBreaker.registerPauser(pausable, pauser)`.

## Validation

- `/Users/skhomuti/.nvm/versions/node/v22.17.1/bin/node node_modules/hardhat/internal/cli/cli.js compile`
- `/Users/skhomuti/.nvm/versions/node/v22.17.1/bin/node node_modules/typescript/bin/tsc --noEmit`
- `/Users/skhomuti/.nvm/versions/node/v22.17.1/bin/node node_modules/prettier/bin/prettier.cjs --check scripts/scratch/steps/0140-plug-staking-modules.ts scripts/utils/staking-modules.ts`

Note: checks used a temporary `/private/tmp/core-cb-pr/node_modules` symlink to the existing local core checkout dependencies; it was removed before committing.