### PR TITLE
chore: add Hoodi TokenRateNotifier deployment artifacts

### DIFF
--- a/deployed-hoodi.json
+++ b/deployed-hoodi.json
@@ -625,7 +625,7 @@
     },
     "implementation": {
       "contract": "contracts/0.8.9/LidoLocator.sol",
-      "address": "0x1dB06d15976954D48765f40d4bDd840C257CD4B9",
+      "address": "0xa519Be1BBfd95445cEdFea56C12AB0B28330CC2F",
       "constructorArgs": [
         {
           "accountingOracle": "0xcb883B1bD0a41512b42D2dB267F2A2cd919FB216",
@@ -633,7 +633,7 @@
           "elRewardsVault": "0x9b108015fe433F173696Af3Aa0CF7CDb3E104258",
           "lido": "0x3508A952176b3c15387C97BE809eaffB1982176a",
           "oracleReportSanityChecker": "0xD0261b0032A00a7449ee7fbE14d3f98702996441",
-          "postTokenRebaseReceiver": "0x9c53d0075eA00ad77dDAd1b71E67bb97AaBC1e3D",
+          "postTokenRebaseReceiver": "0xe2d1307a8e0eb6996eE9eB6FB5949124F17EDf65",
           "burner": "0xb2c99cd38a2636a6281a849C8de938B3eF4A7C3D",
           "stakingRouter": "0xCc820558B39ee15C7C45B59390B503b83fb499A8",
           "treasury": "0x0534aA41907c9631fae990960bCC72d75fA7cfeD",
@@ -790,7 +790,7 @@
   "resealManager": {
     "address": "0x05172CbCDb7307228F781436b327679e4DAE166B"
   },
-  "scratchDeployGasUsed": "162002512",
+  "scratchDeployGasUsed": "163368640",
   "simpleDvt": {
     "deployParameters": {
       "stakingModuleTypeId": "curated-onchain-v1",
@@ -864,6 +864,11 @@
     "contract": "contracts/0.8.25/vaults/StakingVault.sol",
     "address": "0xE96BE4FB723e68e7b96244b7399C64a58bcD0062",
     "constructorArgs": ["0x00000000219ab540356cBB839Cbe05303d7705Fa"]
+  },
+  "tokenRebaseNotifier": {
+    "contract": "contracts/0.8.9/TokenRateNotifier.sol",
+    "address": "0xe2d1307a8e0eb6996eE9eB6FB5949124F17EDf65",
+    "constructorArgs": ["0x0534aA41907c9631fae990960bCC72d75fA7cfeD", "0x9b5b78D1C9A3238bF24662067e34c57c83E8c354"]
   },
   "tokenRebaseNotifierV3": {
     "implementation": {


### PR DESCRIPTION
Adds the Hoodi deployment artifacts for the TokenRateNotifier upgrade.

- Contracts are deployed and verified.
- Also fixes wrong tx for mainnet